### PR TITLE
fix: preserve caller-supplied agent titles

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -1,5 +1,5 @@
 import { parseScreen } from "./screen-parser.js";
-import type { AgentState, CliType } from "./agent-types.js";
+import type { AgentRole, AgentState, CliType } from "./agent-types.js";
 import type {
   CmuxReadScreenResult,
   CmuxSurface,
@@ -17,6 +17,9 @@ export interface DiscoveredAgent {
   workspace_id?: string | null;
   current_directory?: string | null;
   working_directory_source?: SurfaceWorkingDirectorySource;
+  /** Persisted identity for a registry-managed surface; display titles are not identity. */
+  managed_repo?: string | null;
+  managed_role?: AgentRole | null;
   cli: CliType | "unknown";
   control_state: ParsedControlPlaneState;
   parsed_status: ParsedScreenStatus | null;
@@ -34,6 +37,9 @@ export interface DiscoveryDeps {
   /** Resolve the cmux topology identity that produced a discovery snapshot. */
   observerIdProvider?: () => string | null | undefined;
   listSurfaces: () => Promise<CmuxSurface[]>;
+  managedIdentityProvider?: (
+    surface: Pick<CmuxSurface, "ref" | "id">,
+  ) => { repo: string; cli: CliType; role?: AgentRole | null } | null;
   readScreen: (
     surface: string,
     opts: { lines: number; workspace?: string },
@@ -65,9 +71,13 @@ function inferCliFromLauncherTitle(
 export function inferRepoFromDiscovery(
   discovered: Pick<
     DiscoveredAgent,
-    "current_directory" | "working_directory_source" | "surface_title"
+    | "current_directory"
+    | "working_directory_source"
+    | "surface_title"
+    | "managed_repo"
   >,
 ): string {
+  if (discovered.managed_repo?.trim()) return discovered.managed_repo.trim();
   const titleRepo = inferRepoFromTitle(discovered.surface_title);
   const trustedCwd =
     discovered.working_directory_source === "terminal_metadata" ||
@@ -153,13 +163,17 @@ export class AgentDiscovery {
         workspace: workspaceId ?? undefined,
       });
       const parsed = parseScreen(screen.text);
-      const titleCli = inferCliFromLauncherTitle(surface.title);
+      const managedIdentity = this.deps.managedIdentityProvider?.(surface);
+      // Registry state owns managed identity. Launcher-title parsing remains a
+      // compatibility fallback only for surfaces with no managed record.
+      const fallbackCli =
+        managedIdentity?.cli ?? inferCliFromLauncherTitle(surface.title);
       const cli =
         parsed.agent_type === "unknown"
           ? (parsed.control_state === "permission_prompt" ||
-              parsed.control_state === "interactive_overlay") &&
-            titleCli !== "unknown"
-            ? titleCli
+                parsed.control_state === "interactive_overlay") &&
+              fallbackCli !== "unknown"
+            ? fallbackCli
             : "unknown"
           : (parsed.agent_type as CliType);
 
@@ -175,6 +189,8 @@ export class AgentDiscovery {
           surface.requested_working_directory ??
           null,
         working_directory_source: surface.working_directory_source,
+        managed_repo: managedIdentity?.repo ?? null,
+        managed_role: managedIdentity?.role ?? null,
         cli,
         control_state: parsed.control_state,
         parsed_status: parsed.status,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -500,14 +500,16 @@ export type SessionIdentityResolver = (
  * The title of a managed pane (#492 / #479). A caller-supplied title is already
  * the complete human-facing label, including its role/task convention, so the
  * engine must not compose launcher, surface, or agent-id text around it. Legacy
- * callers that omit a title retain the existing agent-id/surface fallback.
+ * callers that omit or blank a title retain the existing agent-id/surface
+ * fallback. Managed repo/CLI/role identity stays in AgentRecord and discovery
+ * reads that registry state; the display title is never the identity source.
  */
 export function managedPaneTitle(
   agentId: string,
   surface: string,
   title?: string | null,
 ): string {
-  return title ?? buildTitle(`${agentId} [${surface}]`);
+  return title?.trim() ? title : buildTitle(`${agentId} [${surface}]`);
 }
 
 function sessionCollisionSuffix(sessionId: string): string {
@@ -7534,6 +7536,7 @@ export class AgentEngine {
       cli_session_id: null,
       cli_session_path: null,
       launcher_name: preflight?.launcherName ?? null,
+      tab_name: spawnParams.title?.trim() ? spawnParams.title : null,
       launch_mode: launchMode,
       model_pin: modelPin.pin,
       seat_id: seatIdentity.seat_id,
@@ -7829,7 +7832,7 @@ export class AgentEngine {
       // A resumed pane is the same agent; it must say so, like the spawn path.
       await this.client.renameTab(
         surface.surface,
-        managedPaneTitle(agent.agent_id, surface.surface),
+        managedPaneTitle(agent.agent_id, surface.surface, agent.tab_name),
         { workspace },
       );
       const booting = this.stateMgr.transition(agent.agent_id, "booting", {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -497,20 +497,17 @@ export type SessionIdentityResolver = (
 ) => CapturedSessionIdentity | string | null;
 
 /**
- * The title of a managed pane (#492 / #479). The operator has to be able to
- * look at a pane and know it is the right one to close, and `<launcher>
- * [surface:N]` made five workers in one repo indistinguishable. The AGENT ID
- * leads -- it begins with the launcher name, so agent-discovery still parses
- * repo and cli back out of it, but it also carries the per-worker suffix that
- * tells them apart. The caller's own label follows when one was given.
+ * The title of a managed pane (#492 / #479). A caller-supplied title is already
+ * the complete human-facing label, including its role/task convention, so the
+ * engine must not compose launcher, surface, or agent-id text around it. Legacy
+ * callers that omit a title retain the existing agent-id/surface fallback.
  */
 export function managedPaneTitle(
   agentId: string,
   surface: string,
   title?: string | null,
 ): string {
-  const label = title?.trim();
-  return buildTitle(`${agentId} [${surface}]`, label);
+  return title ?? buildTitle(`${agentId} [${surface}]`);
 }
 
 function sessionCollisionSuffix(sessionId: string): string {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -597,7 +597,11 @@ export class AgentRegistry {
   }
 
   private explicitRoleFor(discovered: DiscoveredAgent): AgentRole | null {
-    return this.explicitRoleProvider?.(discovered) ?? null;
+    return (
+      discovered.managed_role ??
+      this.explicitRoleProvider?.(discovered) ??
+      null
+    );
   }
 
   /** Capture persisted owner and transient epoch before an awaited scan. */
@@ -973,6 +977,30 @@ export class AgentRegistry {
 
   get(agentId: string): AgentRecord | null {
     return this.agents.get(this.resolveAlias(agentId)) ?? null;
+  }
+
+  /** Resolve managed identity from the durable surface binding, never its title. */
+  managedIdentityForSurface(
+    surface: Pick<CmuxSurface, "ref" | "id">,
+  ): Pick<AgentRecord, "repo" | "cli" | "role"> | null {
+    const observedUuid = surfaceUuidKey(surface.id);
+    const matches = this.list().filter((record) => {
+      const persistedUuid = surfaceUuidKey(record.surface_uuid);
+      const stableMatch = Boolean(
+        observedUuid && persistedUuid && observedUuid === persistedUuid,
+      );
+      // A UUID-backed row must never fall back to a mutable ref on one
+      // identity-free observation. That fallback is only safe when a complete
+      // topology scan proves the entire transport is operating in ref-only
+      // compatibility mode, which this per-surface lookup cannot establish.
+      const refMatch =
+        !persistedUuid && !observedUuid && record.surface_id === surface.ref;
+      return (
+        (stableMatch || refMatch) &&
+        this.canUseObservedBinding(record, surface.id)
+      );
+    });
+    return matches.length === 1 ? matches[0]! : null;
   }
 
   list(filter?: AgentFilter): AgentRecord[] {

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -268,6 +268,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     this.discovery = new AgentDiscovery({
       observerIdProvider: () => this.getSurfaceObserverEpoch(),
       listSurfaces: surfaceProvider,
+      managedIdentityProvider: (surface) =>
+        this.registry.managedIdentityForSurface(surface),
       readScreen: (surface, readOpts) =>
         this.client.readScreen(surface, readOpts),
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -11175,6 +11175,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const discovery = new AgentDiscovery({
       observerIdProvider: () => context.surfaceObserverEpoch,
       listSurfaces: surfaceProvider,
+      managedIdentityProvider: (surface) =>
+        registry?.managedIdentityForSurface(surface) ?? null,
       readScreen: (surface, opts) => client.readScreen(surface, opts),
     });
     // AIDEV-NOTE (F1): from here on, every consumer that used to read
@@ -12505,7 +12507,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe(
-            "The caller-supplied agent pane title is applied verbatim (for example `cmuxlayer-WORKER · run1 name-the-tabs`); when omitted, the existing agent-id/surface fallback is retained (#479/#492).",
+            "The caller-supplied agent pane title is applied verbatim (for example `cmuxlayer-WORKER · run1 name-the-tabs`); when omitted or blank, the existing agent-id/surface fallback is retained. Managed identity comes from the agent registry, not this display title (#479/#492).",
           ),
         prompt: z
           .string()

--- a/src/server.ts
+++ b/src/server.ts
@@ -12505,7 +12505,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .string()
           .optional()
           .describe(
-            "Human label for the pane. For type=agent the tab is titled `<agent_id> · <title> [surface:N]` -- the agent id is always there, so five workers in one repo are still distinguishable when you omit this (#479/#492).",
+            "The caller-supplied agent pane title is applied verbatim (for example `cmuxlayer-WORKER · run1 name-the-tabs`); when omitted, the existing agent-id/surface fallback is retained (#479/#492).",
           ),
         prompt: z
           .string()

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -17,6 +17,40 @@ const deadCodexShellFixture = JSON.parse(
 ) as { lines_80: string };
 
 describe("AgentDiscovery", () => {
+  it("uses managed registry identity instead of parsing a role-first display title", async () => {
+    const discovery = new AgentDiscovery({
+      listSurfaces: async () => [
+        {
+          ref: "surface:managed",
+          title: "run1 name-the-tabs",
+          type: "terminal",
+          index: 0,
+          selected: true,
+        },
+      ],
+      managedIdentityProvider: () => ({
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+      }),
+      readScreen: async (surface) => ({
+        surface,
+        text: "Select an action:\n> 1. Continue\n  2. Cancel\n",
+        lines: 3,
+        scrollback_used: false,
+      }),
+    });
+
+    const [managed] = await discovery.scan(true);
+
+    expect(managed).toMatchObject({
+      cli: "codex",
+      managed_repo: "cmuxlayer",
+      managed_role: "worker",
+    });
+    expect(inferRepoFromDiscovery(managed!)).toBe("cmuxlayer");
+  });
+
   it("keeps a frozen discovered agent non-terminal while it waits for input", () => {
     expect(discoveredStatusToAgentState("frozen")).toBe("error");
   });

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -18,7 +18,6 @@ import {
 import type { CmuxClient } from "../src/cmux-client.js";
 import type { AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface } from "../src/types.js";
-import { inferAgentRole } from "../src/layout-policy.js";
 import { resetResumeArtifactResolver } from "../src/resume-verification.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-revive-on-purpose");
@@ -341,7 +340,7 @@ describe("revive on purpose (#492)", () => {
     expect(mockClient.newSurface).not.toHaveBeenCalled();
   });
 
-  it("titles a managed pane with the agent id so a close is unambiguous", async () => {
+  it("uses the caller's role-first title verbatim", async () => {
     (mockClient.newSplit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       workspace: "ws:1",
       surface: "surface:worker-a",
@@ -350,39 +349,47 @@ describe("revive on purpose (#492)", () => {
       type: "terminal",
     });
 
-    const spawned = await engine.spawnAgent({
+    await engine.spawnAgent({
       repo: "cmuxlayer",
       cli: "codex",
       prompt: "lane work",
+      title: "cmuxlayer-WORKER · golden-path",
     });
 
     expect(mockClient.renameTab).toHaveBeenCalledWith(
       "surface:worker-a",
-      expect.stringContaining(spawned.agent_id),
+      "cmuxlayer-WORKER · golden-path",
       { workspace: "ws:1" },
     );
   });
 
-  it("keeps caller labels outside the launcher prefix used for role inference", () => {
+  it("keeps the existing agent-id fallback when the caller omits a title", () => {
+    expect(
+      managedPaneTitle(
+        "cmuxlayerCodex-99887766",
+        "surface:9",
+      ),
+    ).toBe("cmuxlayerCodex-99887766 [surface:9]");
+  });
+
+  it("does not compose caller-supplied role-first titles", () => {
     const leadTitle = managedPaneTitle(
       "brainlayerClaude-ab12cd34",
       "surface:3",
-      "review Codex output",
+      "cmuxlayer-LEAD · review Codex output",
     );
     const workerTitle = managedPaneTitle(
       "cmuxlayerCodex-99887766",
       "surface:9",
-      "pair with Claude",
+      "  cmuxlayer-WORKER · pair with Claude  ",
     );
 
     expect(leadTitle).toBe(
-      "brainlayerClaude-ab12cd34 [surface:3]: review Codex output",
+      "cmuxlayer-LEAD · review Codex output",
     );
     expect(workerTitle).toBe(
-      "cmuxlayerCodex-99887766 [surface:9]: pair with Claude",
+      "  cmuxlayer-WORKER · pair with Claude  ",
     );
-    expect(inferAgentRole({ title: leadTitle })).toBe("orchestrator");
-    expect(inferAgentRole({ title: workerTitle })).toBe("worker");
   });
 
   it("refuses a resume rename after the surface observer epoch changes", async () => {

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -322,6 +322,27 @@ describe("revive on purpose (#492)", () => {
     expect(sends.some((text) => text.includes(CODEX_SESSION))).toBe(true);
   });
 
+  it("restores the persisted caller title when resuming an agent", async () => {
+    writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
+    stateMgr.writeState(
+      makeRecord({
+        state: "done",
+        workspace_id: "ws:1",
+        surface_id: "surface:old",
+        tab_name: "cmuxlayer-WORKER · golden-path",
+      }),
+    );
+    await engine.getRegistry().reconstitute();
+
+    await engine.resumeAgent("cmuxlayerCodex-revive");
+
+    expect(mockClient.renameTab).toHaveBeenCalledWith(
+      "surface:new",
+      "cmuxlayer-WORKER · golden-path",
+      { workspace: "ws:1" },
+    );
+  });
+
   it("refuses to resume into a session that is not on disk, and opens no pane", async () => {
     mkdirSync(join(harnessHome, ".codex", "sessions"), { recursive: true });
     stateMgr.writeState(
@@ -361,6 +382,9 @@ describe("revive on purpose (#492)", () => {
       "cmuxlayer-WORKER · golden-path",
       { workspace: "ws:1" },
     );
+    expect(stateMgr.listStates()[0]?.tab_name).toBe(
+      "cmuxlayer-WORKER · golden-path",
+    );
   });
 
   it("keeps the existing agent-id fallback when the caller omits a title", () => {
@@ -370,6 +394,39 @@ describe("revive on purpose (#492)", () => {
         "surface:9",
       ),
     ).toBe("cmuxlayerCodex-99887766 [surface:9]");
+  });
+
+  it("uses the identifiable fallback when the caller supplies a blank title", () => {
+    expect(
+      managedPaneTitle("cmuxlayerCodex-99887766", "surface:9", ""),
+    ).toBe("cmuxlayerCodex-99887766 [surface:9]");
+    expect(
+      managedPaneTitle("cmuxlayerCodex-99887766", "surface:9", "   "),
+    ).toBe("cmuxlayerCodex-99887766 [surface:9]");
+  });
+
+  it("binds managed identity by UUID instead of a mutable ref or display title", async () => {
+    const surfaceUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    stateMgr.writeState(
+      makeRecord({
+        surface_id: "surface:managed",
+        surface_uuid: surfaceUuid,
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+      }),
+    );
+    await registry.reconstitute();
+
+    expect(
+      registry.managedIdentityForSurface({ ref: "surface:managed" }),
+    ).toBeNull();
+    expect(
+      registry.managedIdentityForSurface({
+        ref: "surface:renumbered",
+        id: surfaceUuid,
+      }),
+    ).toMatchObject({ repo: "cmuxlayer", cli: "codex", role: "worker" });
   });
 
   it("does not compose caller-supplied role-first titles", () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1274,6 +1274,12 @@ describe("lean spawn tool responses", () => {
     expect(spawn.inputSchema.shape.title.description).toContain(
       "caller-supplied agent pane title is applied verbatim",
     );
+    expect(spawn.inputSchema.shape.title.description).toContain(
+      "when omitted or blank",
+    );
+    expect(spawn.inputSchema.shape.title.description).toContain(
+      "identity comes from the agent registry, not this display title",
+    );
   });
 
   it("spawn_agent rejects launcher-incompatible effort before creating a worktree or surface", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1267,6 +1267,15 @@ describe("lean spawn tool responses", () => {
     }
   });
 
+  it("documents caller-supplied agent pane titles as verbatim", () => {
+    const server = createLifecycleServer(makeLifecycleExec());
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+
+    expect(spawn.inputSchema.shape.title.description).toContain(
+      "caller-supplied agent pane title is applied verbatim",
+    );
+  });
+
   it("spawn_agent rejects launcher-incompatible effort before creating a worktree or surface", async () => {
     const repoRoot = join(TEST_DIR, "Gits", "cmuxlayer");
     const registryPath = join(TEST_DIR, "launchers-effort-preflight.zsh");


### PR DESCRIPTION
## Summary
- preserve caller-supplied `spawn_agent` titles exactly, including role-first labels such as `cmuxlayer-WORKER · run1 name-the-tabs`
- retain the existing agent-id/surface fallback only when `title` is omitted
- document the agent title contract and add spawn-level regression coverage

## TDD evidence
- RED: the engine appended the raw agent id to the supplied role/task title; the no-title fallback and schema contract also failed the corrected assertions
- GREEN: the focused title contract tests pass after returning the supplied title verbatim

## Verification
- `bunx vitest run` — 142 files passed; 3,293 tests passed; 1 skipped
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bunx vitest run` — identical 142 files passed; 3,293 tests passed; 1 skipped
- `bun run typecheck` — passed
- pre-push hook — passed, including the full 142-file suite

## Collision policy
Caller-owned distinct task strings. The engine does not append a collision suffix because that would violate the verbatim title contract and introduce topology-aware naming outside #479's bounded scope. Agent IDs remain available in `list_agents` and receipts.

Closes #479.

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02fb4","ts":"2026-08-23T17:55:15Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how managed agents are identified (UUID-backed registry lookup vs title parsing) and how panes are named on spawn/resume. A mismatch could bind the wrong repo/CLI/role, but this is not auth or data-handling.
> 
> **Overview**
> Stops composing pane titles around `agent_id`/`surface`. A non-blank caller `title` is used as-is (including role-first labels like `cmuxlayer-WORKER · …`); omitted/blank titles still fall back to `agentId [surface]`. Spawn persists that string as `tab_name` and resume restores it.
> 
> Discovery no longer treats the display title as identity. Registry `repo`/`cli`/`role` is resolved via `managedIdentityForSurface` (UUID match; ref-only only when both sides lack a UUID) and preferred for CLI/repo/role over launcher-title parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671dc22ec44c2484010f999d120c73c60776dc49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve caller-supplied agent titles and resolve managed identity from registry
> - Caller-supplied non-blank titles are now used verbatim on spawn and persisted as `tab_name` on the `AgentRecord`, then restored on resume via `managedPaneTitle` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/528/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5). The identifiable fallback (`<agentId> [<surface>]`) is only used when the title is omitted or blank.
> - Adds a managed identity path: `AgentDiscovery.scanSurface` consults `deps.managedIdentityProvider` (wired in [app-server-runtime.ts](https://github.com/EtanHey/cmuxlayer/pull/528/files#diff-b06e09ff3b0e74eac8e2e15c6e8907fcab61898d9cf49c2f6a8f6096c32126c3) and [server.ts](https://github.com/EtanHey/cmuxlayer/pull/528/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595)) to source `repo`, `cli`, and `role` from a registry binding, instead of parsing display titles.
> - `AgentRegistry.managedIdentityForSurface` resolves a single matching `AgentRecord` by stable UUID first, falling back to mutable ref only when neither side has a UUID. `inferRepoFromDiscovery` short-circuits to `managed_repo` when present.
> - `explicitRoleFor` now honors `managed_role` from discovery before consulting the external `explicitRoleProvider`.
> - Risk: `managedIdentityForSurface` requires exactly one matching binding (filtered by `canUseObservedBinding`); surfaces with zero or multiple matches silently fall back to title-based inference, which may mask stale or duplicate registry records.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 671dc22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->