### PR TITLE
fix: bound and surface the daemon lifecycle deadlock (#529)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -957,8 +957,13 @@ function parsePositiveInteger(
  * `list_agents`, `spawn_agent`, `send_to` and the periodic sweep. Both waits
  * are bounded now, and the tail slot is released no matter what.
  */
-export const DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = 120_000;
-export const DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = 300_000;
+/**
+ * #530 review P2-1: both bounds must land INSIDE the ~120s harness inactivity
+ * window, so a wedged control plane returns a structured error the caller can
+ * still read rather than being cut off mid-wait.
+ */
+export const DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = 45_000;
+export const DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = 120_000;
 
 export interface LifecycleLockTimeoutRecord {
   holder: string | null;
@@ -6192,9 +6197,14 @@ export class AgentEngine {
     try {
       await this.awaitLifecycleLock(previous, label, waitStartedAt);
     } catch (error) {
-      // Never leave our own slot dangling: a waiter that gave up must not
-      // become the next holder's unbounded `previous`.
-      release();
+      // #530 review P1-1: resolving our own slot HERE broke mutual exclusion —
+      // the next caller chained off an already-resolved promise and ran
+      // concurrently with the live holder (proven: a concurrent list-agents
+      // evict racing a sweep writeState resurrected a durably deleted agent
+      // dir). Chain the abandoned slot behind `previous` instead, so the queue
+      // still advances but only once the real holder is done. The hold guard
+      // is now the ONLY liveness path past a holder that never settles.
+      void previous.then(release, release);
       throw error;
     } finally {
       this.lifecycleLockQueueDepth = Math.max(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -694,6 +694,19 @@ export interface AgentEngineOptions {
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
   /** Render-only timeout for a working seat whose transcript/output stops advancing. */
   fleetWorkingNoProgressTimeoutMs?: number;
+  /**
+   * Bound how long a queued lifecycle mutation waits for the lock before it
+   * fails fast with a structured error naming the holder (#529).
+   * Env: CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS. 0 disables the bound.
+   */
+  lifecycleLockAcquireTimeoutMs?: number;
+  /**
+   * Bound how long one lifecycle mutation may HOLD the lock before its tail
+   * slot is force-released, so a wedged operation degrades one call instead of
+   * poisoning every later caller (#529).
+   * Env: CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS. 0 disables the guard.
+   */
+  lifecycleLockHoldTimeoutMs?: number;
   /** Bound one queued terminal submission so lifecycle sweeps cannot hang forever. */
   deliverySubmitTimeoutMs?: number;
   /** Bound one background verify observation so a hung reader cannot wedge later sweeps. */
@@ -935,6 +948,67 @@ function parsePositiveInteger(
   if (raw === undefined) return fallback;
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * #529: the lifecycle mutex used to be an unbounded chained promise. One hung
+ * holder queued every later caller forever, and an operation that never
+ * settled never ran its `finally`, permanently poisoning the tail for
+ * `list_agents`, `spawn_agent`, `send_to` and the periodic sweep. Both waits
+ * are bounded now, and the tail slot is released no matter what.
+ */
+export const DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = 120_000;
+export const DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = 300_000;
+
+export interface LifecycleLockTimeoutRecord {
+  holder: string | null;
+  waiter: string;
+  waited_ms: number;
+  held_for_ms: number | null;
+  queue_depth: number;
+  at: string;
+}
+
+export interface LifecycleLockState {
+  holder: string | null;
+  held_for_ms: number | null;
+  queue_depth: number;
+  acquire_timeout_ms: number;
+  hold_timeout_ms: number;
+  forced_releases: number;
+  timeouts: number;
+  last_timeout: LifecycleLockTimeoutRecord | null;
+}
+
+/** A queued lifecycle mutation gave up instead of waiting forever. */
+export class LifecycleLockTimeoutError extends Error {
+  readonly code = "ELIFECYCLELOCKTIMEOUT";
+  readonly holder: string | null;
+  readonly waiter: string;
+  readonly waitedMs: number;
+  readonly heldForMs: number | null;
+  readonly queueDepth: number;
+
+  constructor(opts: {
+    holder: string | null;
+    waiter: string;
+    waitedMs: number;
+    heldForMs: number | null;
+    queueDepth: number;
+  }) {
+    super(
+      `lifecycle lock acquire timed out after ${opts.waitedMs}ms for "${opts.waiter}"; ` +
+        `holder="${opts.holder ?? "unknown"}" held_for_ms=${
+          opts.heldForMs ?? "unknown"
+        } queue_depth=${opts.queueDepth}`,
+    );
+    this.name = "LifecycleLockTimeoutError";
+    this.holder = opts.holder;
+    this.waiter = opts.waiter;
+    this.waitedMs = opts.waitedMs;
+    this.heldForMs = opts.heldForMs;
+    this.queueDepth = opts.queueDepth;
+  }
 }
 
 export function resolveSweepTiming(
@@ -1521,6 +1595,14 @@ export class AgentEngine {
   private fleetWorkingNoProgressTimeoutMs: number;
   private startupInitializePromise: Promise<void> | null = null;
   private lifecycleMutationTail: Promise<void> = Promise.resolve();
+  private readonly lifecycleLockAcquireTimeoutMs: number;
+  private readonly lifecycleLockHoldTimeoutMs: number;
+  private lifecycleLockHolder: string | null = null;
+  private lifecycleLockAcquiredAtMs: number | null = null;
+  private lifecycleLockQueueDepth = 0;
+  private lifecycleLockForcedReleases = 0;
+  private lifecycleLockTimeouts = 0;
+  private lifecycleLockLastTimeout: LifecycleLockTimeoutRecord | null = null;
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
   private deliveryReceiptsPath: string;
   private deliverySubmitter: DeliverySubmitter | null = null;
@@ -1566,6 +1648,22 @@ export class AgentEngine {
     this.deliveryQueueDeadlineMs = Math.max(
       1,
       opts?.deliveryQueueDeadlineMs ?? DEFAULT_DELIVERY_QUEUE_DEADLINE_MS,
+    );
+    this.lifecycleLockAcquireTimeoutMs = Math.max(
+      0,
+      opts?.lifecycleLockAcquireTimeoutMs ??
+        parseNonNegativeInteger(
+          process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS,
+          DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS,
+        ),
+    );
+    this.lifecycleLockHoldTimeoutMs = Math.max(
+      0,
+      opts?.lifecycleLockHoldTimeoutMs ??
+        parseNonNegativeInteger(
+          process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS,
+          DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS,
+        ),
     );
     this.deliveryTicketDir = opts?.deliveryTicketDir ?? null;
     this.deliveryIssueFiler = opts?.deliveryIssueFiler ?? null;
@@ -2926,8 +3024,7 @@ export class AgentEngine {
 
   private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
     return (
-      agent.cli !== "codex" &&
-      this.canUseSelfRegistrationProcessEvidence(agent)
+      agent.cli !== "codex" && this.canUseSelfRegistrationProcessEvidence(agent)
     );
   }
 
@@ -3275,8 +3372,8 @@ export class AgentEngine {
     const identity = this.normalizeCapturedSessionIdentity(capturedIdentity);
     const hasCapturedProcessEvidence = Boolean(
       agent.surface_provenance === "cmuxlayer_spawn" &&
-        identity.pid &&
-        identity.pid_registered_at,
+      identity.pid &&
+      identity.pid_registered_at,
     );
     const capturedProcessEvidence = hasCapturedProcessEvidence
       ? {
@@ -3458,10 +3555,7 @@ export class AgentEngine {
         canResolveSelfRegistration &&
         Boolean(agent.pid) &&
         agentProcessLiveness(agent) === "gone";
-      if (
-        canResolveSelfRegistration &&
-        (!agent.pid || recordedProcessGone)
-      ) {
+      if (canResolveSelfRegistration && (!agent.pid || recordedProcessGone)) {
         try {
           const registered = this.selfRegistrationSessionResolver?.(agent);
           if (registered) {
@@ -6063,22 +6157,146 @@ export class AgentEngine {
    * records carried over from the previous cmux session while retaining any
    * records that this startup's own topology scan just marked surfaceless.
    */
-  async runLifecycleMutation<T>(operation: () => Promise<T>): Promise<T> {
+  /**
+   * Serialize a lifecycle mutation behind a BOUNDED mutex.
+   *
+   * #529: both waits used to be unbounded. `await previous` queued every later
+   * caller behind a hung holder forever, and an `operation()` that never
+   * settled never reached its `finally`, so `release()` never fired and the
+   * tail stayed poisoned for the life of the process — `list_agents` and
+   * `spawn_agent` deadlocked from cold. Now the acquire is bounded and fails
+   * fast with a structured error naming the holder, and this call's tail slot
+   * is released unconditionally: on acquire timeout, on operation settle, and
+   * by a hold guard if the operation never settles at all.
+   */
+  async runLifecycleMutation<T>(
+    operation: () => Promise<T>,
+    opts?: { label?: string },
+  ): Promise<T> {
+    const label = opts?.label ?? "lifecycle-mutation";
     const previous = this.lifecycleMutationTail;
-    let release!: () => void;
-    this.lifecycleMutationTail = new Promise<void>((resolve) => {
-      release = resolve;
+    let released = false;
+    let resolveTail!: () => void;
+    const tail = new Promise<void>((resolve) => {
+      resolveTail = resolve;
     });
-    await previous;
+    const release = () => {
+      if (released) return;
+      released = true;
+      resolveTail();
+    };
+    this.lifecycleMutationTail = tail;
+
+    const waitStartedAt = Date.now();
+    this.lifecycleLockQueueDepth += 1;
+    try {
+      await this.awaitLifecycleLock(previous, label, waitStartedAt);
+    } catch (error) {
+      // Never leave our own slot dangling: a waiter that gave up must not
+      // become the next holder's unbounded `previous`.
+      release();
+      throw error;
+    } finally {
+      this.lifecycleLockQueueDepth = Math.max(
+        0,
+        this.lifecycleLockQueueDepth - 1,
+      );
+    }
+
+    this.lifecycleLockHolder = label;
+    this.lifecycleLockAcquiredAtMs = Date.now();
+    const holdGuard =
+      this.lifecycleLockHoldTimeoutMs > 0
+        ? setTimeout(() => {
+            if (released) return;
+            this.lifecycleLockForcedReleases += 1;
+            console.error(
+              `[cmuxlayer] lifecycle lock force-released after ${this.lifecycleLockHoldTimeoutMs}ms; holder="${label}" never settled`,
+            );
+            release();
+          }, this.lifecycleLockHoldTimeoutMs)
+        : null;
+    holdGuard?.unref?.();
+
     try {
       return await operation();
     } finally {
+      if (holdGuard) clearTimeout(holdGuard);
+      if (this.lifecycleLockHolder === label) {
+        this.lifecycleLockHolder = null;
+        this.lifecycleLockAcquiredAtMs = null;
+      }
       release();
     }
   }
 
+  private async awaitLifecycleLock(
+    previous: Promise<void>,
+    waiter: string,
+    waitStartedAt: number,
+  ): Promise<void> {
+    if (this.lifecycleLockAcquireTimeoutMs <= 0) {
+      await previous;
+      return;
+    }
+    let timer: NodeJS.Timeout | null = null;
+    try {
+      await Promise.race([
+        previous,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            const record: LifecycleLockTimeoutRecord = {
+              holder: this.lifecycleLockHolder,
+              waiter,
+              waited_ms: Date.now() - waitStartedAt,
+              held_for_ms:
+                this.lifecycleLockAcquiredAtMs === null
+                  ? null
+                  : Date.now() - this.lifecycleLockAcquiredAtMs,
+              queue_depth: this.lifecycleLockQueueDepth,
+              at: new Date().toISOString(),
+            };
+            this.lifecycleLockTimeouts += 1;
+            this.lifecycleLockLastTimeout = record;
+            reject(
+              new LifecycleLockTimeoutError({
+                holder: record.holder,
+                waiter,
+                waitedMs: record.waited_ms,
+                heldForMs: record.held_for_ms,
+                queueDepth: record.queue_depth,
+              }),
+            );
+          }, this.lifecycleLockAcquireTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Lifecycle-lock truth for `control_health` — holder, age, queue depth. */
+  lifecycleLockState(): LifecycleLockState {
+    return {
+      holder: this.lifecycleLockHolder,
+      held_for_ms:
+        this.lifecycleLockAcquiredAtMs === null
+          ? null
+          : Date.now() - this.lifecycleLockAcquiredAtMs,
+      queue_depth: this.lifecycleLockQueueDepth,
+      acquire_timeout_ms: this.lifecycleLockAcquireTimeoutMs,
+      hold_timeout_ms: this.lifecycleLockHoldTimeoutMs,
+      forced_releases: this.lifecycleLockForcedReleases,
+      timeouts: this.lifecycleLockTimeouts,
+      last_timeout: this.lifecycleLockLastTimeout,
+    };
+  }
+
   async runSweep(): Promise<void> {
-    await this.runLifecycleMutation(() => this.runSweepOnce());
+    await this.runLifecycleMutation(() => this.runSweepOnce(), {
+      label: "sweep",
+    });
     await this.drainDeliveryQueue();
     await this.verifyPendingDeliveries();
   }
@@ -6549,9 +6767,7 @@ export class AgentEngine {
    * timers, not a defect. The local evidence ticket is still written either
    * way, so the verdict keeps citing its evidence; only the escalation stops.
    */
-  private deliveryFailureEscalationDecline(
-    reason: string,
-  ): string | null {
+  private deliveryFailureEscalationDecline(reason: string): string | null {
     if (reason === "verify_deadline_elapsed") {
       return (
         "background verify ran out of deadline before observing an outcome; " +
@@ -6869,7 +7085,9 @@ export class AgentEngine {
       void (this.startupInitializePromise ?? Promise.resolve())
         .then(() => {
           if (this.fleetSidebarWakeRepublishTimer !== timer) return;
-          return this.runLifecycleMutation(() => this.syncSidebar());
+          return this.runLifecycleMutation(() => this.syncSidebar(), {
+            label: "sync-sidebar",
+          });
         })
         .catch((error) => {
           console.error(
@@ -7080,7 +7298,11 @@ export class AgentEngine {
 
     let screenText: string | null = null;
     let readError: unknown = null;
-    for (let attempt = 0; attempt < WATCH_OBSERVATION_READ_ATTEMPTS; attempt++) {
+    for (
+      let attempt = 0;
+      attempt < WATCH_OBSERVATION_READ_ATTEMPTS;
+      attempt++
+    ) {
       try {
         const screen = await this.client.readScreen(agent.surface_id, {
           ...(agent.workspace_id ? { workspace: agent.workspace_id } : {}),
@@ -8076,12 +8298,12 @@ export class AgentEngine {
             current &&
             INTERACTIVE_AGENT_STATES.has(targetState) &&
             timeoutInteractiveEvidenceIsGated
-            ? await this.getTargetStateEvidenceSource(
-                current,
-                targetState,
-                timeoutState,
-              )
-            : null;
+              ? await this.getTargetStateEvidenceSource(
+                  current,
+                  targetState,
+                  timeoutState,
+                )
+              : null;
           if (current && timeoutEvidence) {
             finish({
               matched: true,
@@ -8465,11 +8687,14 @@ export class AgentEngine {
     }
     const normalizedSurfaceUuid = agent.surface_uuid.trim().toLowerCase();
     const routedAgentId = agent.agent_id;
-    const competingRecord = this.registry.list().find(
-      (candidate) =>
-        candidate.agent_id !== routedAgentId &&
-        candidate.surface_uuid?.trim().toLowerCase() === normalizedSurfaceUuid,
-    );
+    const competingRecord = this.registry
+      .list()
+      .find(
+        (candidate) =>
+          candidate.agent_id !== routedAgentId &&
+          candidate.surface_uuid?.trim().toLowerCase() ===
+            normalizedSurfaceUuid,
+      );
     if (competingRecord) {
       throw new Error(
         `Agent "${agent.agent_id}" cannot use socketless teardown because ` +
@@ -8930,7 +9155,8 @@ export class AgentEngine {
         finalRoute.surface_id,
         finalRoute.workspace_id,
       );
-      const confirmedRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
+      const confirmedRoute =
+        await this.resolveAgentStopIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(finalRoute, confirmedRoute)) {
         throw new Error(
           `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +
@@ -9060,7 +9286,8 @@ export class AgentEngine {
           closeRoute.surface_id,
           closeRoute.workspace_id,
         );
-        confirmedCloseRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
+        confirmedCloseRoute =
+          await this.resolveAgentStopIoRoute(canonicalAgentId);
         if (!this.sameSurfaceRoute(closeRoute, confirmedCloseRoute)) {
           throw new Error(
             `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1005,7 +1005,8 @@ export class LifecycleLockTimeoutError extends Error {
       `lifecycle lock acquire timed out after ${opts.waitedMs}ms for "${opts.waiter}"; ` +
         `holder="${opts.holder ?? "unknown"}" held_for_ms=${
           opts.heldForMs ?? "unknown"
-        } queue_depth=${opts.queueDepth}`,
+        } queue_depth=${opts.queueDepth}. ` +
+        "Retry; if it persists, see control_health.daemon_lifecycle.lifecycle_lock.",
     );
     this.name = "LifecycleLockTimeoutError";
     this.holder = opts.holder;
@@ -1603,6 +1604,14 @@ export class AgentEngine {
   private readonly lifecycleLockAcquireTimeoutMs: number;
   private readonly lifecycleLockHoldTimeoutMs: number;
   private lifecycleLockHolder: string | null = null;
+  /**
+   * #530 review (Macroscope/CodeRabbit): labels are shared strings like
+   * "sweep", so an orphaned operation's `finally` could clear a NEWER holder's
+   * state and blank the diagnostics this PR exists to add. Ownership is tracked
+   * by a per-acquisition token instead.
+   */
+  private lifecycleLockAcquisitionSeq = 0;
+  private lifecycleLockAcquisitionId: number | null = null;
   private lifecycleLockAcquiredAtMs: number | null = null;
   private lifecycleLockQueueDepth = 0;
   private lifecycleLockForcedReleases = 0;
@@ -6213,7 +6222,9 @@ export class AgentEngine {
       );
     }
 
+    const acquisitionId = ++this.lifecycleLockAcquisitionSeq;
     this.lifecycleLockHolder = label;
+    this.lifecycleLockAcquisitionId = acquisitionId;
     this.lifecycleLockAcquiredAtMs = Date.now();
     const holdGuard =
       this.lifecycleLockHoldTimeoutMs > 0
@@ -6232,8 +6243,9 @@ export class AgentEngine {
       return await operation();
     } finally {
       if (holdGuard) clearTimeout(holdGuard);
-      if (this.lifecycleLockHolder === label) {
+      if (this.lifecycleLockAcquisitionId === acquisitionId) {
         this.lifecycleLockHolder = null;
+        this.lifecycleLockAcquisitionId = null;
         this.lifecycleLockAcquiredAtMs = null;
       }
       release();

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -545,6 +545,11 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
       `lifecycle lock was force-released ${lifecycle.lifecycle_lock.forced_releases} time(s); an operation never settled.`,
     );
   }
+  // #530: a stranded/unrestorable socket, or any recorded daemon lifecycle
+  // error, must be visible rather than living only in a log line.
+  if (lifecycle?.last_error) {
+    warnings.push(`daemon lifecycle error: ${lifecycle.last_error}`);
+  }
   if (lifecycle?.lifecycle_start?.error) {
     warnings.push(
       `lifecycle initialization failed: ${lifecycle.lifecycle_start.error}`,

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -544,9 +544,17 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
       `lifecycle initialization failed: ${lifecycle.lifecycle_start.error}`,
     );
   }
-  if (lifecycle?.lifecycle_start && lifecycle.lifecycle_start.timeouts > 0) {
+  // #530 final pass F5: gating on `timeouts > 0` alone latched the warning
+  // forever, the same never-clearing class as P2-3. Once initialization has
+  // settled cleanly, past timeouts are history, not a current degradation.
+  const startHealth = lifecycle?.lifecycle_start;
+  if (
+    startHealth &&
+    startHealth.timeouts > 0 &&
+    (!startHealth.settled || startHealth.error !== null)
+  ) {
     warnings.push(
-      `lifecycle initialization wait timed out ${lifecycle.lifecycle_start.timeouts} time(s) (last at ${lifecycle.lifecycle_start.last_timeout_at ?? "unknown"}); lifecycle-gated tools are degraded.`,
+      `lifecycle initialization wait timed out ${startHealth.timeouts} time(s) (last at ${startHealth.last_timeout_at ?? "unknown"}); lifecycle-gated tools are degraded.`,
     );
   }
   const envSocket = health.current_process.env.CMUX_SOCKET_PATH;

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -16,9 +16,10 @@ import {
 } from "./monitor-registry.js";
 import type { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
 import {
-  daemonLifecycleSnapshot,
+  daemonLifecycleSnapshotFor,
   type DaemonLifecycleSnapshot,
 } from "./daemon-lifecycle-state.js";
+import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
 import type { LifecycleLockState } from "./agent-engine.js";
 
 const MAX_SELF_HEAL_DETAILS = 100;
@@ -62,8 +63,13 @@ export interface ControlHealthOptions {
   surfaceIds?: readonly string[];
   panePtyDeadSince?: ReadonlyMap<string, number>;
   monitorRegistryPath?: string;
-  /** #529: daemon spawn/exit/reap facts; defaults to this process's record. */
+  /**
+   * #529: daemon spawn/exit/reap facts. Defaults to this process's record,
+   * falling back to the sidecar written by whichever process spawned the
+   * daemon (#530 — the daemon serves control_health but the PROXY spawns it).
+   */
   daemonLifecycle?: DaemonLifecycleSnapshot;
+  daemonSocketPath?: string;
   lifecycleLock?: LifecycleLockState | null;
   lifecycleStart?: LifecycleStartHealth | null;
 }
@@ -757,7 +763,10 @@ export async function collectControlHealth(
         : undefined,
     }),
     daemon_lifecycle: {
-      ...(opts.daemonLifecycle ?? daemonLifecycleSnapshot()),
+      ...(opts.daemonLifecycle ??
+        daemonLifecycleSnapshotFor(
+          opts.daemonSocketPath ?? defaultDaemonSocketPath(env),
+        )),
       lifecycle_lock: opts.lifecycleLock ?? null,
       lifecycle_start: opts.lifecycleStart ?? null,
     },

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -15,6 +15,11 @@ import {
   type MonitorRegistryOptions,
 } from "./monitor-registry.js";
 import type { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
+import {
+  daemonLifecycleSnapshot,
+  type DaemonLifecycleSnapshot,
+} from "./daemon-lifecycle-state.js";
+import type { LifecycleLockState } from "./agent-engine.js";
 
 const MAX_SELF_HEAL_DETAILS = 100;
 const MAX_MONITOR_REGISTRY_BYTES = 1024 * 1024;
@@ -57,6 +62,10 @@ export interface ControlHealthOptions {
   surfaceIds?: readonly string[];
   panePtyDeadSince?: ReadonlyMap<string, number>;
   monitorRegistryPath?: string;
+  /** #529: daemon spawn/exit/reap facts; defaults to this process's record. */
+  daemonLifecycle?: DaemonLifecycleSnapshot;
+  lifecycleLock?: LifecycleLockState | null;
+  lifecycleStart?: LifecycleStartHealth | null;
 }
 
 export interface ControlHealthSelfHeal {
@@ -112,6 +121,23 @@ export interface CmuxInstanceHealth {
   processes: Array<{ pid: number | null; command: string }>;
 }
 
+/**
+ * #529 observability. A dead daemon and a wedged lifecycle lock used to look
+ * exactly like a healthy control plane to every tool that did not need them.
+ */
+export interface LifecycleStartHealth {
+  started: boolean;
+  settled: boolean;
+  waiting_for_ms: number | null;
+  timeout_ms: number;
+  error: string | null;
+}
+
+export interface ControlHealthDaemonLifecycle extends DaemonLifecycleSnapshot {
+  lifecycle_lock: LifecycleLockState | null;
+  lifecycle_start: LifecycleStartHealth | null;
+}
+
 export interface ControlHealth {
   generated_at: string;
   current_process: {
@@ -139,15 +165,18 @@ export interface ControlHealth {
     nightly: CmuxInstanceHealth;
   };
   self_heal: ControlHealthSelfHeal;
+  daemon_lifecycle: ControlHealthDaemonLifecycle;
   warnings: string[];
 }
 
-export function collectSelfHealHealth(opts: {
-  surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
-  surfaceIds?: readonly string[];
-  panePtyDeadSince?: ReadonlyMap<string, number>;
-  monitorRegistry?: MonitorRegistryOptions;
-} = {}): ControlHealthSelfHeal {
+export function collectSelfHealHealth(
+  opts: {
+    surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
+    surfaceIds?: readonly string[];
+    panePtyDeadSince?: ReadonlyMap<string, number>;
+    monitorRegistry?: MonitorRegistryOptions;
+  } = {},
+): ControlHealthSelfHeal {
   const surfaceIds = [...new Set(opts.surfaceIds ?? [])];
   const deadSurfaces: ControlHealthSelfHeal["pane_pty_dead"]["surfaces"] = [];
   let deadSurfaceCount = 0;
@@ -164,9 +193,7 @@ export function collectSelfHealHealth(opts: {
           ...(sinceAt === undefined
             ? {}
             : { since_at: new Date(sinceAt).toISOString() }),
-          last_attempt_at: new Date(
-            observation.last_attempt_at,
-          ).toISOString(),
+          last_attempt_at: new Date(observation.last_attempt_at).toISOString(),
         });
       } catch {
         // One malformed/stale surface observation must not break control_health.
@@ -195,13 +222,9 @@ export function collectSelfHealHealth(opts: {
       ) {
         throw new Error("monitor registry JSON has invalid shape");
       }
-      const registryQuery = queryMonitorRegistryForGates(
-        opts.monitorRegistry,
-      );
+      const registryQuery = queryMonitorRegistryForGates(opts.monitorRegistry);
       if (
-        registryQuery.monitors.some(
-          (monitor) => monitor.liveness === "invalid",
-        )
+        registryQuery.monitors.some((monitor) => monitor.liveness === "invalid")
       ) {
         throw new Error("monitor registry contains invalid records");
       }
@@ -241,7 +264,8 @@ export function collectSelfHealHealth(opts: {
       available: monitorRegistryAvailable,
       ...(monitorRegistryError ? { error: monitorRegistryError } : {}),
       total: monitors.length,
-      rearming: monitors.filter((monitor) => monitor.state === "rearming").length,
+      rearming: monitors.filter((monitor) => monitor.state === "rearming")
+        .length,
       collapsed: collapsedMonitors.length,
       collapsed_monitors: collapsedMonitors.slice(0, MAX_SELF_HEAL_DETAILS),
       truncated: collapsedMonitors.length > MAX_SELF_HEAL_DETAILS,
@@ -488,6 +512,32 @@ function describeClient(client: unknown): ControlHealth["selected_transport"] {
 
 function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
   const warnings: string[] = [];
+  // #529: never let a dead daemon or a wedged lifecycle lock stay silent.
+  const lifecycle = health.daemon_lifecycle;
+  if (lifecycle?.last_exit && lifecycle.last_exit.code !== 0) {
+    warnings.push(
+      `cmuxlayer daemon exited with code ${lifecycle.last_exit.code ?? "none"} at ${lifecycle.last_exit.at}; this runtime is not daemon-backed.`,
+    );
+  }
+  if (lifecycle?.lifecycle_lock?.last_timeout) {
+    const timeout = lifecycle.lifecycle_lock.last_timeout;
+    warnings.push(
+      `lifecycle lock acquire timed out for "${timeout.waiter}" after ${timeout.waited_ms}ms (holder "${timeout.holder ?? "unknown"}").`,
+    );
+  }
+  if (
+    lifecycle?.lifecycle_lock &&
+    lifecycle.lifecycle_lock.forced_releases > 0
+  ) {
+    warnings.push(
+      `lifecycle lock was force-released ${lifecycle.lifecycle_lock.forced_releases} time(s); an operation never settled.`,
+    );
+  }
+  if (lifecycle?.lifecycle_start?.error) {
+    warnings.push(
+      `lifecycle initialization failed: ${lifecycle.lifecycle_start.error}`,
+    );
+  }
   const envSocket = health.current_process.env.CMUX_SOCKET_PATH;
   const bundledCli = health.current_process.env.CMUX_BUNDLED_CLI_PATH;
   const firstCmux = health.current_process.cmux_resolution[0];
@@ -687,6 +737,11 @@ export async function collectControlHealth(
         ? { registryPath: opts.monitorRegistryPath }
         : undefined,
     }),
+    daemon_lifecycle: {
+      ...(opts.daemonLifecycle ?? daemonLifecycleSnapshot()),
+      lifecycle_lock: opts.lifecycleLock ?? null,
+      lifecycle_start: opts.lifecycleStart ?? null,
+    },
   };
 
   return { ...base, warnings: buildWarnings(base) };
@@ -709,6 +764,71 @@ function formatInstance(instance: CmuxInstanceHealth): string[] {
     `  app: ${instance.app_binary_path}`,
     `  pids: ${processSummary}`,
   ];
+}
+
+function formatDaemonLifecycle(
+  lifecycle: ControlHealthDaemonLifecycle | undefined,
+): string[] {
+  if (!lifecycle) return [];
+  const lines = [
+    `daemon lifecycle: spawn_attempts=${lifecycle.spawn_attempts}${
+      lifecycle.last_spawn_at ? ` last_spawn_at=${lifecycle.last_spawn_at}` : ""
+    }`,
+  ];
+  if (lifecycle.last_exit) {
+    lines.push(
+      `  last daemon exit: code=${lifecycle.last_exit.code ?? "none"} signal=${
+        lifecycle.last_exit.signal ?? "none"
+      } at=${lifecycle.last_exit.at}`,
+    );
+    for (const line of lifecycle.last_exit.stderr_excerpt
+      .split("\n")
+      .filter((entry) => entry.trim().length > 0)
+      .slice(-5)) {
+      lines.push(`    stderr: ${line}`);
+    }
+  }
+  if (lifecycle.last_socket_reap) {
+    lines.push(
+      `  socket reaped: ${lifecycle.last_socket_reap.path} (${lifecycle.last_socket_reap.reason})`,
+    );
+  }
+  if (lifecycle.last_socket_in_use) {
+    lines.push(
+      `  socket in use: ${lifecycle.last_socket_in_use.path} owner_pid=${
+        lifecycle.last_socket_in_use.owner_pid ?? "unknown"
+      }`,
+    );
+  }
+  if (lifecycle.last_error) {
+    lines.push(`  last daemon error: ${lifecycle.last_error}`);
+  }
+  const lock = lifecycle.lifecycle_lock;
+  if (lock) {
+    lines.push(
+      `lifecycle lock: holder=${lock.holder ?? "none"} held_for_ms=${
+        lock.held_for_ms ?? 0
+      } queue_depth=${lock.queue_depth} timeouts=${lock.timeouts} forced_releases=${lock.forced_releases}`,
+    );
+    if (lock.last_timeout) {
+      lines.push(
+        `  last lock timeout: waiter=${lock.last_timeout.waiter} holder=${
+          lock.last_timeout.holder ?? "unknown"
+        } waited_ms=${lock.last_timeout.waited_ms} at=${lock.last_timeout.at}`,
+      );
+    }
+  }
+  const start = lifecycle.lifecycle_start;
+  if (start) {
+    lines.push(
+      `lifecycle start: started=${start.started} settled=${start.settled}${
+        start.waiting_for_ms === null
+          ? ""
+          : ` waiting_for_ms=${start.waiting_for_ms}`
+      }${start.error ? ` error=${start.error}` : ""}`,
+    );
+  }
+  return lines;
 }
 
 export function formatControlHealth(health: ControlHealth): string {
@@ -758,6 +878,7 @@ export function formatControlHealth(health: ControlHealth): string {
     ...health.self_heal.monitor_registry.collapsed_monitors.map(
       (monitor) => `  ${monitor.monitor_id}: ${monitor.reason}`,
     ),
+    ...formatDaemonLifecycle(health.daemon_lifecycle),
   ];
 
   if (health.current_process.cmux_resolution.length === 0) {

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -131,6 +131,12 @@ export interface LifecycleStartHealth {
   waiting_for_ms: number | null;
   timeout_ms: number;
   error: string | null;
+  /**
+   * #530 review P2-4: how many callers gave up on the bound this PR added.
+   * Without it the new timeout was itself silent — the exact defect class.
+   */
+  timeouts: number;
+  last_timeout_at: string | null;
 }
 
 export interface ControlHealthDaemonLifecycle extends DaemonLifecycleSnapshot {
@@ -538,6 +544,11 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
       `lifecycle initialization failed: ${lifecycle.lifecycle_start.error}`,
     );
   }
+  if (lifecycle?.lifecycle_start && lifecycle.lifecycle_start.timeouts > 0) {
+    warnings.push(
+      `lifecycle initialization wait timed out ${lifecycle.lifecycle_start.timeouts} time(s) (last at ${lifecycle.lifecycle_start.last_timeout_at ?? "unknown"}); lifecycle-gated tools are degraded.`,
+    );
+  }
   const envSocket = health.current_process.env.CMUX_SOCKET_PATH;
   const bundledCli = health.current_process.env.CMUX_BUNDLED_CLI_PATH;
   const firstCmux = health.current_process.cmux_resolution[0];
@@ -821,7 +832,7 @@ function formatDaemonLifecycle(
   const start = lifecycle.lifecycle_start;
   if (start) {
     lines.push(
-      `lifecycle start: started=${start.started} settled=${start.settled}${
+      `lifecycle start: started=${start.started} settled=${start.settled} timeouts=${start.timeouts}${
         start.waiting_for_ms === null
           ? ""
           : ` waiting_for_ms=${start.waiting_for_ms}`

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -11,6 +11,8 @@
  * never be silent again.
  */
 
+import { readFileSync, writeFileSync } from "node:fs";
+
 /**
  * How a connect(2) probe classified the daemon socket path. `superseded` is
  * not a probe verdict: it means the path was replaced between classification
@@ -187,12 +189,75 @@ function emptySnapshot(): DaemonLifecycleSnapshot {
     last_socket_in_use: null,
     last_error: null,
   };
+  persistSidecar();
 }
 
 let state: DaemonLifecycleSnapshot = emptySnapshot();
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+/**
+ * #530 (Codex P2): in the DEFAULT daemon-first topology the proxy process
+ * spawns the daemon and records its exits, while `control_health` is served by
+ * the detached daemon — a different process with its own module-local
+ * snapshot. Without a sidecar the health block reports zeros in exactly the
+ * normal case, which is the observability defect this PR exists to fix.
+ *
+ * The file is best-effort in both directions: never throws, never blocks a
+ * lifecycle decision.
+ */
+export function daemonLifecycleSidecarPath(socketPath: string): string {
+  return `${socketPath}.lifecycle.json`;
+}
+
+function persistSidecar(): void {
+  const socketPath = state.socket_path;
+  if (!socketPath) return;
+  try {
+    writeFileSync(
+      daemonLifecycleSidecarPath(socketPath),
+      JSON.stringify(state),
+      "utf8",
+    );
+  } catch {
+    // Observability must never break the thing it observes.
+  }
+}
+
+export function readDaemonLifecycleSidecar(
+  socketPath: string,
+): DaemonLifecycleSnapshot | null {
+  try {
+    const parsed: unknown = JSON.parse(
+      readFileSync(daemonLifecycleSidecarPath(socketPath), "utf8"),
+    );
+    if (!parsed || typeof parsed !== "object") return null;
+    return { ...emptySnapshot(), ...(parsed as DaemonLifecycleSnapshot) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * This process's record, falling back to the sidecar written by whichever
+ * process actually spawned the daemon.
+ */
+export function daemonLifecycleSnapshotFor(
+  socketPath: string | null | undefined,
+): DaemonLifecycleSnapshot {
+  const local = daemonLifecycleSnapshot();
+  const hasLocalActivity =
+    local.spawn_attempts > 0 ||
+    local.last_exit !== null ||
+    local.last_error !== null ||
+    local.last_socket_reap !== null ||
+    local.last_socket_in_use !== null;
+  if (hasLocalActivity || !socketPath) {
+    return local;
+  }
+  return readDaemonLifecycleSidecar(socketPath) ?? local;
 }
 
 export function recordDaemonSpawnAttempt(opts: {
@@ -245,6 +310,7 @@ export function recordDaemonExit(opts: {
       stderr_excerpt: daemonStderrExcerpt(opts.stderrExcerpt),
     },
   };
+  persistSidecar();
 }
 
 export function recordDaemonSocketReap(opts: {
@@ -255,6 +321,7 @@ export function recordDaemonSocketReap(opts: {
     ...state,
     last_socket_reap: { path: opts.path, reason: opts.reason, at: nowIso() },
   };
+  persistSidecar();
 }
 
 export function recordDaemonSocketInUse(opts: {
@@ -269,10 +336,12 @@ export function recordDaemonSocketInUse(opts: {
       at: nowIso(),
     },
   };
+  persistSidecar();
 }
 
 export function recordDaemonLifecycleError(message: string): void {
   state = { ...state, last_error: message };
+  persistSidecar();
 }
 
 export function daemonLifecycleSnapshot(): DaemonLifecycleSnapshot {

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -189,7 +189,6 @@ function emptySnapshot(): DaemonLifecycleSnapshot {
     last_socket_in_use: null,
     last_error: null,
   };
-  persistSidecar();
 }
 
 let state: DaemonLifecycleSnapshot = emptySnapshot();
@@ -278,6 +277,7 @@ export function recordDaemonSpawnAttempt(opts: {
     last_socket_in_use: null,
     last_error: null,
   };
+  persistSidecar();
 }
 
 export function recordDaemonExit(opts: {

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -198,6 +198,20 @@ export function recordDaemonExit(opts: {
   pid?: number | null;
   stderrExcerpt?: string;
 }): void {
+  // #530 final pass F9: a SUPERSEDED generation's exit can land after a healthy
+  // successor spawned. Recording it re-poisons `last_exit` and re-raises the
+  // "not daemon-backed" warning against a daemon that is serving fine. Only
+  // drop it when both pids are known and differ — an unknown pid cannot be
+  // attributed, and dropping it would reintroduce silence.
+  const currentGeneration = state.last_spawn_pid;
+  if (
+    currentGeneration !== null &&
+    opts.pid !== null &&
+    opts.pid !== undefined &&
+    opts.pid !== currentGeneration
+  ) {
+    return;
+  }
   state = {
     ...state,
     last_exit: {

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -11,8 +11,13 @@
  * never be silent again.
  */
 
-/** How a connect(2) probe classified the daemon socket path. */
-export type DaemonSocketProbe = "live" | "missing" | "stale" | "unknown";
+/**
+ * How a connect(2) probe classified the daemon socket path. `superseded` is
+ * not a probe verdict: it means the path was replaced between classification
+ * and reap, so a successor owns it now (#530 review P2-2).
+ */
+export type DaemonSocketProbe =
+  "live" | "missing" | "stale" | "unknown" | "superseded";
 
 export const DAEMON_SOCKET_IN_USE_CODE = "EDAEMONSOCKETINUSE";
 export const DAEMON_STARTUP_FAILED_CODE = "EDAEMONSTARTUPFAILED";
@@ -171,12 +176,19 @@ export function recordDaemonSpawnAttempt(opts: {
   socketPath: string;
   pid?: number | null;
 }): void {
+  // #530 review P2-3: a new spawn starts a new daemon GENERATION. Carrying the
+  // previous generation's exit/error forward made control_health warn "not
+  // daemon-backed" forever, even once a healthy successor was serving. The
+  // cumulative counter and the reap history survive; the failure state does not.
   state = {
     ...state,
     socket_path: opts.socketPath,
     spawn_attempts: state.spawn_attempts + 1,
     last_spawn_at: nowIso(),
     last_spawn_pid: opts.pid ?? null,
+    last_exit: null,
+    last_socket_in_use: null,
+    last_error: null,
   };
 }
 

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -17,7 +17,30 @@
  * and reap, so a successor owns it now (#530 review P2-2).
  */
 export type DaemonSocketProbe =
-  "live" | "missing" | "stale" | "unknown" | "superseded";
+  "live" | "missing" | "stale" | "unknown" | "superseded" | "occupied";
+
+export const DAEMON_SOCKET_PATH_OCCUPIED_CODE = "EDAEMONSOCKETPATHOCCUPIED";
+
+/**
+ * The socket path holds something that is NOT a daemon artifact — a regular
+ * file with content, a directory, anything cmuxlayer did not create. Never
+ * reaped: a mistyped `CMUXLAYER_DAEMON_SOCKET` must fail loudly rather than
+ * delete the operator's data (#530, Codex P1).
+ */
+export class DaemonSocketPathOccupiedError extends Error {
+  readonly code = DAEMON_SOCKET_PATH_OCCUPIED_CODE;
+  readonly socketPath: string;
+
+  constructor(opts: { socketPath: string; detail: string }) {
+    super(
+      `cmuxlayer daemon socket path is occupied by ${opts.detail}: ${opts.socketPath}. ` +
+        "Refusing to delete it. Point CMUXLAYER_DAEMON_SOCKET at a free path, " +
+        "or remove that file yourself if it is genuinely disposable.",
+    );
+    this.name = "DaemonSocketPathOccupiedError";
+    this.socketPath = opts.socketPath;
+  }
+}
 
 export const DAEMON_SOCKET_IN_USE_CODE = "EDAEMONSOCKETINUSE";
 export const DAEMON_STARTUP_FAILED_CODE = "EDAEMONSTARTUPFAILED";

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -1,0 +1,236 @@
+/**
+ * Daemon lifecycle truth: the structured failures every daemon-dependent
+ * waiter must see, plus the in-process record that makes a dead daemon look
+ * different from a healthy one.
+ *
+ * #529: a leftover file at the daemon socket path made socket reaping throw,
+ * the daemon exited code 1 right after being spawned, and nothing propagated
+ * that exit to the readiness waiters — so `list_agents` and `spawn_agent`
+ * deadlocked forever while lock-free tools kept answering in milliseconds.
+ * Every failure below is deliberately typed and recorded so the same shape can
+ * never be silent again.
+ */
+
+/** How a connect(2) probe classified the daemon socket path. */
+export type DaemonSocketProbe = "live" | "missing" | "stale" | "unknown";
+
+export const DAEMON_SOCKET_IN_USE_CODE = "EDAEMONSOCKETINUSE";
+export const DAEMON_STARTUP_FAILED_CODE = "EDAEMONSTARTUPFAILED";
+export const DAEMON_READINESS_TIMEOUT_CODE = "EDAEMONREADINESSTIMEOUT";
+
+const STDERR_EXCERPT_LIMIT = 4_000;
+
+export function daemonStderrExcerpt(text: string | undefined | null): string {
+  if (!text) return "";
+  const trimmed = text.trimEnd();
+  return trimmed.length > STDERR_EXCERPT_LIMIT
+    ? trimmed.slice(-STDERR_EXCERPT_LIMIT)
+    : trimmed;
+}
+
+/**
+ * The socket path is owned by a daemon that is actually accepting connections
+ * (or by a process whose owner receipt proves it is still alive). The caller
+ * must CONNECT to it, never reap it.
+ */
+export class DaemonSocketInUseError extends Error {
+  readonly code = DAEMON_SOCKET_IN_USE_CODE;
+  readonly socketPath: string;
+  readonly ownerPid: number | null;
+  readonly probe: DaemonSocketProbe;
+
+  constructor(opts: {
+    socketPath: string;
+    ownerPid?: number | null;
+    probe: DaemonSocketProbe;
+  }) {
+    const owner =
+      opts.ownerPid !== null && opts.ownerPid !== undefined
+        ? ` (owner pid ${opts.ownerPid})`
+        : "";
+    super(
+      `cmuxlayer daemon socket is already in use: ${opts.socketPath}${owner} [probe=${opts.probe}]`,
+    );
+    this.name = "DaemonSocketInUseError";
+    this.socketPath = opts.socketPath;
+    this.ownerPid = opts.ownerPid ?? null;
+    this.probe = opts.probe;
+  }
+}
+
+/** The spawned daemon child died (or failed to spawn) before it was ready. */
+export class DaemonStartupFailedError extends Error {
+  readonly code = DAEMON_STARTUP_FAILED_CODE;
+  readonly socketPath: string;
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly stderrExcerpt: string;
+
+  constructor(opts: {
+    socketPath: string;
+    exitCode?: number | null;
+    signal?: string | null;
+    stderrExcerpt?: string;
+    reason?: string;
+    cause?: unknown;
+  }) {
+    const stderr = daemonStderrExcerpt(opts.stderrExcerpt);
+    const detail =
+      opts.reason ??
+      `exited (code=${opts.exitCode ?? "none"}, signal=${opts.signal ?? "none"})`;
+    super(
+      `cmuxlayer daemon failed to start at ${opts.socketPath}: ${detail}${
+        stderr ? `\ndaemon stderr:\n${stderr}` : ""
+      }`,
+    );
+    this.name = "DaemonStartupFailedError";
+    this.socketPath = opts.socketPath;
+    this.exitCode = opts.exitCode ?? null;
+    this.signal = opts.signal ?? null;
+    this.stderrExcerpt = stderr;
+    if (opts.cause !== undefined) {
+      this.cause = opts.cause;
+    }
+  }
+}
+
+/** The daemon never became ready and never died — bounded, never unsettled. */
+export class DaemonReadinessTimeoutError extends Error {
+  readonly code = DAEMON_READINESS_TIMEOUT_CODE;
+  readonly socketPath: string;
+  readonly waitedMs: number;
+  readonly stderrExcerpt: string;
+
+  constructor(opts: {
+    socketPath: string;
+    waitedMs: number;
+    stderrExcerpt?: string;
+  }) {
+    const stderr = daemonStderrExcerpt(opts.stderrExcerpt);
+    super(
+      `cmuxlayer daemon did not become ready at ${opts.socketPath} within ${opts.waitedMs}ms${
+        stderr ? `\ndaemon stderr:\n${stderr}` : ""
+      }`,
+    );
+    this.name = "DaemonReadinessTimeoutError";
+    this.socketPath = opts.socketPath;
+    this.waitedMs = opts.waitedMs;
+    this.stderrExcerpt = stderr;
+  }
+}
+
+export interface DaemonExitRecord {
+  code: number | null;
+  signal: string | null;
+  at: string;
+  pid: number | null;
+  stderr_excerpt: string;
+}
+
+export interface DaemonSocketReapRecord {
+  path: string;
+  reason: string;
+  at: string;
+}
+
+export interface DaemonLifecycleSnapshot {
+  socket_path: string | null;
+  spawn_attempts: number;
+  last_spawn_at: string | null;
+  last_spawn_pid: number | null;
+  last_exit: DaemonExitRecord | null;
+  last_socket_reap: DaemonSocketReapRecord | null;
+  last_socket_in_use: {
+    path: string;
+    owner_pid: number | null;
+    at: string;
+  } | null;
+  last_error: string | null;
+}
+
+function emptySnapshot(): DaemonLifecycleSnapshot {
+  return {
+    socket_path: null,
+    spawn_attempts: 0,
+    last_spawn_at: null,
+    last_spawn_pid: null,
+    last_exit: null,
+    last_socket_reap: null,
+    last_socket_in_use: null,
+    last_error: null,
+  };
+}
+
+let state: DaemonLifecycleSnapshot = emptySnapshot();
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function recordDaemonSpawnAttempt(opts: {
+  socketPath: string;
+  pid?: number | null;
+}): void {
+  state = {
+    ...state,
+    socket_path: opts.socketPath,
+    spawn_attempts: state.spawn_attempts + 1,
+    last_spawn_at: nowIso(),
+    last_spawn_pid: opts.pid ?? null,
+  };
+}
+
+export function recordDaemonExit(opts: {
+  code?: number | null;
+  signal?: string | null;
+  pid?: number | null;
+  stderrExcerpt?: string;
+}): void {
+  state = {
+    ...state,
+    last_exit: {
+      code: opts.code ?? null,
+      signal: opts.signal ?? null,
+      pid: opts.pid ?? null,
+      at: nowIso(),
+      stderr_excerpt: daemonStderrExcerpt(opts.stderrExcerpt),
+    },
+  };
+}
+
+export function recordDaemonSocketReap(opts: {
+  path: string;
+  reason: string;
+}): void {
+  state = {
+    ...state,
+    last_socket_reap: { path: opts.path, reason: opts.reason, at: nowIso() },
+  };
+}
+
+export function recordDaemonSocketInUse(opts: {
+  path: string;
+  ownerPid: number | null;
+}): void {
+  state = {
+    ...state,
+    last_socket_in_use: {
+      path: opts.path,
+      owner_pid: opts.ownerPid,
+      at: nowIso(),
+    },
+  };
+}
+
+export function recordDaemonLifecycleError(message: string): void {
+  state = { ...state, last_error: message };
+}
+
+export function daemonLifecycleSnapshot(): DaemonLifecycleSnapshot {
+  return { ...state };
+}
+
+/** Test-only reset so lifecycle observability is deterministic per test. */
+export function resetDaemonLifecycleState(): void {
+  state = emptySnapshot();
+}

--- a/src/daemon-socket-owner.ts
+++ b/src/daemon-socket-owner.ts
@@ -1,0 +1,103 @@
+/**
+ * Daemon socket owner receipts — the sidecar that says WHICH process owns the
+ * socket path, and whether it is still that process.
+ *
+ * Split out of `daemon.ts` so the thin entry path can read it without pulling in
+ * the whole heavy daemon/server graph (#530). `entry.ts` needs this as
+ * OUT-OF-BAND evidence that a refusal came from a live owner, because a
+ * spawned daemon's stderr is not guaranteed to be drained when its `exit`
+ * fires.
+ */
+import { readFileSync } from "node:fs";
+import { processLiveness, processStartedAtMs } from "./process-liveness.js";
+
+export interface DaemonSocketOwnerReceipt {
+  pid: number;
+  /**
+   * Process start time, so a pid recycled across a reboot cannot masquerade as
+   * the original owner. Null for receipts written by an older build.
+   */
+  startedAtMs: number | null;
+}
+
+/** Sidecar receipt naming the process that currently owns the daemon socket. */
+export function daemonSocketOwnerPath(socketPath: string): string {
+  return `${socketPath}.owner`;
+}
+
+/** `<pid> <startedAtMs>` — the second field is omitted when unavailable. */
+export function daemonSocketOwnerReceiptText(
+  pid: number = process.pid,
+): string {
+  const startedAtMs = processStartedAtMs(pid);
+  return startedAtMs === null ? `${pid}\n` : `${pid} ${startedAtMs}\n`;
+}
+
+export function parseDaemonSocketOwnerReceipt(
+  raw: string,
+): DaemonSocketOwnerReceipt | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const [pidText, startedText] = trimmed.split(/\s+/);
+  const pid = Number.parseInt(pidText ?? "", 10);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const startedAtMs = Number.parseInt(startedText ?? "", 10);
+  return {
+    pid,
+    startedAtMs: Number.isInteger(startedAtMs) ? startedAtMs : null,
+  };
+}
+
+export function readDaemonSocketOwnerReceiptAt(
+  receiptPath: string,
+): DaemonSocketOwnerReceipt | null {
+  try {
+    return parseDaemonSocketOwnerReceipt(readFileSync(receiptPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function readDaemonSocketOwnerReceipt(
+  socketPath: string,
+): DaemonSocketOwnerReceipt | null {
+  return readDaemonSocketOwnerReceiptAt(daemonSocketOwnerPath(socketPath));
+}
+
+export function readDaemonSocketOwnerPid(socketPath: string): number | null {
+  return readDaemonSocketOwnerReceipt(socketPath)?.pid ?? null;
+}
+
+/** `ps lstart` has whole-second precision, so allow a one-second skew. */
+const OWNER_START_SKEW_MS = 1_000;
+
+/**
+ * Is the recorded owner still the SAME live process? A bare-pid receipt (older
+ * build) cannot rule out pid reuse, so it is trusted only while the pid is
+ * live — which keeps #529's reboot fix working: a rebooted machine's leftover
+ * receipt names a pid that is either gone or demonstrably a different process.
+ */
+export function daemonSocketOwnerAlive(
+  receipt: DaemonSocketOwnerReceipt,
+): boolean {
+  if (processLiveness(receipt.pid) === "gone") {
+    return false;
+  }
+  if (receipt.startedAtMs !== null) {
+    const current = processStartedAtMs(receipt.pid);
+    if (
+      current !== null &&
+      Math.abs(current - receipt.startedAtMs) > OWNER_START_SKEW_MS
+    ) {
+      // The pid is live, but it is a DIFFERENT process wearing a recycled pid.
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Does a LIVE owner currently claim this socket path? */
+export function daemonSocketHasLiveOwner(socketPath: string): boolean {
+  const receipt = readDaemonSocketOwnerReceipt(socketPath);
+  return receipt !== null && daemonSocketOwnerAlive(receipt);
+}

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -33,6 +33,20 @@ export function capturedDaemonStderr(child: unknown): string {
   return daemonStderrExcerpt(capturedStderr.get(child as object)?.text ?? "");
 }
 
+let parentStderrGuardInstalled = false;
+
+/**
+ * Install exactly ONE `error` listener on this process's stderr. Async EPIPE
+ * (the MCP client going away while the daemon is still writing) would
+ * otherwise surface as an unhandled 'error' event and kill the spawner. Guarded
+ * by a module flag so repeated spawns cannot leak listeners.
+ */
+function installParentStderrErrorGuard(): void {
+  if (parentStderrGuardInstalled) return;
+  parentStderrGuardInstalled = true;
+  process.stderr.on("error", () => {});
+}
+
 function defaultDaemonScriptPath(): string {
   return resolve(dirname(fileURLToPath(import.meta.url)), "daemon.js");
 }
@@ -67,22 +81,33 @@ export async function spawnDaemonProcess(
   const buffer = { text: "" };
   capturedStderr.set(child, buffer);
   if (captureStderr && child.stderr) {
+    const stderrStream = child.stderr;
+    // #530 review P2-5: EPIPE on process.stderr arrives ASYNCHRONOUSLY, so a
+    // try/catch around write() never sees it. Guard the stream itself, once.
+    installParentStderrErrorGuard();
     const sink =
       opts.stderrSink ??
       ((chunk: string) => {
         try {
-          process.stderr.write(chunk);
+          if (!process.stderr.write(chunk)) {
+            // Honor backpressure rather than buffering the daemon's output
+            // without bound: pause the child until the parent drains.
+            stderrStream.pause();
+            process.stderr.once("drain", () => {
+              if (!stderrStream.destroyed) stderrStream.resume();
+            });
+          }
         } catch {
           // A closed stderr must never take the spawning process down.
         }
       });
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
+    stderrStream.setEncoding("utf8");
+    stderrStream.on("data", (chunk: string) => {
       buffer.text = `${buffer.text}${chunk}`.slice(-STDERR_BUFFER_LIMIT);
       sink(chunk);
     });
-    child.stderr.on("error", () => {});
-    (child.stderr as unknown as { unref?: () => void }).unref?.();
+    stderrStream.on("error", () => {});
+    (stderrStream as unknown as { unref?: () => void }).unref?.();
   }
 
   child.once("error", (error) => {

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -2,12 +2,35 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  daemonStderrExcerpt,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+  recordDaemonSpawnAttempt,
+} from "./daemon-lifecycle-state.js";
 
 export interface SpawnDaemonOptions {
   socketPath: string;
   env: NodeJS.ProcessEnv;
   daemonScriptPath?: string;
   logger: Pick<Console, "error">;
+  /**
+   * Capture the daemon's stderr so a startup failure can be reported to the
+   * readiness waiters instead of vanishing (#529). Defaults to true; the
+   * captured text is still forwarded to this process's stderr.
+   */
+  captureStderr?: boolean;
+  /** Test seam for the stderr forwarder. */
+  stderrSink?: (chunk: string) => void;
+}
+
+const STDERR_BUFFER_LIMIT = 8_000;
+const capturedStderr = new WeakMap<object, { text: string }>();
+
+/** Bounded excerpt of what a spawned daemon printed on stderr. */
+export function capturedDaemonStderr(child: unknown): string {
+  if (!child || typeof child !== "object") return "";
+  return daemonStderrExcerpt(capturedStderr.get(child as object)?.text ?? "");
 }
 
 function defaultDaemonScriptPath(): string {
@@ -30,17 +53,51 @@ export async function spawnDaemonProcess(
       env.CMUXLAYER_NODE_MAX_OLD_SPACE_MB ?? "1536"
     }`.trim();
   }
+  const captureStderr = opts.captureStderr !== false;
   const child = spawn(process.execPath, [daemonScriptPath], {
     detached: true,
     env,
-    stdio: ["ignore", "ignore", "inherit"],
+    stdio: ["ignore", "ignore", captureStderr ? "pipe" : "inherit"],
   });
+  recordDaemonSpawnAttempt({
+    socketPath: opts.socketPath,
+    pid: child.pid ?? null,
+  });
+
+  const buffer = { text: "" };
+  capturedStderr.set(child, buffer);
+  if (captureStderr && child.stderr) {
+    const sink =
+      opts.stderrSink ??
+      ((chunk: string) => {
+        try {
+          process.stderr.write(chunk);
+        } catch {
+          // A closed stderr must never take the spawning process down.
+        }
+      });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      buffer.text = `${buffer.text}${chunk}`.slice(-STDERR_BUFFER_LIMIT);
+      sink(chunk);
+    });
+    child.stderr.on("error", () => {});
+    (child.stderr as unknown as { unref?: () => void }).unref?.();
+  }
+
   child.once("error", (error) => {
+    recordDaemonLifecycleError(error.message);
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon failed (pid=${child.pid ?? "unknown"}): ${error.message}`,
     );
   });
   child.once("exit", (code, signal) => {
+    recordDaemonExit({
+      code,
+      signal,
+      pid: child.pid ?? null,
+      stderrExcerpt: buffer.text,
+    });
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,
     );

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -85,20 +85,36 @@ export async function spawnDaemonProcess(
     // #530 review P2-5: EPIPE on process.stderr arrives ASYNCHRONOUSLY, so a
     // try/catch around write() never sees it. Guard the stream itself, once.
     installParentStderrErrorGuard();
+    // #530 final pass F1: pausing on backpressure and resuming ONLY on `drain`
+    // introduced a NEW hang. An errored writable never emits `drain`, and the
+    // error guard swallows the error — so the child stayed paused forever, its
+    // 64KB stderr pipe filled, and the daemon blocked in write(2). Resume on
+    // `error` and `close` too, and stop forwarding once the destination is
+    // broken (capture is unaffected: the excerpt buffer is fed separately).
+    let forwardingBroken = false;
+    const resumeStderr = () => {
+      if (!stderrStream.destroyed) stderrStream.resume();
+    };
+    const breakForwarding = () => {
+      forwardingBroken = true;
+      resumeStderr();
+    };
+    process.stderr.once("error", breakForwarding);
+    process.stderr.once("close", breakForwarding);
     const sink =
       opts.stderrSink ??
       ((chunk: string) => {
+        if (forwardingBroken) return;
         try {
           if (!process.stderr.write(chunk)) {
             // Honor backpressure rather than buffering the daemon's output
             // without bound: pause the child until the parent drains.
             stderrStream.pause();
-            process.stderr.once("drain", () => {
-              if (!stderrStream.destroyed) stderrStream.resume();
-            });
+            process.stderr.once("drain", resumeStderr);
           }
         } catch {
           // A closed stderr must never take the spawning process down.
+          breakForwarding();
         }
       });
     stderrStream.setEncoding("utf8");

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -33,6 +33,47 @@ export function capturedDaemonStderr(child: unknown): string {
   return daemonStderrExcerpt(capturedStderr.get(child as object)?.text ?? "");
 }
 
+interface Settled {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createSettled(): Settled {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const stderrDrained = new WeakMap<object, Promise<void>>();
+
+/**
+ * Wait, briefly, for a dead child's stderr to finish arriving (#530).
+ *
+ * A daemon that refuses the socket prints its marker and calls
+ * `process.exit(1)` immediately, so `exit` can beat the pipe and leave the
+ * excerpt empty. `close` fires only once stdio is done — this waits for that,
+ * bounded, so a child that never closes cannot stall readiness.
+ */
+export async function awaitDaemonStderrDrained(
+  child: unknown,
+  timeoutMs = 300,
+): Promise<void> {
+  if (!child || typeof child !== "object") return;
+  const drained = stderrDrained.get(child as object);
+  if (!drained) return;
+  let timer: NodeJS.Timeout | null = null;
+  await Promise.race([
+    drained,
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs);
+      timer.unref?.();
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+}
+
 let parentStderrGuardInstalled = false;
 
 /**
@@ -80,6 +121,8 @@ export async function spawnDaemonProcess(
 
   const buffer = { text: "" };
   capturedStderr.set(child, buffer);
+  const stderrSettled = createSettled();
+  stderrDrained.set(child, stderrSettled.promise);
   if (captureStderr && child.stderr) {
     const stderrStream = child.stderr;
     // #530 review P2-5: EPIPE on process.stderr arrives ASYNCHRONOUSLY, so a
@@ -131,6 +174,11 @@ export async function spawnDaemonProcess(
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon failed (pid=${child.pid ?? "unknown"}): ${error.message}`,
     );
+  });
+  child.once("close", () => {
+    // #530 (Codex P1): `close` fires only after the stdio streams are done, so
+    // by here the captured excerpt is complete. `exit` alone can beat the pipe.
+    stderrSettled.resolve();
   });
   child.once("exit", (code, signal) => {
     recordDaemonExit({

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -144,6 +144,19 @@ export async function spawnDaemonProcess(
     };
     process.stderr.once("error", breakForwarding);
     process.stderr.once("close", breakForwarding);
+    // #530 (CodeRabbit): these fire only on a BROKEN destination, so after a
+    // normal child exit they would stay attached forever. runDaemonFirstEntry
+    // can spawn several times (autostart, handoff respawn, version bump), and
+    // ten spawns would trip MaxListenersExceededWarning on the very stderr
+    // channel that carries daemon diagnostics. Detach when the child's stderr
+    // closes.
+    const detachParentStderrListeners = () => {
+      process.stderr.off("error", breakForwarding);
+      process.stderr.off("close", breakForwarding);
+      process.stderr.off("drain", resumeStderr);
+    };
+    stderrStream.once("close", detachParentStderrListeners);
+    stderrStream.once("end", detachParentStderrListeners);
     const sink =
       opts.stderrSink ??
       ((chunk: string) => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -75,6 +75,7 @@ import {
 import {
   DaemonSocketInUseError,
   DaemonSocketPathOccupiedError,
+  recordDaemonLifecycleError,
   recordDaemonSocketInUse,
   recordDaemonSocketReap,
   type DaemonSocketProbe,
@@ -410,9 +411,17 @@ async function restoreSheltered(
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "EEXIST") {
-      logger.error(
-        `[cmuxlayer-daemon] not restoring ${shelterPath}: ${path} is owned by someone else now; leaving the sheltered copy in place`,
-      );
+      // #530 (Codex P1): a third racer bound the path while we were sheltering.
+      // We will NOT clobber it, and we cannot terminate the sheltered owner —
+      // killing another daemon mid-drain is worse than either alternative. So
+      // the sheltered owner may keep serving its existing connections while new
+      // clients route to the newer daemon. That residual is accepted (see the
+      // follow-up issue) but it is NOT silent: it is recorded and warned on.
+      const detail =
+        `stranded daemon socket: ${shelterPath} could not be restored to ${path} ` +
+        "because another owner bound it first; two backends may be serving";
+      logger.error(`[cmuxlayer-daemon] ${detail}`);
+      recordDaemonLifecycleError(detail);
       return;
     }
     logger.error(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -10,7 +10,7 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
   Transport,
@@ -47,7 +47,11 @@ import type { ExecFn } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxServerContext, CreateServerOptions } from "./server.js";
-import { defaultDaemonSocketPath } from "./daemon-socket-path.js";
+import {
+  DAEMON_SOCKET_FILENAME,
+  NIGHTLY_DAEMON_SOCKET_FILENAME,
+  defaultDaemonSocketPath,
+} from "./daemon-socket-path.js";
 import { ensureNodeMaxOldSpaceEnv, installHeapGuard } from "./heap-guard.js";
 import { JsonRpcLineBuffer } from "./json-rpc-line-buffer.js";
 import {
@@ -648,6 +652,30 @@ export async function probeDaemonSocketPath(
   });
 }
 
+/**
+ * Weak ownership evidence for a receiptless EMPTY file (#530, Macroscope).
+ *
+ * Nothing intrinsic distinguishes cmuxlayer's placeholder from an operator's
+ * empty lock file — that is the honest shape of the problem. The name is the
+ * only signal available, so:
+ *
+ * - cmuxlayer's own canonical filenames always qualify;
+ * - so does any `*.sock`, because a path configured as a SOCKET is a path the
+ *   operator handed to cmuxlayer for that purpose. Custom
+ *   `CMUXLAYER_DAEMON_SOCKET` names are supported and must keep working, and a
+ *   0.4.56 leftover has no receipt to fall back on.
+ *
+ * A mistyped path at a document, config, or `.lock` fails this and is refused.
+ */
+function hasDaemonSocketOwnershipEvidence(path: string): boolean {
+  const name = basename(path);
+  return (
+    name === DAEMON_SOCKET_FILENAME ||
+    name === NIGHTLY_DAEMON_SOCKET_FILENAME ||
+    name.endsWith(".sock")
+  );
+}
+
 export type UnlinkStaleSocketOutcome = "absent" | "reaped";
 
 export interface UnlinkStaleSocketOptions {
@@ -727,6 +755,25 @@ export async function unlinkStaleSocket(
   }
   if (status === "live") {
     refuse(status, readOwnerReceipt(path));
+  }
+
+  // #530 (Macroscope): an EMPTY regular file is cmuxlayer's placeholder shape,
+  // but it is also the shape of an operator's lock/sentinel file. Reaping one
+  // with no receipt is only safe where cmuxlayer owns the NAME. A mistyped
+  // CMUXLAYER_DAEMON_SOCKET pointing at someone's empty file does not match,
+  // and is refused; the canonical filename still reaps, which preserves the
+  // #529 upgrade path from builds that never wrote receipts at all.
+  if (
+    status === "stale" &&
+    observedReceipt === null &&
+    observedIdentity?.kind === "file" &&
+    !hasDaemonSocketOwnershipEvidence(path)
+  ) {
+    throw new DaemonSocketPathOccupiedError({
+      socketPath: path,
+      detail:
+        "an empty file cmuxlayer cannot prove it created (no owner receipt, and the name is not a socket path)",
+    });
   }
 
   const liveOwner = observedReceipt !== null && ownerAlive(observedReceipt);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -56,6 +56,7 @@ import { isMainModule } from "./is-main.js";
 import { processLiveness, processStartedAtMs } from "./process-liveness.js";
 import {
   DaemonSocketInUseError,
+  DaemonSocketPathOccupiedError,
   recordDaemonSocketInUse,
   recordDaemonSocketReap,
   type DaemonSocketProbe,
@@ -558,7 +559,12 @@ export async function probeDaemonSocketPath(
   try {
     const stats = await lstat(path);
     if (!stats.isSocket()) {
-      return "stale";
+      // #530 (Codex P1): only cmuxlayer's OWN artifact shape is reapable. The
+      // shutdown placeholder is an empty regular file
+      // (`writeFile(path, "", { flag: "wx" })`), so anything with content — or
+      // any other node type — is the operator's data at a mistyped socket path
+      // and must fail loudly instead of being deleted.
+      return stats.isFile() && stats.size === 0 ? "stale" : "occupied";
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -662,6 +668,13 @@ export async function unlinkStaleSocket(
   const status = await probe(path);
   if (status === "missing") {
     return "absent";
+  }
+  if (status === "occupied") {
+    // Not a daemon artifact at all. Never reaped — see the probe's note.
+    throw new DaemonSocketPathOccupiedError({
+      socketPath: path,
+      detail: "a file cmuxlayer did not create",
+    });
   }
   if (status === "live") {
     refuse(status, readOwnerReceipt(path));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -53,7 +53,7 @@ import {
   type StaleBuildResult,
 } from "./version.js";
 import { isMainModule } from "./is-main.js";
-import { processLiveness } from "./process-liveness.js";
+import { processLiveness, processStartedAtMs } from "./process-liveness.js";
 import {
   DaemonSocketInUseError,
   recordDaemonSocketInUse,
@@ -339,10 +339,15 @@ function isJsonRpcResponse(
 const DAEMON_SOCKET_PROBE_TIMEOUT_MS = 250;
 
 /**
- * connect(2) failures that PROVE nothing is listening on the path any more.
- * ENOTSOCK is the reboot shape: `detachOwnedSocketPath()` leaves an empty
- * regular file at the socket path on every clean shutdown, so a SIGTERM at
- * logout/reboot leaves a leftover that no daemon can ever own (#529).
+ * connect(2) failures that mean NOTHING ANSWERED. ENOTSOCK is the reboot shape:
+ * `detachOwnedSocketPath()` leaves an empty regular file at the socket path on
+ * every clean shutdown, so a SIGTERM at logout/reboot leaves a leftover no
+ * daemon can own (#529).
+ *
+ * These are NOT proof that the path is free. ECONNRESET and EPIPE in particular
+ * require a peer that accepted and reset — a live daemon draining or destroying
+ * the connection produces exactly that (CodeRabbit, #530). `unlinkStaleSocket`
+ * therefore consults the owner receipt on this path too, and a live owner wins.
  */
 const DEAD_OWNER_CONNECT_CODES = new Set([
   "ECONNREFUSED",
@@ -352,19 +357,77 @@ const DEAD_OWNER_CONNECT_CODES = new Set([
   "EPIPE",
 ]);
 
-/** Sidecar receipt naming the pid that currently owns the daemon socket. */
+/** Sidecar receipt naming the process that currently owns the daemon socket. */
 export function daemonSocketOwnerPath(socketPath: string): string {
   return `${socketPath}.owner`;
 }
 
-export function readDaemonSocketOwnerPid(socketPath: string): number | null {
+export interface DaemonSocketOwnerReceipt {
+  pid: number;
+  /**
+   * Process start time, so a pid recycled across a reboot cannot masquerade as
+   * the original owner. Null for receipts written by an older build.
+   */
+  startedAtMs: number | null;
+}
+
+/** `<pid> <startedAtMs>` — the second field is omitted when unavailable. */
+export function daemonSocketOwnerReceiptText(
+  pid: number = process.pid,
+): string {
+  const startedAtMs = processStartedAtMs(pid);
+  return startedAtMs === null ? `${pid}\n` : `${pid} ${startedAtMs}\n`;
+}
+
+export function readDaemonSocketOwnerReceipt(
+  socketPath: string,
+): DaemonSocketOwnerReceipt | null {
   try {
     const raw = readFileSync(daemonSocketOwnerPath(socketPath), "utf8").trim();
-    const pid = Number.parseInt(raw, 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
+    if (!raw) return null;
+    const [pidText, startedText] = raw.split(/\s+/);
+    const pid = Number.parseInt(pidText ?? "", 10);
+    if (!Number.isInteger(pid) || pid <= 0) return null;
+    const startedAtMs = Number.parseInt(startedText ?? "", 10);
+    return {
+      pid,
+      startedAtMs: Number.isInteger(startedAtMs) ? startedAtMs : null,
+    };
   } catch {
     return null;
   }
+}
+
+export function readDaemonSocketOwnerPid(socketPath: string): number | null {
+  return readDaemonSocketOwnerReceipt(socketPath)?.pid ?? null;
+}
+
+/** `ps lstart` has whole-second precision, so allow a one-second skew. */
+const OWNER_START_SKEW_MS = 1_000;
+
+/**
+ * Is the recorded owner still the SAME live process? A bare-pid receipt (older
+ * build) cannot rule out pid reuse, so it is trusted only while the pid is
+ * live — which keeps #529's reboot fix working: a rebooted machine's leftover
+ * receipt names a pid that is either gone or demonstrably a different process.
+ */
+export function daemonSocketOwnerAlive(
+  receipt: DaemonSocketOwnerReceipt,
+): boolean {
+  if (processLiveness(receipt.pid) === "gone") {
+    return false;
+  }
+  if (receipt.startedAtMs !== null) {
+    const current = processStartedAtMs(receipt.pid);
+    if (
+      current !== null &&
+      Math.abs(current - receipt.startedAtMs) > OWNER_START_SKEW_MS
+    ) {
+      // The pid is live, but it is a DIFFERENT process wearing a recycled pid.
+      return false;
+    }
+  }
+  return true;
 }
 
 async function unlinkIfPresent(path: string): Promise<void> {
@@ -380,15 +443,25 @@ interface DaemonSocketIdentity {
   ino: number;
 }
 
-/** dev/ino of the path right now, or null when it does not exist. */
+/**
+ * dev/ino of the path right now, or null when it genuinely does not exist.
+ *
+ * #530 final pass F2: swallowing EVERY lstat error meant EIO/EACCES read as
+ * "absent", which silently disabled the superseded guard and let
+ * `unlinkStaleSocket` report "reaped" without deleting anything. Only ENOENT is
+ * absence; every other errno is a real failure and must propagate.
+ */
 async function socketIdentity(
   path: string,
 ): Promise<DaemonSocketIdentity | null> {
   try {
     const stats = await lstat(path);
     return { dev: stats.dev, ino: stats.ino };
-  } catch {
-    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -406,13 +479,16 @@ function sameIdentity(
  */
 async function unlinkOwnerReceiptIfUnchanged(
   path: string,
-  expectedPid: number | null,
-  readOwnerPid: (path: string) => number | null,
+  expected: DaemonSocketOwnerReceipt | null,
+  readOwnerReceipt: (path: string) => DaemonSocketOwnerReceipt | null,
 ): Promise<void> {
-  if (expectedPid === null) {
+  // No receipt at classification time also covers F8's absent-then-present
+  // case for the receipt: a successor's brand-new receipt is never ours to delete.
+  if (expected === null) {
     return;
   }
-  if (readOwnerPid(path) !== expectedPid) {
+  const current = readOwnerReceipt(path);
+  if (current === null || current.pid !== expected.pid) {
     return;
   }
   await unlinkIfPresent(daemonSocketOwnerPath(path));
@@ -480,84 +556,103 @@ export type UnlinkStaleSocketOutcome = "absent" | "reaped";
 
 export interface UnlinkStaleSocketOptions {
   probe?: (path: string) => Promise<DaemonSocketProbe>;
-  readOwnerPid?: (path: string) => number | null;
-  ownerAlive?: (pid: number) => boolean;
+  readOwnerReceipt?: (path: string) => DaemonSocketOwnerReceipt | null;
+  ownerAlive?: (receipt: DaemonSocketOwnerReceipt) => boolean;
 }
 
 /**
- * Reap a genuinely dead-owner leftover; refuse a socket a live daemon owns.
+ * Reap a genuinely dead-owner leftover; refuse anything a live daemon owns.
+ *
+ * The owner receipt OUTRANKS the connect probe whenever it names a process
+ * that is still alive:
  *
  * - `missing`  -> nothing to do.
- * - `stale`    -> no listener can exist behind it; reap it and its receipt.
- * - `live`     -> a daemon is accepting connections. Throw
- *                 `DaemonSocketInUseError` so the caller CONNECTS to it.
- * - `unknown`  -> inconclusive. The owner receipt decides: a receipt naming a
- *                 dead pid proves a leftover, anything else fails closed.
+ * - `live`     -> a daemon is accepting connections. Refuse.
+ * - `stale`    -> nothing answered. #530 final pass F3 (Codex P1): that is NOT
+ *                 sufficient. `closeListener()` parks a regular-file
+ *                 placeholder BEFORE `waitForDrain()`, so a daemon that is
+ *                 still draining in-flight requests presents exactly this
+ *                 shape for up to 5s. CodeRabbit's ECONNRESET/EPIPE finding is
+ *                 the same hole from the other side: both errnos require a
+ *                 peer that reset, i.e. a live owner. So consult the receipt
+ *                 here too, and only reap when no live owner claims the path.
+ * - `unknown`  -> inconclusive; the receipt decides, and no receipt fails closed.
+ *
+ * On refusal the daemon fatals, its readiness rejects, and the ENTRY layer
+ * re-probes and attaches to the live owner (or falls back in-process). The
+ * "connect to it" outcome belongs to that layer, not to this function.
  */
 export async function unlinkStaleSocket(
   path: string,
   opts: UnlinkStaleSocketOptions = {},
 ): Promise<UnlinkStaleSocketOutcome> {
   const probe = opts.probe ?? probeDaemonSocketPath;
-  const readOwnerPid = opts.readOwnerPid ?? readDaemonSocketOwnerPid;
-  const ownerAlive =
-    opts.ownerAlive ?? ((pid: number) => processLiveness(pid) !== "gone");
+  const readOwnerReceipt =
+    opts.readOwnerReceipt ?? readDaemonSocketOwnerReceipt;
+  const ownerAlive = opts.ownerAlive ?? daemonSocketOwnerAlive;
 
-  // #530 review P2-2: capture the identity we are about to classify so the
-  // reap can prove it is still deleting THAT file and not a successor's.
+  const refuse = (
+    observedProbe: DaemonSocketProbe,
+    receipt: DaemonSocketOwnerReceipt | null,
+  ): never => {
+    const ownerPid = receipt?.pid ?? null;
+    recordDaemonSocketInUse({ path, ownerPid });
+    throw new DaemonSocketInUseError({
+      socketPath: path,
+      ownerPid,
+      probe: observedProbe,
+    });
+  };
+
+  // #530 review P2-2: capture what we are about to classify so the reap can
+  // prove it is still deleting THAT object and not a successor's.
   const observedIdentity = await socketIdentity(path);
-  const observedOwnerPid = readOwnerPid(path);
+  const observedReceipt = readOwnerReceipt(path);
 
   const status = await probe(path);
   if (status === "missing") {
     return "absent";
   }
-
-  let reason: string;
   if (status === "live") {
-    const ownerPid = readOwnerPid(path);
-    recordDaemonSocketInUse({ path, ownerPid });
-    throw new DaemonSocketInUseError({
-      socketPath: path,
-      ownerPid,
-      probe: status,
-    });
-  } else if (status === "unknown") {
-    const ownerPid = readOwnerPid(path);
-    if (ownerPid === null || ownerAlive(ownerPid)) {
-      recordDaemonSocketInUse({ path, ownerPid });
-      throw new DaemonSocketInUseError({
-        socketPath: path,
-        ownerPid,
-        probe: status,
-      });
-    }
-    reason = `owner-receipt-pid-${ownerPid}-gone`;
-  } else {
-    reason = "dead-owner-leftover";
+    refuse(status, readOwnerReceipt(path));
   }
+
+  const liveOwner = observedReceipt !== null && ownerAlive(observedReceipt);
+  if (liveOwner) {
+    refuse(status, observedReceipt);
+  }
+  if (status === "unknown" && observedReceipt === null) {
+    // Nothing answered and nothing claims it: fail closed rather than steal a
+    // socket an older build may still own.
+    refuse(status, null);
+  }
+  const reason =
+    observedReceipt === null
+      ? "dead-owner-leftover"
+      : `owner-receipt-pid-${observedReceipt.pid}-gone`;
 
   const current = await socketIdentity(path);
   if (current === null) {
     // It vanished on its own between classification and reap. Nothing left to
     // delete, and the path is free for us to bind.
-    await unlinkOwnerReceiptIfUnchanged(path, observedOwnerPid, readOwnerPid);
+    await unlinkOwnerReceiptIfUnchanged(
+      path,
+      observedReceipt,
+      readOwnerReceipt,
+    );
     recordDaemonSocketReap({ path, reason: `${reason}-vanished` });
     return "reaped";
   }
-  if (observedIdentity !== null && !sameIdentity(current, observedIdentity)) {
-    // Something replaced the leftover while we were classifying it. Unlinking
-    // now would steal a successor's socket, so refuse instead.
-    const ownerPid = readOwnerPid(path);
-    recordDaemonSocketInUse({ path, ownerPid });
-    throw new DaemonSocketInUseError({
-      socketPath: path,
-      ownerPid,
-      probe: "superseded",
-    });
+  // #530 final pass F8 (Codex addendum): when the path was ABSENT at
+  // classification, `observedIdentity` is null and the identity comparison used
+  // to be skipped entirely — so a successor that bound DURING classification
+  // was unlinked. Absent-then-present is a successor, never a leftover.
+  if (observedIdentity === null || !sameIdentity(current, observedIdentity)) {
+    refuse("superseded", readOwnerReceipt(path));
   }
+
   await unlinkIfPresent(path);
-  await unlinkOwnerReceiptIfUnchanged(path, observedOwnerPid, readOwnerPid);
+  await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, readOwnerReceipt);
   recordDaemonSocketReap({ path, reason });
   return "reaped";
 }
@@ -659,7 +754,7 @@ export class CmuxLayerDaemon {
       // when the connect probe is inconclusive.
       await writeFile(
         daemonSocketOwnerPath(this.socketPath),
-        `${process.pid}\n`,
+        daemonSocketOwnerReceiptText(),
         "utf8",
       ).catch(() => {});
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -424,11 +424,15 @@ async function restoreSheltered(
       recordDaemonLifecycleError(detail);
       return;
     }
-    logger.error(
-      `[cmuxlayer-daemon] failed to restore ${shelterPath} to ${path}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
+    // #530 (Macroscope): swallowing this returned "restored" while a live
+    // socket sat stranded at the shelter name and the well-known path stayed
+    // vacant — unreachable daemon, silent. Record it and propagate.
+    const detail =
+      `failed to restore ${shelterPath} to ${path}: ` +
+      (error instanceof Error ? error.message : String(error));
+    logger.error(`[cmuxlayer-daemon] ${detail}`);
+    recordDaemonLifecycleError(detail);
+    throw error;
   }
 }
 
@@ -1557,11 +1561,19 @@ export class CmuxLayerDaemon {
     }
 
     if (observed !== null) {
-      if (!sameIdentity(await socketIdentity(this.socketPath), observed)) {
-        // Replaced under us between the check and the unlink.
+      // #530 (Codex P1): this was still check-then-unlink, so a starter could
+      // move the placeholder after the comparison, bind its successor socket,
+      // and have that LIVE socket removed by our unlink. Claim it atomically
+      // with the same rename-verify-or-restore path the reap uses.
+      const claimed = await reapClassifiedSocket(
+        this.socketPath,
+        observed,
+        socketIdentity,
+        this.logger,
+      ).catch(() => false);
+      if (!claimed) {
         return;
       }
-      await unlinkIfPresent(this.socketPath).catch(() => {});
     }
 
     if (readDaemonSocketOwnerReceipt(this.socketPath)?.pid === process.pid) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -430,6 +430,49 @@ export function daemonSocketOwnerAlive(
   return true;
 }
 
+/**
+ * Reap the EXACT object we classified, using rename(2) as the arbitration
+ * primitive (#530, Codex P1).
+ *
+ * A dev/ino check followed by a separate `unlink(2)` cannot be made safe: two
+ * successors can both validate the old inode, and the loser then deletes the
+ * winner's live socket. `rename` is atomic, so exactly one racer can move the
+ * object out of the well-known path; everyone else gets ENOENT and simply finds
+ * the path free. Identity is then verified on a name no other process knows,
+ * and anything we did not mean to move is put back rather than destroyed.
+ *
+ * `detachOwnedSocketPath()` already uses this shelter-and-restore idiom.
+ *
+ * Returns true when the path is ours to bind, false when we moved something
+ * that turned out to belong to a successor (restored, and the caller refuses).
+ */
+async function reapClassifiedSocket(
+  path: string,
+  observedIdentity: DaemonSocketIdentity | null,
+): Promise<boolean> {
+  const reapingPath = `${path}.reaping-${process.pid}-${Date.now()}`;
+  try {
+    await rename(path, reapingPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      // Another racer moved it first; the path is free either way.
+      return true;
+    }
+    throw error;
+  }
+
+  const moved = await socketIdentity(reapingPath).catch(() => null);
+  if (observedIdentity !== null && !sameIdentity(moved, observedIdentity)) {
+    // We grabbed something that is NOT what we classified — a successor bound
+    // here after our check. Put it back; never delete it.
+    await rename(reapingPath, path).catch(() => {});
+    return false;
+  }
+
+  await unlinkIfPresent(reapingPath);
+  return true;
+}
+
 async function unlinkIfPresent(path: string): Promise<void> {
   await unlink(path).catch((error: NodeJS.ErrnoException) => {
     if (error.code !== "ENOENT") {
@@ -663,7 +706,9 @@ export async function unlinkStaleSocket(
     refuse("superseded", readOwnerReceipt(path));
   }
 
-  await unlinkIfPresent(path);
+  if (!(await reapClassifiedSocket(path, observedIdentity))) {
+    refuse("superseded", readOwnerReceipt(path));
+  }
   await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, readOwnerReceipt);
   recordDaemonSocketReap({ path, reason });
   return "reaped";
@@ -1550,6 +1595,14 @@ if (isMainModule(import.meta.url, process.argv[1])) {
   // an unhandled EPIPE there would kill an otherwise healthy shared daemon.
   process.stderr.on("error", () => {});
   runDaemon().catch((error) => {
+    // #530 (Codex P1): the spawning entry reads this stderr to tell "another
+    // owner holds the socket, wait for it" apart from a genuine startup
+    // failure. Print the structured code so that decision is not string
+    // matching on prose.
+    const code = (error as { code?: unknown } | null)?.code;
+    if (typeof code === "string") {
+      console.error(`[cmuxlayer-daemon] fatal code=${code}`);
+    }
     console.error("[cmuxlayer-daemon] fatal", error);
     process.exit(1);
   });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -450,6 +450,7 @@ export function daemonSocketOwnerAlive(
 async function reapClassifiedSocket(
   path: string,
   observedIdentity: DaemonSocketIdentity | null,
+  readIdentity: (path: string) => Promise<DaemonSocketIdentity | null>,
 ): Promise<boolean> {
   const reapingPath = `${path}.reaping-${process.pid}-${Date.now()}`;
   try {
@@ -462,8 +463,20 @@ async function reapClassifiedSocket(
     throw error;
   }
 
-  const moved = await socketIdentity(reapingPath).catch(() => null);
-  if (observedIdentity !== null && !sameIdentity(moved, observedIdentity)) {
+  const moved = await readIdentity(reapingPath).catch(() => null);
+  const stillOurs =
+    observedIdentity !== null && sameIdentity(moved, observedIdentity);
+
+  // Last line of defence, independent of identity entirely: a socket that
+  // ANSWERS has a live listener behind it, whatever its dev/ino say. The
+  // listener is bound to the inode, so it still answers on the sheltered name.
+  // This catches the residual socket-to-socket inode-reuse case that the kind
+  // check cannot (#530 CI).
+  const answersNow =
+    moved?.kind === "socket" &&
+    (await probeDaemonSocketPath(reapingPath)) === "live";
+
+  if (!stillOurs || answersNow) {
     // We grabbed something that is NOT what we classified — a successor bound
     // here after our check. Put it back; never delete it.
     await rename(reapingPath, path).catch(() => {});
@@ -482,9 +495,32 @@ async function unlinkIfPresent(path: string): Promise<void> {
   });
 }
 
-interface DaemonSocketIdentity {
+export type DaemonSocketPathKind = "socket" | "file" | "directory" | "other";
+
+export interface DaemonSocketIdentity {
   dev: number;
   ino: number;
+  /**
+   * #530 (CI, Linux): dev/ino ALONE cannot identify an object across a
+   * delete-and-recreate. Linux hands the freed inode number straight back, so a
+   * successor's brand-new SOCKET can carry the exact dev/ino of the
+   * regular-file placeholder we classified — and the reap then deleted a LIVE
+   * socket. macOS happened to allocate a different inode, which is why this
+   * passed on the laptop and failed in CI. The node type is stable across
+   * rename(2) and can never collide, so it is part of identity.
+   */
+  kind: DaemonSocketPathKind;
+}
+
+function statsKind(stats: {
+  isSocket(): boolean;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}): DaemonSocketPathKind {
+  if (stats.isSocket()) return "socket";
+  if (stats.isFile()) return "file";
+  if (stats.isDirectory()) return "directory";
+  return "other";
 }
 
 /**
@@ -500,7 +536,7 @@ async function socketIdentity(
 ): Promise<DaemonSocketIdentity | null> {
   try {
     const stats = await lstat(path);
-    return { dev: stats.dev, ino: stats.ino };
+    return { dev: stats.dev, ino: stats.ino, kind: statsKind(stats) };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
@@ -513,7 +549,13 @@ function sameIdentity(
   a: DaemonSocketIdentity | null,
   b: DaemonSocketIdentity | null,
 ): boolean {
-  return a !== null && b !== null && a.dev === b.dev && a.ino === b.ino;
+  return (
+    a !== null &&
+    b !== null &&
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.kind === b.kind
+  );
 }
 
 /**
@@ -614,6 +656,12 @@ export interface UnlinkStaleSocketOptions {
   probe?: (path: string) => Promise<DaemonSocketProbe>;
   readOwnerReceipt?: (path: string) => DaemonSocketOwnerReceipt | null;
   ownerAlive?: (receipt: DaemonSocketOwnerReceipt) => boolean;
+  /**
+   * Test seam for path identity, so inode REUSE — which only occurs naturally
+   * on some filesystems — can be reproduced deterministically on any platform
+   * (#530 CI).
+   */
+  readIdentity?: (path: string) => Promise<DaemonSocketIdentity | null>;
 }
 
 /**
@@ -646,6 +694,7 @@ export async function unlinkStaleSocket(
   const readOwnerReceipt =
     opts.readOwnerReceipt ?? readDaemonSocketOwnerReceipt;
   const ownerAlive = opts.ownerAlive ?? daemonSocketOwnerAlive;
+  const readIdentity = opts.readIdentity ?? socketIdentity;
 
   const refuse = (
     observedProbe: DaemonSocketProbe,
@@ -662,7 +711,7 @@ export async function unlinkStaleSocket(
 
   // #530 review P2-2: capture what we are about to classify so the reap can
   // prove it is still deleting THAT object and not a successor's.
-  const observedIdentity = await socketIdentity(path);
+  const observedIdentity = await readIdentity(path);
   const observedReceipt = readOwnerReceipt(path);
 
   const status = await probe(path);
@@ -699,7 +748,7 @@ export async function unlinkStaleSocket(
       ? "dead-owner-leftover"
       : `owner-receipt-pid-${observedReceipt.pid}-gone`;
 
-  const current = await socketIdentity(path);
+  const current = await readIdentity(path);
   if (current === null) {
     // It vanished on its own between classification and reap. Nothing left to
     // delete, and the path is free for us to bind.
@@ -719,7 +768,7 @@ export async function unlinkStaleSocket(
     refuse("superseded", readOwnerReceipt(path));
   }
 
-  if (!(await reapClassifiedSocket(path, observedIdentity))) {
+  if (!(await reapClassifiedSocket(path, observedIdentity, readIdentity))) {
     refuse("superseded", readOwnerReceipt(path));
   }
   await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, readOwnerReceipt);
@@ -1445,7 +1494,7 @@ export class CmuxLayerDaemon {
         // its receipt, entirely alone.
         return;
       }
-      observed = { dev: stats.dev, ino: stats.ino };
+      observed = { dev: stats.dev, ino: stats.ino, kind: statsKind(stats) };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -488,7 +488,14 @@ async function unlinkOwnerReceiptIfUnchanged(
     return;
   }
   const current = readOwnerReceipt(path);
-  if (current === null || current.pid !== expected.pid) {
+  if (
+    current === null ||
+    current.pid !== expected.pid ||
+    current.startedAtMs !== expected.startedAtMs
+  ) {
+    // A successor that happens to REUSE the classified pid is still a
+    // different process, and its receipt is the only evidence later probes
+    // have that it owns the path (Macroscope, #530).
     return;
   }
   await unlinkIfPresent(daemonSocketOwnerPath(path));
@@ -621,10 +628,15 @@ export async function unlinkStaleSocket(
   if (liveOwner) {
     refuse(status, observedReceipt);
   }
-  if (status === "unknown" && observedReceipt === null) {
-    // Nothing answered and nothing claims it: fail closed rather than steal a
-    // socket an older build may still own.
-    refuse(status, null);
+  if (status === "unknown") {
+    // An inconclusive probe is NEVER sufficient evidence that the path is safe
+    // to reap, receipt or no receipt (Macroscope, #530). The receipt write is
+    // best-effort, and an fd-activated daemon never writes one at all, so a
+    // stale receipt naming a dead pid can coexist with a live owner — reaping
+    // on that combination orphans a running daemon and lets a second one bind.
+    // Failing closed costs a fallback to the in-process runtime, which is
+    // degraded but correct, and control_health now says why.
+    refuse(status, observedReceipt);
   }
   const reason =
     observedReceipt === null

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -375,6 +375,49 @@ async function unlinkIfPresent(path: string): Promise<void> {
   });
 }
 
+interface DaemonSocketIdentity {
+  dev: number;
+  ino: number;
+}
+
+/** dev/ino of the path right now, or null when it does not exist. */
+async function socketIdentity(
+  path: string,
+): Promise<DaemonSocketIdentity | null> {
+  try {
+    const stats = await lstat(path);
+    return { dev: stats.dev, ino: stats.ino };
+  } catch {
+    return null;
+  }
+}
+
+function sameIdentity(
+  a: DaemonSocketIdentity | null,
+  b: DaemonSocketIdentity | null,
+): boolean {
+  return a !== null && b !== null && a.dev === b.dev && a.ino === b.ino;
+}
+
+/**
+ * #530 review P2-2: only remove the owner receipt when it still names the pid
+ * we classified. The old unconditional unlink could delete a SUCCESSOR
+ * daemon's receipt written between classification and reap.
+ */
+async function unlinkOwnerReceiptIfUnchanged(
+  path: string,
+  expectedPid: number | null,
+  readOwnerPid: (path: string) => number | null,
+): Promise<void> {
+  if (expectedPid === null) {
+    return;
+  }
+  if (readOwnerPid(path) !== expectedPid) {
+    return;
+  }
+  await unlinkIfPresent(daemonSocketOwnerPath(path));
+}
+
 /**
  * Classify the daemon socket path WITHOUT ever collapsing "someone is
  * listening" into "something is in the way". A path that exists but is not a
@@ -460,6 +503,11 @@ export async function unlinkStaleSocket(
   const ownerAlive =
     opts.ownerAlive ?? ((pid: number) => processLiveness(pid) !== "gone");
 
+  // #530 review P2-2: capture the identity we are about to classify so the
+  // reap can prove it is still deleting THAT file and not a successor's.
+  const observedIdentity = await socketIdentity(path);
+  const observedOwnerPid = readOwnerPid(path);
+
   const status = await probe(path);
   if (status === "missing") {
     return "absent";
@@ -489,8 +537,27 @@ export async function unlinkStaleSocket(
     reason = "dead-owner-leftover";
   }
 
+  const current = await socketIdentity(path);
+  if (current === null) {
+    // It vanished on its own between classification and reap. Nothing left to
+    // delete, and the path is free for us to bind.
+    await unlinkOwnerReceiptIfUnchanged(path, observedOwnerPid, readOwnerPid);
+    recordDaemonSocketReap({ path, reason: `${reason}-vanished` });
+    return "reaped";
+  }
+  if (observedIdentity !== null && !sameIdentity(current, observedIdentity)) {
+    // Something replaced the leftover while we were classifying it. Unlinking
+    // now would steal a successor's socket, so refuse instead.
+    const ownerPid = readOwnerPid(path);
+    recordDaemonSocketInUse({ path, ownerPid });
+    throw new DaemonSocketInUseError({
+      socketPath: path,
+      ownerPid,
+      probe: "superseded",
+    });
+  }
   await unlinkIfPresent(path);
-  await unlinkIfPresent(daemonSocketOwnerPath(path));
+  await unlinkOwnerReceiptIfUnchanged(path, observedOwnerPid, readOwnerPid);
   recordDaemonSocketReap({ path, reason });
   return "reaped";
 }
@@ -1203,18 +1270,37 @@ export class CmuxLayerDaemon {
     if (this.listenFd !== undefined || !this.ownedSocketIdentity) {
       return;
     }
+    // #530 review P2-2: revalidate dev/ino immediately before the unlink, and
+    // never delete an owner receipt a successor may have just written.
+    let observed: DaemonSocketIdentity | null;
     try {
       const stats = await lstat(this.socketPath);
       if (stats.isSocket()) {
+        // A successor already bound a real socket here. Leave it, and leave
+        // its receipt, entirely alone.
         return;
       }
-      await unlink(this.socketPath);
+      observed = { dev: stats.dev, ino: stats.ino };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         return;
       }
+      observed = null;
     }
-    await unlink(daemonSocketOwnerPath(this.socketPath)).catch(() => {});
+
+    if (observed !== null) {
+      if (!sameIdentity(await socketIdentity(this.socketPath), observed)) {
+        // Replaced under us between the check and the unlink.
+        return;
+      }
+      await unlinkIfPresent(this.socketPath).catch(() => {});
+    }
+
+    if (readDaemonSocketOwnerPid(this.socketPath) === process.pid) {
+      await unlinkIfPresent(daemonSocketOwnerPath(this.socketPath)).catch(
+        () => {},
+      );
+    }
   }
 
   private async detachOwnedSocketPath(): Promise<{

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import net from "node:net";
+import { readFileSync } from "node:fs";
 import { lstat, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
@@ -25,10 +26,7 @@ import {
   httpNotifyMonitorDeadman,
   reconcileMonitorRegistry,
 } from "./monitor-registry.js";
-import {
-  defaultWatchRegistryPath,
-  httpNotifyWatch,
-} from "./watch-spec.js";
+import { defaultWatchRegistryPath, httpNotifyWatch } from "./watch-spec.js";
 import {
   ackedIds,
   dispatchOnce,
@@ -55,6 +53,13 @@ import {
   type StaleBuildResult,
 } from "./version.js";
 import { isMainModule } from "./is-main.js";
+import { processLiveness } from "./process-liveness.js";
+import {
+  DaemonSocketInUseError,
+  recordDaemonSocketInUse,
+  recordDaemonSocketReap,
+  type DaemonSocketProbe,
+} from "./daemon-lifecycle-state.js";
 import { loadCmuxlayerConfigFile } from "./config-file.js";
 import { FleetSidebarPublisher } from "./fleet-sidebar.js";
 
@@ -331,15 +336,38 @@ function isJsonRpcResponse(
   );
 }
 
-async function unlinkStaleSocket(path: string): Promise<void> {
-  const status = await probeSocket(path);
-  if (status === "live") {
-    throw new Error(`cmuxlayer daemon socket is already in use: ${path}`);
-  }
-  if (status === "missing") {
-    return;
-  }
+const DAEMON_SOCKET_PROBE_TIMEOUT_MS = 250;
 
+/**
+ * connect(2) failures that PROVE nothing is listening on the path any more.
+ * ENOTSOCK is the reboot shape: `detachOwnedSocketPath()` leaves an empty
+ * regular file at the socket path on every clean shutdown, so a SIGTERM at
+ * logout/reboot leaves a leftover that no daemon can ever own (#529).
+ */
+const DEAD_OWNER_CONNECT_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTSOCK",
+  "ENOTCONN",
+  "EPIPE",
+]);
+
+/** Sidecar receipt naming the pid that currently owns the daemon socket. */
+export function daemonSocketOwnerPath(socketPath: string): string {
+  return `${socketPath}.owner`;
+}
+
+export function readDaemonSocketOwnerPid(socketPath: string): number | null {
+  try {
+    const raw = readFileSync(daemonSocketOwnerPath(socketPath), "utf8").trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
   await unlink(path).catch((error: NodeJS.ErrnoException) => {
     if (error.code !== "ENOENT") {
       throw error;
@@ -347,12 +375,34 @@ async function unlinkStaleSocket(path: string): Promise<void> {
   });
 }
 
-function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
-  return new Promise((resolve, reject) => {
+/**
+ * Classify the daemon socket path WITHOUT ever collapsing "someone is
+ * listening" into "something is in the way". A path that exists but is not a
+ * socket can never have a live owner, so it is stale by construction; an
+ * inconclusive probe stays `unknown` and is resolved against the owner receipt
+ * rather than being guessed either way.
+ */
+export async function probeDaemonSocketPath(
+  path: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<DaemonSocketProbe> {
+  try {
+    const stats = await lstat(path);
+    if (!stats.isSocket()) {
+      return "stale";
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "missing";
+    }
+    // Anything else (EACCES on a parent dir, races) falls through to connect.
+  }
+
+  return new Promise<DaemonSocketProbe>((resolve) => {
     const socket = net.createConnection(path);
     let settled = false;
     const ignoreLateError = () => {};
-    const settle = (value: "live" | "missing" | "stale") => {
+    const settle = (value: DaemonSocketProbe) => {
       if (settled) {
         return;
       }
@@ -363,20 +413,86 @@ function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
       resolve(value);
     };
 
-    socket.setTimeout(250, () => settle("live"));
+    socket.setTimeout(opts.timeoutMs ?? DAEMON_SOCKET_PROBE_TIMEOUT_MS, () =>
+      settle("unknown"),
+    );
     socket.once("connect", () => settle("live"));
     socket.once("error", (error: NodeJS.ErrnoException) => {
       if (error.code === "ENOENT") {
         settle("missing");
         return;
       }
-      if (error.code === "ECONNREFUSED") {
+      if (error.code && DEAD_OWNER_CONNECT_CODES.has(error.code)) {
         settle("stale");
         return;
       }
-      reject(error);
+      // Never re-throw out of the probe: an unexpected errno used to reject and
+      // fatal the daemon, which is exactly the silent deadlock this fixes.
+      settle("unknown");
     });
   });
+}
+
+export type UnlinkStaleSocketOutcome = "absent" | "reaped";
+
+export interface UnlinkStaleSocketOptions {
+  probe?: (path: string) => Promise<DaemonSocketProbe>;
+  readOwnerPid?: (path: string) => number | null;
+  ownerAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Reap a genuinely dead-owner leftover; refuse a socket a live daemon owns.
+ *
+ * - `missing`  -> nothing to do.
+ * - `stale`    -> no listener can exist behind it; reap it and its receipt.
+ * - `live`     -> a daemon is accepting connections. Throw
+ *                 `DaemonSocketInUseError` so the caller CONNECTS to it.
+ * - `unknown`  -> inconclusive. The owner receipt decides: a receipt naming a
+ *                 dead pid proves a leftover, anything else fails closed.
+ */
+export async function unlinkStaleSocket(
+  path: string,
+  opts: UnlinkStaleSocketOptions = {},
+): Promise<UnlinkStaleSocketOutcome> {
+  const probe = opts.probe ?? probeDaemonSocketPath;
+  const readOwnerPid = opts.readOwnerPid ?? readDaemonSocketOwnerPid;
+  const ownerAlive =
+    opts.ownerAlive ?? ((pid: number) => processLiveness(pid) !== "gone");
+
+  const status = await probe(path);
+  if (status === "missing") {
+    return "absent";
+  }
+
+  let reason: string;
+  if (status === "live") {
+    const ownerPid = readOwnerPid(path);
+    recordDaemonSocketInUse({ path, ownerPid });
+    throw new DaemonSocketInUseError({
+      socketPath: path,
+      ownerPid,
+      probe: status,
+    });
+  } else if (status === "unknown") {
+    const ownerPid = readOwnerPid(path);
+    if (ownerPid === null || ownerAlive(ownerPid)) {
+      recordDaemonSocketInUse({ path, ownerPid });
+      throw new DaemonSocketInUseError({
+        socketPath: path,
+        ownerPid,
+        probe: status,
+      });
+    }
+    reason = `owner-receipt-pid-${ownerPid}-gone`;
+  } else {
+    reason = "dead-owner-leftover";
+  }
+
+  await unlinkIfPresent(path);
+  await unlinkIfPresent(daemonSocketOwnerPath(path));
+  recordDaemonSocketReap({ path, reason });
+  return "reaped";
 }
 
 function positiveEnvMs(value: string | undefined): number | null {
@@ -471,6 +587,14 @@ export class CmuxLayerDaemon {
       await this.listen(this.socketPath);
       const stats = await lstat(this.socketPath);
       this.ownedSocketIdentity = { dev: stats.dev, ino: stats.ino };
+      // #529: publish the owner pid next to the socket so a successor can tell
+      // "a live daemon owns this" from "a dead process left this behind" even
+      // when the connect probe is inconclusive.
+      await writeFile(
+        daemonSocketOwnerPath(this.socketPath),
+        `${process.pid}\n`,
+        "utf8",
+      ).catch(() => {});
     }
     void this.runMonitorReconcile();
     this.startMonitorReconcileWatcher();
@@ -1054,7 +1178,9 @@ export class CmuxLayerDaemon {
     });
     if (detachedSocket?.restore) {
       await rename(detachedSocket.path, this.socketPath);
-    } else if (detachedSocket) {
+      return;
+    }
+    if (detachedSocket) {
       await unlink(detachedSocket.path).catch(
         (error: NodeJS.ErrnoException) => {
           if (error.code !== "ENOENT") {
@@ -1063,6 +1189,32 @@ export class CmuxLayerDaemon {
         },
       );
     }
+    await this.removeOwnedSocketPlaceholder();
+  }
+
+  /**
+   * #529: `detachOwnedSocketPath()` parks an empty REGULAR FILE at the socket
+   * path so a racing daemon cannot bind mid-shutdown. Nothing ever removed it,
+   * so every clean shutdown (a reboot's SIGTERM included) left a leftover that
+   * connect(2) answers with ENOTSOCK. Remove the placeholder once the listener
+   * is closed, and never touch a real socket some successor already bound.
+   */
+  private async removeOwnedSocketPlaceholder(): Promise<void> {
+    if (this.listenFd !== undefined || !this.ownedSocketIdentity) {
+      return;
+    }
+    try {
+      const stats = await lstat(this.socketPath);
+      if (stats.isSocket()) {
+        return;
+      }
+      await unlink(this.socketPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return;
+      }
+    }
+    await unlink(daemonSocketOwnerPath(this.socketPath)).catch(() => {});
   }
 
   private async detachOwnedSocketPath(): Promise<{
@@ -1200,6 +1352,10 @@ if (isMainModule(import.meta.url, process.argv[1])) {
   // A GUI-launched client starts the daemon without a login shell, so the
   // config file is read here too rather than only in the CLI entrypoint.
   loadCmuxlayerConfigFile();
+  // #529: the spawning proxy now PIPES daemon stderr so a startup failure can
+  // be reported to its waiters. A piped stderr breaks when that parent exits;
+  // an unhandled EPIPE there would kill an otherwise healthy shared daemon.
+  process.stderr.on("error", () => {});
   runDaemon().catch((error) => {
     console.error("[cmuxlayer-daemon] fatal", error);
     process.exit(1);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,7 +2,14 @@
 
 import net from "node:net";
 import { readFileSync } from "node:fs";
-import { lstat, mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import {
+  link,
+  lstat,
+  mkdir,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname } from "node:path";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
@@ -53,7 +60,14 @@ import {
   type StaleBuildResult,
 } from "./version.js";
 import { isMainModule } from "./is-main.js";
-import { processLiveness, processStartedAtMs } from "./process-liveness.js";
+import {
+  daemonSocketOwnerAlive,
+  daemonSocketOwnerPath,
+  daemonSocketOwnerReceiptText,
+  readDaemonSocketOwnerReceipt,
+  readDaemonSocketOwnerReceiptAt,
+  type DaemonSocketOwnerReceipt,
+} from "./daemon-socket-owner.js";
 import {
   DaemonSocketInUseError,
   DaemonSocketPathOccupiedError,
@@ -358,77 +372,51 @@ const DEAD_OWNER_CONNECT_CODES = new Set([
   "EPIPE",
 ]);
 
-/** Sidecar receipt naming the process that currently owns the daemon socket. */
-export function daemonSocketOwnerPath(socketPath: string): string {
-  return `${socketPath}.owner`;
-}
-
-export interface DaemonSocketOwnerReceipt {
-  pid: number;
-  /**
-   * Process start time, so a pid recycled across a reboot cannot masquerade as
-   * the original owner. Null for receipts written by an older build.
-   */
-  startedAtMs: number | null;
-}
-
-/** `<pid> <startedAtMs>` — the second field is omitted when unavailable. */
-export function daemonSocketOwnerReceiptText(
-  pid: number = process.pid,
-): string {
-  const startedAtMs = processStartedAtMs(pid);
-  return startedAtMs === null ? `${pid}\n` : `${pid} ${startedAtMs}\n`;
-}
-
-export function readDaemonSocketOwnerReceipt(
-  socketPath: string,
-): DaemonSocketOwnerReceipt | null {
-  try {
-    const raw = readFileSync(daemonSocketOwnerPath(socketPath), "utf8").trim();
-    if (!raw) return null;
-    const [pidText, startedText] = raw.split(/\s+/);
-    const pid = Number.parseInt(pidText ?? "", 10);
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    const startedAtMs = Number.parseInt(startedText ?? "", 10);
-    return {
-      pid,
-      startedAtMs: Number.isInteger(startedAtMs) ? startedAtMs : null,
-    };
-  } catch {
-    return null;
-  }
-}
-
-export function readDaemonSocketOwnerPid(socketPath: string): number | null {
-  return readDaemonSocketOwnerReceipt(socketPath)?.pid ?? null;
-}
-
-/** `ps lstart` has whole-second precision, so allow a one-second skew. */
-const OWNER_START_SKEW_MS = 1_000;
+export {
+  daemonSocketOwnerPath,
+  daemonSocketOwnerReceiptText,
+  readDaemonSocketOwnerReceipt,
+  readDaemonSocketOwnerPid,
+  daemonSocketOwnerAlive,
+  type DaemonSocketOwnerReceipt,
+} from "./daemon-socket-owner.js";
 
 /**
- * Is the recorded owner still the SAME live process? A bare-pid receipt (older
- * build) cannot rule out pid reuse, so it is trusted only while the pid is
- * live — which keeps #529's reboot fix working: a rebooted machine's leftover
- * receipt names a pid that is either gone or demonstrably a different process.
+ * Put a sheltered object back at its well-known path WITHOUT clobbering
+ * whatever may have taken that path meanwhile (#530, Codex P1).
+ *
+ * POSIX `rename` always replaces, so restoring with it can overwrite a
+ * successor that bound the briefly-vacant path — leaving a live daemon
+ * unreachable. `link(2)` refuses with EEXIST instead, which is exactly the
+ * no-replace semantic needed here (verified on macOS and Linux: link works on
+ * socket files and returns EEXIST on an occupied name).
+ *
+ * When the path is taken, the sheltered object is deliberately LEFT in place
+ * rather than deleted: an orphaned socket is recoverable, a deleted live one is
+ * not.
  */
-export function daemonSocketOwnerAlive(
-  receipt: DaemonSocketOwnerReceipt,
-): boolean {
-  if (processLiveness(receipt.pid) === "gone") {
-    return false;
-  }
-  if (receipt.startedAtMs !== null) {
-    const current = processStartedAtMs(receipt.pid);
-    if (
-      current !== null &&
-      Math.abs(current - receipt.startedAtMs) > OWNER_START_SKEW_MS
-    ) {
-      // The pid is live, but it is a DIFFERENT process wearing a recycled pid.
-      return false;
+async function restoreSheltered(
+  shelterPath: string,
+  path: string,
+  logger: Pick<Console, "error">,
+): Promise<void> {
+  try {
+    await link(shelterPath, path);
+    await unlinkIfPresent(shelterPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      logger.error(
+        `[cmuxlayer-daemon] not restoring ${shelterPath}: ${path} is owned by someone else now; leaving the sheltered copy in place`,
+      );
+      return;
     }
+    logger.error(
+      `[cmuxlayer-daemon] failed to restore ${shelterPath} to ${path}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
-  return true;
 }
 
 /**
@@ -442,8 +430,6 @@ export function daemonSocketOwnerAlive(
  * the path free. Identity is then verified on a name no other process knows,
  * and anything we did not mean to move is put back rather than destroyed.
  *
- * `detachOwnedSocketPath()` already uses this shelter-and-restore idiom.
- *
  * Returns true when the path is ours to bind, false when we moved something
  * that turned out to belong to a successor (restored, and the caller refuses).
  */
@@ -451,6 +437,7 @@ async function reapClassifiedSocket(
   path: string,
   observedIdentity: DaemonSocketIdentity | null,
   readIdentity: (path: string) => Promise<DaemonSocketIdentity | null>,
+  logger: Pick<Console, "error">,
 ): Promise<boolean> {
   const reapingPath = `${path}.reaping-${process.pid}-${Date.now()}`;
   try {
@@ -477,14 +464,54 @@ async function reapClassifiedSocket(
     (await probeDaemonSocketPath(reapingPath)) === "live";
 
   if (!stillOurs || answersNow) {
-    // We grabbed something that is NOT what we classified — a successor bound
-    // here after our check. Put it back; never delete it.
-    await rename(reapingPath, path).catch(() => {});
+    await restoreSheltered(reapingPath, path, logger);
     return false;
   }
 
   await unlinkIfPresent(reapingPath);
   return true;
+}
+
+/**
+ * Remove the owner receipt only when it is still the one we classified, with
+ * validation and deletion made ATOMIC by the same shelter trick (#530, Codex).
+ *
+ * Comparing then unlinking left a window in which a successor could rewrite the
+ * receipt and have its brand-new one deleted — which later removes the
+ * live-owner evidence that protects that successor's own shutdown placeholder.
+ */
+async function unlinkOwnerReceiptIfUnchanged(
+  path: string,
+  expected: DaemonSocketOwnerReceipt | null,
+  logger: Pick<Console, "error">,
+): Promise<void> {
+  // No receipt at classification time also covers the absent-then-present case:
+  // a successor's brand-new receipt is never ours to delete.
+  if (expected === null) {
+    return;
+  }
+  const receiptPath = daemonSocketOwnerPath(path);
+  const shelterPath = `${receiptPath}.reaping-${process.pid}-${Date.now()}`;
+  try {
+    await rename(receiptPath, shelterPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  const moved = readDaemonSocketOwnerReceiptAt(shelterPath);
+  if (
+    moved !== null &&
+    moved.pid === expected.pid &&
+    moved.startedAtMs === expected.startedAtMs
+  ) {
+    await unlinkIfPresent(shelterPath);
+    return;
+  }
+  // A successor rewrote it between classification and now. Put it back.
+  await restoreSheltered(shelterPath, receiptPath, logger);
 }
 
 async function unlinkIfPresent(path: string): Promise<void> {
@@ -556,35 +583,6 @@ function sameIdentity(
     a.ino === b.ino &&
     a.kind === b.kind
   );
-}
-
-/**
- * #530 review P2-2: only remove the owner receipt when it still names the pid
- * we classified. The old unconditional unlink could delete a SUCCESSOR
- * daemon's receipt written between classification and reap.
- */
-async function unlinkOwnerReceiptIfUnchanged(
-  path: string,
-  expected: DaemonSocketOwnerReceipt | null,
-  readOwnerReceipt: (path: string) => DaemonSocketOwnerReceipt | null,
-): Promise<void> {
-  // No receipt at classification time also covers F8's absent-then-present
-  // case for the receipt: a successor's brand-new receipt is never ours to delete.
-  if (expected === null) {
-    return;
-  }
-  const current = readOwnerReceipt(path);
-  if (
-    current === null ||
-    current.pid !== expected.pid ||
-    current.startedAtMs !== expected.startedAtMs
-  ) {
-    // A successor that happens to REUSE the classified pid is still a
-    // different process, and its receipt is the only evidence later probes
-    // have that it owns the path (Macroscope, #530).
-    return;
-  }
-  await unlinkIfPresent(daemonSocketOwnerPath(path));
 }
 
 /**
@@ -662,6 +660,7 @@ export interface UnlinkStaleSocketOptions {
    * (#530 CI).
    */
   readIdentity?: (path: string) => Promise<DaemonSocketIdentity | null>;
+  logger?: Pick<Console, "error">;
 }
 
 /**
@@ -695,6 +694,7 @@ export async function unlinkStaleSocket(
     opts.readOwnerReceipt ?? readDaemonSocketOwnerReceipt;
   const ownerAlive = opts.ownerAlive ?? daemonSocketOwnerAlive;
   const readIdentity = opts.readIdentity ?? socketIdentity;
+  const logger = opts.logger ?? console;
 
   const refuse = (
     observedProbe: DaemonSocketProbe,
@@ -752,11 +752,7 @@ export async function unlinkStaleSocket(
   if (current === null) {
     // It vanished on its own between classification and reap. Nothing left to
     // delete, and the path is free for us to bind.
-    await unlinkOwnerReceiptIfUnchanged(
-      path,
-      observedReceipt,
-      readOwnerReceipt,
-    );
+    await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, logger);
     recordDaemonSocketReap({ path, reason: `${reason}-vanished` });
     return "reaped";
   }
@@ -768,10 +764,12 @@ export async function unlinkStaleSocket(
     refuse("superseded", readOwnerReceipt(path));
   }
 
-  if (!(await reapClassifiedSocket(path, observedIdentity, readIdentity))) {
+  if (
+    !(await reapClassifiedSocket(path, observedIdentity, readIdentity, logger))
+  ) {
     refuse("superseded", readOwnerReceipt(path));
   }
-  await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, readOwnerReceipt);
+  await unlinkOwnerReceiptIfUnchanged(path, observedReceipt, logger);
   recordDaemonSocketReap({ path, reason });
   return "reaped";
 }
@@ -1510,7 +1508,7 @@ export class CmuxLayerDaemon {
       await unlinkIfPresent(this.socketPath).catch(() => {});
     }
 
-    if (readDaemonSocketOwnerPid(this.socketPath) === process.pid) {
+    if (readDaemonSocketOwnerReceipt(this.socketPath)?.pid === process.pid) {
       await unlinkIfPresent(daemonSocketOwnerPath(this.socketPath)).catch(
         () => {},
       );

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -116,6 +116,13 @@ export interface DaemonChildLike {
   once?(event: string, listener: (...args: any[]) => void): unknown;
   off?(event: string, listener: (...args: any[]) => void): unknown;
   removeListener?(event: string, listener: (...args: any[]) => void): unknown;
+  /**
+   * Settled exit state. A child that died before readiness attached its
+   * listeners will never emit `exit` again, so these fields are the only
+   * evidence of why it is gone (#530 review).
+   */
+  exitCode?: number | null;
+  signalCode?: string | null;
 }
 
 export interface DaemonReadinessOptions {
@@ -163,7 +170,47 @@ export async function awaitDaemonReadiness(
   let aborted = false;
 
   const childFailure = new Promise<never>((_, reject) => {
-    if (!child || typeof child.once !== "function") {
+    if (!child) {
+      return;
+    }
+    // #530 review (Macroscope, src/entry.ts:189): a daemon that dies BEFORE we
+    // attach listeners is already gone — node never replays the missed `exit`,
+    // so the old wiring reported a readiness TIMEOUT after the full deadline
+    // instead of the exit code that actually explains it. Read the settled
+    // fields first.
+    if (child.exitCode !== null && child.exitCode !== undefined) {
+      recordDaemonExit({
+        code: child.exitCode,
+        signal: child.signalCode ?? null,
+        stderrExcerpt: readStderr(),
+      });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: child.exitCode,
+          signal: child.signalCode ?? null,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+      return;
+    }
+    if (child.signalCode !== null && child.signalCode !== undefined) {
+      recordDaemonExit({
+        code: null,
+        signal: child.signalCode,
+        stderrExcerpt: readStderr(),
+      });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: null,
+          signal: child.signalCode,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+      return;
+    }
+    if (typeof child.once !== "function") {
       return;
     }
     onExit = (code, signal) => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -23,6 +23,7 @@ import { callerContextFromEnv } from "./caller-context.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
+const DEFAULT_DAEMON_HANDOFF_TIMEOUT_MS = 8_000;
 
 export { resolveDefaultDaemonSocketPath as defaultDaemonSocketPath };
 
@@ -52,6 +53,8 @@ export interface DaemonFirstEntryOptions {
   daemonScriptPath?: string;
   autostartTimeoutMs?: number;
   autostartPollMs?: number;
+  /** Bound the wait for a draining daemon owner to hand off (#530). */
+  daemonHandoffTimeoutMs?: number;
   exit?: ExitFn;
 }
 
@@ -404,6 +407,72 @@ export function bindProxyStdioLifecycle(opts: {
   opts.input.once("close", () => shutdown("stdin close"));
 }
 
+/**
+ * Did the daemon refuse because ANOTHER owner holds the socket? The daemon
+ * prints `fatal code=EDAEMONSOCKETINUSE` before exiting, so this is a
+ * structured check rather than prose matching (#530).
+ */
+export function isOwnerBusyFailure(error: unknown): boolean {
+  return (
+    error instanceof DaemonStartupFailedError &&
+    /EDAEMONSOCKETINUSE|DaemonSocketInUseError|socket is already in use/.test(
+      error.stderrExcerpt,
+    )
+  );
+}
+
+export interface DaemonHandoffOptions {
+  socketPath: string;
+  probeDaemon: (socketPath: string) => Promise<boolean>;
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  pollMs: number;
+  spawnDaemon: () => Promise<unknown>;
+  awaitReady: (child: unknown) => Promise<void>;
+  logger: Pick<Console, "error">;
+  now?: () => number;
+}
+
+/**
+ * Wait out a draining owner rather than starting a competing backend.
+ *
+ * Poll for a daemon answering on the socket. Once the drainer clears its
+ * placeholder, retry the spawn ONCE so the control plane comes back on the
+ * daemon path instead of degrading to an in-process runtime that would outlive
+ * the successor. Returns true when a daemon is answering.
+ */
+export async function awaitDaemonHandoff(
+  opts: DaemonHandoffOptions,
+): Promise<boolean> {
+  const now = opts.now ?? Date.now;
+  const deadline = now() + opts.timeoutMs;
+  let respawned = false;
+
+  for (;;) {
+    if (await opts.probeDaemon(opts.socketPath)) {
+      return true;
+    }
+    if (now() >= deadline) {
+      return opts.probeDaemon(opts.socketPath);
+    }
+    await opts.sleep(opts.pollMs);
+
+    if (!respawned && !(await opts.probeDaemon(opts.socketPath))) {
+      // The drainer may have finished and left the path free for us.
+      respawned = true;
+      try {
+        const child = await opts.spawnDaemon();
+        await opts.awaitReady(child);
+        return true;
+      } catch (error) {
+        opts.logger.error(
+          `[cmuxlayer] daemon handoff respawn failed: ${errorText(error)}`,
+        );
+      }
+    }
+  }
+}
+
 export async function runDaemonFirstEntry(
   opts: DaemonFirstEntryOptions = {},
 ): Promise<EntryRuntime> {
@@ -419,6 +488,9 @@ export async function runDaemonFirstEntry(
   const autostartTimeoutMs =
     opts.autostartTimeoutMs ?? DEFAULT_AUTOSTART_TIMEOUT_MS;
   const autostartPollMs = opts.autostartPollMs ?? DEFAULT_AUTOSTART_POLL_MS;
+  // Long enough to outlast the daemon's own drain bound (5s) plus its handoff.
+  const handoffTimeoutMs =
+    opts.daemonHandoffTimeoutMs ?? DEFAULT_DAEMON_HANDOFF_TIMEOUT_MS;
 
   const startProxy = async (): Promise<EntryRuntime> => {
     const input = opts.input ?? process.stdin;
@@ -501,6 +573,48 @@ export async function runDaemonFirstEntry(
   // A daemon that came up on the very last tick still wins the race.
   if (await probeDaemon(socketPath)) {
     return startProxy();
+  }
+
+  // #530 (Codex P1): when autostart overlaps a CLEAN SHUTDOWN, the socket path
+  // is deliberately a regular-file placeholder whose receipt names the still
+  // draining owner, so our spawned daemon refuses and exits at once. Falling
+  // back in-process here would start a SECOND backend against the same registry
+  // while the old daemon is still handling in-flight mutations — the exact
+  // two-sources-of-truth harm the refusal exists to prevent. Wait for the
+  // handoff instead: the drainer removes its placeholder when it finishes, and
+  // either it or a successor answers on the socket.
+  if (isOwnerBusyFailure(readinessError)) {
+    terminateSpawnedDaemon(spawnedDaemon, logger);
+    const handoff = await awaitDaemonHandoff({
+      socketPath,
+      probeDaemon,
+      sleep,
+      timeoutMs: handoffTimeoutMs,
+      pollMs: autostartPollMs,
+      spawnDaemon: async () => {
+        spawnedDaemon = await spawnDaemon({
+          socketPath,
+          env,
+          daemonScriptPath: opts.daemonScriptPath,
+          logger,
+        });
+        return spawnedDaemon;
+      },
+      awaitReady: (child) =>
+        awaitDaemonReadiness({
+          socketPath,
+          probeDaemon,
+          sleep,
+          timeoutMs: autostartTimeoutMs,
+          pollMs: autostartPollMs,
+          child: child as DaemonChildLike | null,
+          readStderr: () => capturedDaemonStderr(child),
+        }),
+      logger,
+    });
+    if (handoff) {
+      return startProxy();
+    }
   }
 
   terminateSpawnedDaemon(spawnedDaemon, logger);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -69,6 +69,51 @@ function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * SIGTERM the child AND wait for it to be gone (#530, Codex P1).
+ *
+ * Terminating without awaiting let the daemon's graceful shutdown — and its
+ * startup lifecycle sweep — overlap the in-process fallback's registry
+ * mutations: two sources of truth despite the attempted termination. Bounded,
+ * because a child that refuses to die must not hang startup.
+ */
+export async function terminateSpawnedDaemonAndWait(
+  spawnedDaemon: unknown,
+  logger: Pick<Console, "error">,
+  opts: { timeoutMs?: number } = {},
+): Promise<void> {
+  terminateSpawnedDaemon(spawnedDaemon, logger);
+  const child = spawnedDaemon as DaemonChildLike | null;
+  if (!child) return;
+  if (child.exitCode !== null && child.exitCode !== undefined) return;
+  if (child.signalCode !== null && child.signalCode !== undefined) return;
+  if (typeof child.once !== "function") return;
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      logger.error(
+        "[cmuxlayer] timed-out daemon did not exit before the in-process fallback started",
+      );
+      finish();
+    }, opts.timeoutMs ?? 2_000);
+    timer.unref?.();
+    child.once!("exit", () => {
+      clearTimeout(timer);
+      finish();
+    });
+    child.once!("close", () => {
+      clearTimeout(timer);
+      finish();
+    });
+  });
+}
+
 function terminateSpawnedDaemon(
   spawnedDaemon: unknown,
   logger: Pick<Console, "error">,
@@ -662,7 +707,7 @@ export async function runDaemonFirstEntry(
     }
   }
 
-  terminateSpawnedDaemon(spawnedDaemon, logger);
+  await terminateSpawnedDaemonAndWait(spawnedDaemon, logger);
   const detail =
     readinessError instanceof DaemonStartupFailedError
       ? `daemon exited before ready (code=${readinessError.exitCode ?? "none"}, signal=${

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -123,6 +123,8 @@ export interface DaemonChildLike {
    */
   exitCode?: number | null;
   signalCode?: string | null;
+  /** Generation marker for lifecycle exit recording (#530 F9). */
+  pid?: number | null;
 }
 
 export interface DaemonReadinessOptions {
@@ -182,6 +184,7 @@ export async function awaitDaemonReadiness(
       recordDaemonExit({
         code: child.exitCode,
         signal: child.signalCode ?? null,
+        pid: child.pid ?? null,
         stderrExcerpt: readStderr(),
       });
       reject(
@@ -198,6 +201,7 @@ export async function awaitDaemonReadiness(
       recordDaemonExit({
         code: null,
         signal: child.signalCode,
+        pid: child.pid ?? null,
         stderrExcerpt: readStderr(),
       });
       reject(
@@ -216,7 +220,12 @@ export async function awaitDaemonReadiness(
     onExit = (code, signal) => {
       // Record here as well as in the spawner: readiness is the authority on
       // "the daemon died before it could serve", whoever spawned it.
-      recordDaemonExit({ code, signal, stderrExcerpt: readStderr() });
+      recordDaemonExit({
+        code,
+        signal,
+        pid: child.pid ?? null,
+        stderrExcerpt: readStderr(),
+      });
       reject(
         new DaemonStartupFailedError({
           socketPath: opts.socketPath,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,5 @@
 import net from "node:net";
+import { stat } from "node:fs/promises";
 import type { Readable, Writable } from "node:stream";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CreateServerOptions } from "./server.js";
@@ -431,6 +432,12 @@ export interface DaemonHandoffOptions {
   awaitReady: (child: unknown) => Promise<void>;
   logger: Pick<Console, "error">;
   now?: () => number;
+  /**
+   * Has the draining owner actually removed its placeholder? Defaults to "the
+   * socket path no longer exists". Respawning before this is true wastes the
+   * attempt on a daemon that will refuse for the same reason (#530).
+   */
+  isPathClear?: () => Promise<boolean>;
 }
 
 /**
@@ -446,6 +453,13 @@ export async function awaitDaemonHandoff(
 ): Promise<boolean> {
   const now = opts.now ?? Date.now;
   const deadline = now() + opts.timeoutMs;
+  const isPathClear =
+    opts.isPathClear ??
+    (() =>
+      stat(opts.socketPath).then(
+        () => false,
+        () => true,
+      ));
   let respawned = false;
 
   for (;;) {
@@ -457,8 +471,11 @@ export async function awaitDaemonHandoff(
     }
     await opts.sleep(opts.pollMs);
 
-    if (!respawned && !(await opts.probeDaemon(opts.socketPath))) {
-      // The drainer may have finished and left the path free for us.
+    // #530 (Macroscope): the respawn must WAIT for the placeholder to go. Firing
+    // it on the first probe failure spent the only attempt on a daemon that
+    // refused for the very reason we are waiting out, so nothing ever started
+    // once the path did clear.
+    if (!respawned && (await isPathClear())) {
       respawned = true;
       try {
         const child = await opts.spawnDaemon();

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -10,6 +10,7 @@ import {
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
 import {
+  awaitDaemonStderrDrained,
   capturedDaemonStderr,
   spawnDaemonProcess,
   type SpawnDaemonOptions,
@@ -20,6 +21,7 @@ import {
   recordDaemonExit,
   recordDaemonLifecycleError,
 } from "./daemon-lifecycle-state.js";
+import { daemonSocketHasLiveOwner } from "./daemon-socket-owner.js";
 import { callerContextFromEnv } from "./caller-context.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
@@ -222,6 +224,14 @@ export async function awaitDaemonReadiness(
       return;
     }
     onExit = (code, signal) => {
+      // #530 (Codex P1): give the piped stderr a bounded moment to finish
+      // arriving before we classify the failure — the daemon prints its refusal
+      // marker and exits immediately, so `exit` can beat the pipe.
+      void awaitDaemonStderrDrained(child).then(() => {
+        rejectWithExit(code, signal);
+      });
+    };
+    const rejectWithExit = (code: number | null, signal: string | null) => {
       // Record here as well as in the spawner: readiness is the authority on
       // "the daemon died before it could serve", whoever spawned it.
       recordDaemonExit({
@@ -413,13 +423,27 @@ export function bindProxyStdioLifecycle(opts: {
  * prints `fatal code=EDAEMONSOCKETINUSE` before exiting, so this is a
  * structured check rather than prose matching (#530).
  */
-export function isOwnerBusyFailure(error: unknown): boolean {
-  return (
-    error instanceof DaemonStartupFailedError &&
+export function isOwnerBusyFailure(
+  error: unknown,
+  socketPath?: string,
+): boolean {
+  if (!(error instanceof DaemonStartupFailedError)) {
+    return false;
+  }
+  if (
     /EDAEMONSOCKETINUSE|DaemonSocketInUseError|socket is already in use/.test(
       error.stderrExcerpt,
     )
-  );
+  ) {
+    return true;
+  }
+  // #530 (Codex P1): stderr is NOT guaranteed to be drained when `exit` fires —
+  // the daemon calls process.exit(1) immediately after printing the marker, so
+  // the excerpt can be empty. Fall back to OUT-OF-BAND evidence: if a live
+  // owner still claims the socket path, the refusal was an owner-busy refusal
+  // whatever we did or did not manage to read.
+  const path = socketPath ?? error.socketPath;
+  return path ? daemonSocketHasLiveOwner(path) : false;
 }
 
 export interface DaemonHandoffOptions {
@@ -604,7 +628,7 @@ export async function runDaemonFirstEntry(
   // two-sources-of-truth harm the refusal exists to prevent. Wait for the
   // handoff instead: the drainer removes its placeholder when it finishes, and
   // either it or a successor answers on the socket.
-  if (isOwnerBusyFailure(readinessError)) {
+  if (isOwnerBusyFailure(readinessError, socketPath)) {
     terminateSpawnedDaemon(spawnedDaemon, logger);
     const handoff = await awaitDaemonHandoff({
       socketPath,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -453,12 +453,16 @@ export async function awaitDaemonHandoff(
 ): Promise<boolean> {
   const now = opts.now ?? Date.now;
   const deadline = now() + opts.timeoutMs;
+  // #530 (Macroscope): only ENOENT means "the placeholder is gone" — the same
+  // rule as F2. Treating EACCES/EIO as cleared would respawn into a path we
+  // cannot even inspect, spending the single attempt on a daemon that will
+  // refuse, and leaving nothing to start once the path really does clear.
   const isPathClear =
     opts.isPathClear ??
     (() =>
       stat(opts.socketPath).then(
         () => false,
-        () => true,
+        (error: NodeJS.ErrnoException) => error?.code === "ENOENT",
       ));
   let respawned = false;
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -8,7 +8,17 @@ import {
   type CmuxLayerProxyOptions,
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
-import { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
+import {
+  capturedDaemonStderr,
+  spawnDaemonProcess,
+  type SpawnDaemonOptions,
+} from "./daemon-spawn.js";
+import {
+  DaemonReadinessTimeoutError,
+  DaemonStartupFailedError,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+} from "./daemon-lifecycle-state.js";
 import { callerContextFromEnv } from "./caller-context.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
@@ -101,27 +111,120 @@ export async function probeDaemonSocket(socketPath: string): Promise<boolean> {
   });
 }
 
-async function waitForDaemon(
-  socketPath: string,
-  opts: Required<
-    Pick<
-      DaemonFirstEntryOptions,
-      "probeDaemon" | "sleep" | "autostartTimeoutMs" | "autostartPollMs"
-    >
-  >,
-): Promise<boolean> {
-  const deadline = Date.now() + opts.autostartTimeoutMs;
-  do {
-    if (await opts.probeDaemon(socketPath)) {
-      return true;
-    }
-    if (opts.autostartTimeoutMs === 0) {
-      return false;
-    }
-    await opts.sleep(opts.autostartPollMs);
-  } while (Date.now() < deadline);
+/** The subset of a spawned daemon child that readiness needs to observe. */
+export interface DaemonChildLike {
+  once?(event: string, listener: (...args: any[]) => void): unknown;
+  off?(event: string, listener: (...args: any[]) => void): unknown;
+  removeListener?(event: string, listener: (...args: any[]) => void): unknown;
+}
 
-  return opts.probeDaemon(socketPath);
+export interface DaemonReadinessOptions {
+  socketPath: string;
+  probeDaemon: (socketPath: string) => Promise<boolean>;
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  pollMs: number;
+  /** The spawned daemon, when this process is the one that spawned it. */
+  child?: DaemonChildLike | null;
+  /** Bounded excerpt of what the child printed on stderr. */
+  readStderr?: () => string;
+  now?: () => number;
+}
+
+/**
+ * Wait for the daemon to answer on its socket, ALWAYS settling.
+ *
+ * #529: the old poll loop watched only the socket. When the spawned daemon
+ * fataled on a leftover socket file and exited code 1, nothing rejected — the
+ * readiness promise simply never settled and every daemon-dependent tool
+ * deadlocked. The child's `exit`/`error` events are now wired straight into
+ * the rejection path, and the deadline is a hard bound.
+ */
+export async function awaitDaemonReadiness(
+  opts: DaemonReadinessOptions,
+): Promise<void> {
+  const now = opts.now ?? Date.now;
+  const startedAt = now();
+  const readStderr = () => {
+    try {
+      return opts.readStderr?.() ?? "";
+    } catch {
+      return "";
+    }
+  };
+
+  let onExit: ((code: number | null, signal: string | null) => void) | null =
+    null;
+  let onError: ((error: Error) => void) | null = null;
+  const child = opts.child;
+
+  const childFailure = new Promise<never>((_, reject) => {
+    if (!child || typeof child.once !== "function") {
+      return;
+    }
+    onExit = (code, signal) => {
+      // Record here as well as in the spawner: readiness is the authority on
+      // "the daemon died before it could serve", whoever spawned it.
+      recordDaemonExit({ code, signal, stderrExcerpt: readStderr() });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: code,
+          signal,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+    };
+    onError = (error) => {
+      recordDaemonLifecycleError(error.message);
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          reason: `spawn failed: ${error.message}`,
+          stderrExcerpt: readStderr(),
+          cause: error,
+        }),
+      );
+    };
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+  // Nothing else may observe this promise until the race below.
+  childFailure.catch(() => {});
+
+  const polling = (async (): Promise<void> => {
+    const deadline = startedAt + opts.timeoutMs;
+    for (;;) {
+      if (await opts.probeDaemon(opts.socketPath)) {
+        return;
+      }
+      if (opts.timeoutMs === 0 || now() >= deadline) {
+        throw new DaemonReadinessTimeoutError({
+          socketPath: opts.socketPath,
+          waitedMs: Math.max(0, now() - startedAt),
+          stderrExcerpt: readStderr(),
+        });
+      }
+      await opts.sleep(opts.pollMs);
+    }
+  })();
+
+  try {
+    await Promise.race([polling, childFailure]);
+  } finally {
+    polling.catch(() => {});
+    const detach =
+      child &&
+      (typeof child.off === "function"
+        ? child.off.bind(child)
+        : typeof child.removeListener === "function"
+          ? child.removeListener.bind(child)
+          : null);
+    if (detach) {
+      if (onExit) detach("exit", onExit);
+      if (onError) detach("error", onError);
+    }
+  }
 }
 
 export async function startInProcessRuntime(
@@ -158,8 +261,7 @@ export async function startInProcessRuntime(
   const explicitStateDir = runtimeEnv.CMUXLAYER_STATE_DIR?.trim();
   const serverOpts: CreateServerOptions = {
     client,
-    safetyCallerContextProvider: () =>
-      callerContextFromEnv(runtimeEnv),
+    safetyCallerContextProvider: () => callerContextFromEnv(runtimeEnv),
     outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,
@@ -317,22 +419,44 @@ export async function runDaemonFirstEntry(
     );
   }
 
-  const available = await waitForDaemon(socketPath, {
-    probeDaemon,
-    sleep,
-    autostartTimeoutMs,
-    autostartPollMs,
-  });
-  if (available) {
+  let readinessError: unknown = null;
+  try {
+    await awaitDaemonReadiness({
+      socketPath,
+      probeDaemon,
+      sleep,
+      timeoutMs: autostartTimeoutMs,
+      pollMs: autostartPollMs,
+      child: spawnedDaemon as DaemonChildLike | null,
+      readStderr: () => capturedDaemonStderr(spawnedDaemon),
+    });
     return startProxy();
+  } catch (error) {
+    readinessError = error;
   }
 
+  // A daemon that came up on the very last tick still wins the race.
   if (await probeDaemon(socketPath)) {
     return startProxy();
   }
 
   terminateSpawnedDaemon(spawnedDaemon, logger);
+  const detail =
+    readinessError instanceof DaemonStartupFailedError
+      ? `daemon exited before ready (code=${readinessError.exitCode ?? "none"}, signal=${
+          readinessError.signal ?? "none"
+        })${
+          readinessError.stderrExcerpt
+            ? `; daemon stderr: ${readinessError.stderrExcerpt}`
+            : ""
+        }`
+      : `daemon autostart timeout${
+          readinessError instanceof DaemonReadinessTimeoutError
+            ? ` after ${readinessError.waitedMs}ms`
+            : ""
+        }`;
+  recordDaemonLifecycleError(detail);
   return fallback(
-    `daemon unavailable; using heavy in-process runtime after daemon autostart timeout at ${socketPath}`,
+    `daemon unavailable; using heavy in-process runtime after ${detail} at ${socketPath}`,
   );
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -157,6 +157,10 @@ export async function awaitDaemonReadiness(
     null;
   let onError: ((error: Error) => void) | null = null;
   const child = opts.child;
+  // #530 review P2-7: once childFailure wins the race, the polling loop must
+  // stop. Without this it kept probing and sleeping to the deadline behind an
+  // already-settled promise.
+  let aborted = false;
 
   const childFailure = new Promise<never>((_, reject) => {
     if (!child || typeof child.once !== "function") {
@@ -195,9 +199,11 @@ export async function awaitDaemonReadiness(
   const polling = (async (): Promise<void> => {
     const deadline = startedAt + opts.timeoutMs;
     for (;;) {
+      if (aborted) return;
       if (await opts.probeDaemon(opts.socketPath)) {
         return;
       }
+      if (aborted) return;
       if (opts.timeoutMs === 0 || now() >= deadline) {
         throw new DaemonReadinessTimeoutError({
           socketPath: opts.socketPath,
@@ -212,6 +218,7 @@ export async function awaitDaemonReadiness(
   try {
     await Promise.race([polling, childFailure]);
   } finally {
+    aborted = true;
     polling.catch(() => {});
     const detach =
       child &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ import {
   resolveSweepTiming,
   type AgentDeliveryReceipt,
   type AgentLifecycleEvent,
+  type LifecycleLockState,
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
@@ -105,10 +106,7 @@ import {
   toAgentStatePayload,
   toObservedPublicAgent,
 } from "./agent-facade.js";
-import {
-  evaluateAgentHealth,
-  type AgentHealth,
-} from "./agent-health.js";
+import { evaluateAgentHealth, type AgentHealth } from "./agent-health.js";
 import {
   AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
   AGENT_HEALTH_MONITOR_MAX_AGE_MS,
@@ -236,6 +234,7 @@ import {
   collectControlHealth,
   formatControlHealth,
   type ControlHealth,
+  type LifecycleStartHealth,
 } from "./control-health.js";
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
@@ -619,12 +618,7 @@ const DeliveryOutputShape = {
   submit_attempted: z.boolean().optional(),
   submit_verified: z.boolean().nullable().optional(),
   submit_evidence: z
-    .enum([
-      "token_delta",
-      "transcript_echo",
-      "cleared_composer",
-      "status_only",
-    ])
+    .enum(["token_delta", "transcript_echo", "cleared_composer", "status_only"])
     .nullable()
     .optional(),
   delivery_id: z.string().optional(),
@@ -945,10 +939,7 @@ export const DELIVERY_RECEIPT_VOCABULARY = [
 ] as const;
 
 export type SubmitEvidence =
-  | "token_delta"
-  | "transcript_echo"
-  | "cleared_composer"
-  | "status_only";
+  "token_delta" | "transcript_echo" | "cleared_composer" | "status_only";
 
 type PublicDeliveryState =
   | "submitted"
@@ -1149,8 +1140,7 @@ type SubmitVerificationFailureReason =
  * available positive evidence.
  */
 type SubmitKeyVerificationReason =
-  | "surface_read_unavailable"
-  | "submit_evidence_absent";
+  "surface_read_unavailable" | "submit_evidence_absent";
 
 class SubmitVerificationError extends Error {
   readonly retry_safe = false;
@@ -3409,6 +3399,59 @@ export type LifecycleAgentInputDeliverer = (args: {
   delivery_id?: string;
 }) => Promise<PublicDeliveryReceipt & { bytes: number }>;
 
+export const DEFAULT_LIFECYCLE_START_TIMEOUT_MS = 60_000;
+
+/** Lifecycle initialization never settled inside its bound (#529). */
+export class LifecycleStartTimeoutError extends Error {
+  readonly code = "ELIFECYCLESTARTTIMEOUT";
+  readonly waitedMs: number;
+
+  constructor(waitedMs: number) {
+    super(
+      `cmuxlayer lifecycle initialization did not complete within ${waitedMs}ms; ` +
+        "the daemon or its startup sweep is wedged (see control_health.daemon_lifecycle)",
+    );
+    this.name = "LifecycleStartTimeoutError";
+    this.waitedMs = waitedMs;
+  }
+}
+
+export function resolveLifecycleStartTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.CMUXLAYER_LIFECYCLE_START_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_LIFECYCLE_START_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_LIFECYCLE_START_TIMEOUT_MS;
+}
+
+export async function awaitBoundedLifecycleStart(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  if (timeoutMs <= 0) {
+    await promise;
+    return;
+  }
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new LifecycleStartTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export interface CmuxServerContext {
   client: CmuxLayerClient;
   /** Persisted stable socket-node owner identity. */
@@ -3452,6 +3495,11 @@ export interface CmuxServerContext {
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
   lifecycleStartError: Error | null;
+  /** #529 observability: when lifecycle init began and whether it settled. */
+  lifecycleStartStartedAtMs: number | null;
+  lifecycleStartSettledAtMs: number | null;
+  /** Lifecycle-lock truth for `control_health`, published by the live engine. */
+  lifecycleLockStateProvider: (() => LifecycleLockState) | null;
   lifecycleSweepEngine: AgentEngine | null;
   lifecycleAgentInputDeliverer: LifecycleAgentInputDeliverer | null;
   lifecycleAgentInputDelivererReadyListeners: Set<() => void>;
@@ -3596,6 +3644,9 @@ export function createServerContext(
     lifecycleStarted: false,
     lifecycleStartPromise: null,
     lifecycleStartError: null,
+    lifecycleStartStartedAtMs: null,
+    lifecycleStartSettledAtMs: null,
+    lifecycleLockStateProvider: null,
     lifecycleSweepEngine: null,
     lifecycleAgentInputDeliverer: null,
     lifecycleAgentInputDelivererReadyListeners: new Set(),
@@ -3632,6 +3683,9 @@ export function createServerContext(
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
       context.lifecycleStartError = null;
+      context.lifecycleStartStartedAtMs = null;
+      context.lifecycleStartSettledAtMs = null;
+      context.lifecycleLockStateProvider = null;
       if (autoVitestStateDir) {
         removeAutoVitestTempDir(autoVitestStateDir);
       }
@@ -3843,7 +3897,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     coordination: CoordinationContract | null,
   ): { text: string; contract_path: string | null } => {
     if (bootContractMode() === "inline") {
-      return { text: mailboxBootContract(agentId, monitorBoot), contract_path: null };
+      return {
+        text: mailboxBootContract(agentId, monitorBoot),
+        contract_path: null,
+      };
     }
     try {
       const written = writeBootContractFile(
@@ -3866,7 +3923,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // A contract-file write failure must not fail an otherwise-successful
       // spawn. Fall back to the pre-P11b inline mailbox contract: the worker
       // loses the report half (exactly as before P11b), not its mailbox.
-      return { text: mailboxBootContract(agentId, monitorBoot), contract_path: null };
+      return {
+        text: mailboxBootContract(agentId, monitorBoot),
+        contract_path: null,
+      };
     }
   };
 
@@ -3963,9 +4023,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // absence is ambiguous.
     const observerOwnerId = context.surfaceObserverId?.trim() || null;
     const ownsRefBinding = (agent: AgentRecord): boolean =>
-      Boolean(
-        observerOwnerId && agent.surface_observer_id === observerOwnerId,
-      );
+      Boolean(observerOwnerId && agent.surface_observer_id === observerOwnerId);
     const live = (agent: AgentRecord): boolean =>
       !isLiveTerminal(liveStateFor(agent));
     return (
@@ -4919,10 +4977,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
   };
 
+  const describeLifecycleStart = (): LifecycleStartHealth => {
+    const settled =
+      context.lifecycleStartPromise === null ||
+      context.lifecycleStartSettledAtMs !== null;
+    return {
+      started: context.lifecycleStarted,
+      settled,
+      waiting_for_ms:
+        settled || context.lifecycleStartStartedAtMs === null
+          ? null
+          : Date.now() - context.lifecycleStartStartedAtMs,
+      timeout_ms: resolveLifecycleStartTimeoutMs(),
+      error: context.lifecycleStartError?.message ?? null,
+    };
+  };
+
   const appendControlHealthSnapshot = async (): Promise<ControlHealth> => {
     const rawHealth = controlHealthCollector
       ? await controlHealthCollector()
-      : await collectControlHealth({ client });
+      : await collectControlHealth({
+          client,
+          lifecycleLock: context.lifecycleLockStateProvider?.() ?? null,
+          lifecycleStart: describeLifecycleStart(),
+        });
     const knownSurfaceIds = [
       ...stateMgr.listStates().map((record) => record.surface_id),
       ...roleSurfaceOverrides.keys(),
@@ -4930,8 +5008,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ...activeSurfaceWrites.keys(),
       ...surfaceWriteLivenessCandidates,
     ];
+    // #529: a dead daemon and a wedged lifecycle lock used to look identical to
+    // a healthy control plane. Publish both, always.
     const healthWithSelfHeal: ControlHealth = {
       ...rawHealth,
+      daemon_lifecycle: {
+        ...rawHealth.daemon_lifecycle,
+        lifecycle_lock: context.lifecycleLockStateProvider?.() ?? null,
+        lifecycle_start: describeLifecycleStart(),
+      },
       self_heal: collectSelfHealHealth({
         surfaceWriteLiveness,
         surfaceIds: knownSurfaceIds,
@@ -5718,12 +5803,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               surface: opts.surface,
               workspace: opts.workspace,
               text: submittedText,
-              timeout_ms:
-                Math.min(
-                  opts.submit_verify_timeout_ms ??
-                    SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
-                  BOOT_PAYLOAD_OBSERVE_TIMEOUT_MS,
-                ),
+              timeout_ms: Math.min(
+                opts.submit_verify_timeout_ms ??
+                  SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
+                BOOT_PAYLOAD_OBSERVE_TIMEOUT_MS,
+              ),
               beforeRead: opts.beforeMutation,
             })
           : null;
@@ -6058,9 +6142,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? (consecutiveMatches.get(candidate) ?? 0) + 1
             : 0;
           consecutiveMatches.set(candidate, count);
-          if (
-            count >= requiredBootReadyObservations(candidate, screen.text)
-          ) {
+          if (count >= requiredBootReadyObservations(candidate, screen.text)) {
             return {
               metrics: parseSubmitEvidenceMetrics(screen.text, parsed),
               route: target,
@@ -10119,7 +10201,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   // 10. close_surface
   server.tool(
     "close_surface",
-    "Close one surface, managed agent, or workspace with live-agent guards. scope=\"agent\" stops the agent AND closes its pane, and reports the two halves separately (agent_stopped, surface_closed) so a pane that survives is never reported as closed. The pane close obeys the same live-agent guard as scope=\"surface\": without force:true a still-live agent keeps its pane, and the receipt says so.",
+    'Close one surface, managed agent, or workspace with live-agent guards. scope="agent" stops the agent AND closes its pane, and reports the two halves separately (agent_stopped, surface_closed) so a pane that survives is never reported as closed. The pane close obeys the same live-agent guard as scope="surface": without force:true a still-live agent keeps its pane, and the receipt says so.',
     {
       scope: z
         .enum(["surface", "agent", "workspace"])
@@ -10152,7 +10234,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // harvesting panes got success and kept every one of them. Resolve
           // the bound surface BEFORE stopping (the stop can evict the record),
           // stop, then close the pane for real and say which halves happened.
-          const boundAgent = context.lifecycleRegistry?.get(args.agent_id) ?? null;
+          const boundAgent =
+            context.lifecycleRegistry?.get(args.agent_id) ?? null;
           const boundSurface = boundAgent?.surface_id?.trim() || null;
           const boundWorkspace = boundAgent?.workspace_id ?? undefined;
           if (
@@ -10174,8 +10257,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 surface: boundSurface,
                 surface_closed: false,
                 surface_close_skipped: "live_process",
-                WARNING:
-                  `Live process ${boundAgent?.pid} was not stopped and its surface was not closed; pass force:true for deliberate teardown.`,
+                WARNING: `Live process ${boundAgent?.pid} was not stopped and its surface was not closed; pass force:true for deliberate teardown.`,
               },
             );
           }
@@ -10191,8 +10273,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Drop the stop receipt's own envelope fields; this response owns
           // ok/error, and letting stop_agent's ok:true through was exactly how
           // a half-done close reported success.
-          const { ok: _stopOk, error: _stopError, ...stopContent } =
-            rawStopContent;
+          const {
+            ok: _stopOk,
+            error: _stopError,
+            ...stopContent
+          } = rawStopContent;
           if (!agentStopped) {
             // The stop itself failed: keep its verbatim ok:false/error and add
             // the surface half, which was never attempted.
@@ -11268,9 +11353,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return null;
       }
     };
+    const lifecycleStartTimeoutMs = resolveLifecycleStartTimeoutMs();
+    /**
+     * #529: this used to `await context.lifecycleStartPromise` with no bound.
+     * When the daemon died before ready that promise never settled, so every
+     * tool gated on it — `list_agents`, `spawn_agent` (new AND resume),
+     * `send_to`, `broadcast`, `report_to_parent` — deadlocked in silence. The
+     * wait is bounded now and reports how long it waited.
+     */
     const awaitLifecycleStart = async (): Promise<void> => {
       if (context.lifecycleStartPromise) {
-        await context.lifecycleStartPromise;
+        await awaitBoundedLifecycleStart(
+          context.lifecycleStartPromise,
+          lifecycleStartTimeoutMs,
+        );
       }
       if (context.lifecycleStartError) {
         throw context.lifecycleStartError;
@@ -11498,7 +11594,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           monitorRegistryNow: opts?.monitorRegistryNow,
           monitorRegistryNotify: opts?.monitorRegistryNotify,
           watchRegistryPath:
-            opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
+            opts?.watchRegistryPath ??
+            join(context.stateDir, "watch-specs.json"),
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
             let externalDelivered = true;
@@ -11660,19 +11757,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     lifecycleEnsureRegistered = async () => {
       await awaitLifecycleStart();
-      await engine.runLifecycleMutation(() =>
-        registry.listMerged(discovery, { force: true }).then(() => undefined),
+      await engine.runLifecycleMutation(
+        () =>
+          registry.listMerged(discovery, { force: true }).then(() => undefined),
+        { label: "lifecycle-ensure-registered" },
       );
     };
     lifecycleRefreshManagedMetadata = async (agentId?: string) => {
       await awaitLifecycleStart();
-      await engine.runLifecycleMutation(() =>
-        registry
-          .refreshManagedSurfaceMetadata(discovery, {
-            agentId,
-            force: true,
-          })
-          .then(() => undefined),
+      await engine.runLifecycleMutation(
+        () =>
+          registry
+            .refreshManagedSurfaceMetadata(discovery, {
+              agentId,
+              force: true,
+            })
+            .then(() => undefined),
+        { label: "lifecycle-refresh-managed-metadata" },
       );
     };
 
@@ -12265,7 +12366,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
 
         const parent =
-          registry.get(intendedParentId) ?? stateMgr.readState(intendedParentId);
+          registry.get(intendedParentId) ??
+          stateMgr.readState(intendedParentId);
         let directError = "parent is absent from the lifecycle registry";
         if (parent) {
           try {
@@ -12282,7 +12384,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               },
             );
           } catch (error) {
-            directError = error instanceof Error ? error.message : String(error);
+            directError =
+              error instanceof Error ? error.message : String(error);
           }
         }
 
@@ -12327,7 +12430,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               },
             );
           } catch (error) {
-            directError = error instanceof Error ? error.message : String(error);
+            directError =
+              error instanceof Error ? error.message : String(error);
             ancestorId = ancestor.parent_agent_id;
           }
         }
@@ -12416,6 +12520,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
       context.lifecycleStartError = null;
+      context.lifecycleStartStartedAtMs = Date.now();
+      context.lifecycleStartSettledAtMs = null;
       const lifecycleInitialization = lifecycleInitializer
         ? Promise.resolve().then(() => lifecycleInitializer())
         : engine.initialize(discovery);
@@ -12429,6 +12535,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         })
         .then(() => {
+          context.lifecycleStartSettledAtMs = Date.now();
           if (
             !context.lifecycleStartError &&
             context.lifecycleStarted &&
@@ -12438,6 +12545,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         });
     }
+    context.lifecycleLockStateProvider = () => engine.lifecycleLockState();
     // The daemon may immediately use this relay for monitor recovery. Publish
     // it only after persisted lifecycle state has been reconstituted so route
     // resolution is ready, then wake any boot-time recovery claim.
@@ -12594,7 +12702,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           })
           .optional()
           .describe(
-            "Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. The engine also WRITES both strings to the spawn contract file (`contract_path`) and points the boot prompt at it, so the worker is told; check `coordination_footer_delivered` -- if false the contract file could not be written and YOU must relay report_path and done_marker, or a done worker renders closure:\"artifact_missing\". Pass this only to place the report somewhere you already watch (e.g. a collab dir).",
+            'Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. The engine also WRITES both strings to the spawn contract file (`contract_path`) and points the boot prompt at it, so the worker is told; check `coordination_footer_delivered` -- if false the contract file could not be written and YOU must relay report_path and done_marker, or a done worker renders closure:"artifact_missing". Pass this only to place the report somewhere you already watch (e.g. a collab dir).',
           ),
         force_new: z
           .boolean()
@@ -15079,51 +15187,54 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ) {
             return renderListAgentsResponse(cached);
           }
-          const live = await engine.runLifecycleMutation(async () => {
-            discovery.invalidate();
-            const discovered = await discovery.scan(true);
-            const observedAtMs = Date.now();
-            registry.repairFromDiscovery(discovered, {
-              seatRegistry,
-              orphansOnly: true,
-            });
-            // #481: `createLiveSeatDiscoveryProof` had exactly one call site --
-            // inside the removed resync tool's unreachable body -- so
-            // `hasLiveManagedSeatSibling` returned false unconditionally and
-            // every crash-recovery-eligible ghost was retained forever. This is
-            // the live path that already holds a same-cycle, observer-pinned
-            // scan, so the proof belongs here.
-            // #480: it is also the only reconciliation callers actually
-            // trigger. Without an eviction here `list_agents` was the one
-            // reader that never dropped a row: 17 agents against 13 surfaces.
-            const liveSeatProof = registry.createLiveSeatDiscoveryProof(
-              discovered,
-              {
+          const live = await engine.runLifecycleMutation(
+            async () => {
+              discovery.invalidate();
+              const discovered = await discovery.scan(true);
+              const observedAtMs = Date.now();
+              registry.repairFromDiscovery(discovered, {
                 seatRegistry,
-                expectedObserverId: registry.getObserverId(),
-                expectedObserverEpoch: registry.getObserverEpoch(),
-              },
-            );
-            await registry.evictSurfaceless({
-              confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
-              now: observedAtMs,
-              liveSeatProof,
-            });
-            const merged = await registry.listMerged(discovery, {
-              filter,
-              force: true,
-              discovered,
-            });
-            const requestedIds = args.agent_ids
-              ? new Set(args.agent_ids)
-              : null;
-            const scoped = merged.filter(
-              (agent) =>
-                (!parentAgentId || agent.parent_agent_id === parentAgentId) &&
-                (!requestedIds || requestedIds.has(agent.agent_id)),
-            );
-            return { merged: scoped, discovered, observedAtMs };
-          });
+                orphansOnly: true,
+              });
+              // #481: `createLiveSeatDiscoveryProof` had exactly one call site --
+              // inside the removed resync tool's unreachable body -- so
+              // `hasLiveManagedSeatSibling` returned false unconditionally and
+              // every crash-recovery-eligible ghost was retained forever. This is
+              // the live path that already holds a same-cycle, observer-pinned
+              // scan, so the proof belongs here.
+              // #480: it is also the only reconciliation callers actually
+              // trigger. Without an eviction here `list_agents` was the one
+              // reader that never dropped a row: 17 agents against 13 surfaces.
+              const liveSeatProof = registry.createLiveSeatDiscoveryProof(
+                discovered,
+                {
+                  seatRegistry,
+                  expectedObserverId: registry.getObserverId(),
+                  expectedObserverEpoch: registry.getObserverEpoch(),
+                },
+              );
+              await registry.evictSurfaceless({
+                confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
+                now: observedAtMs,
+                liveSeatProof,
+              });
+              const merged = await registry.listMerged(discovery, {
+                filter,
+                force: true,
+                discovered,
+              });
+              const requestedIds = args.agent_ids
+                ? new Set(args.agent_ids)
+                : null;
+              const scoped = merged.filter(
+                (agent) =>
+                  (!parentAgentId || agent.parent_agent_id === parentAgentId) &&
+                  (!requestedIds || requestedIds.has(agent.agent_id)),
+              );
+              return { merged: scoped, discovered, observedAtMs };
+            },
+            { label: "list-agents" },
+          );
           return await buildListAgentsResponse(
             live.merged,
             topology,
@@ -15224,22 +15335,27 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const collectTargetRecords = async (): Promise<AgentRecord[]> => {
       try {
-        return await engine.runLifecycleMutation(async () => {
-          try {
-            discovery.invalidate();
-            const discovered = await discovery.scan(true);
-            return await registry.listMerged(discovery, {
-              force: true,
-              discovered,
-            });
-          } catch (error) {
-            if (!(error instanceof SurfaceBindingChangedDuringDiscoveryError)) {
-              throw error;
+        return await engine.runLifecycleMutation(
+          async () => {
+            try {
+              discovery.invalidate();
+              const discovered = await discovery.scan(true);
+              return await registry.listMerged(discovery, {
+                force: true,
+                discovered,
+              });
+            } catch (error) {
+              if (
+                !(error instanceof SurfaceBindingChangedDuringDiscoveryError)
+              ) {
+                throw error;
+              }
+              discovery.invalidate();
+              return registry.listMerged(discovery, { force: true });
             }
-            discovery.invalidate();
-            return registry.listMerged(discovery, { force: true });
-          }
-        });
+          },
+          { label: "collect-target-records" },
+        );
       } catch (e) {
         if (isSurfaceEnumerationError(e)) {
           throw new Error(
@@ -16800,8 +16916,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           await awaitLifecycleStart();
-          const merged = await engine.runLifecycleMutation(() =>
-            registry.listMerged(discovery),
+          const merged = await engine.runLifecycleMutation(
+            () => registry.listMerged(discovery),
+            { label: "list-agent-hierarchy" },
           );
           const agents = args.parent_agent_id
             ? (() => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12379,116 +12379,125 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.mutating,
       async (args) => {
-        await awaitLifecycleStart();
-        const child = resolveCurrentCallerAgent();
-        if (!child) {
-          return err("report_to_parent requires a managed calling agent", {
-            error_code: "report_caller_unmanaged",
-          });
-        }
-        if (!child.parent_agent_id) {
-          return err(`Agent ${child.agent_id} has no parent`, {
-            error_code: "report_parent_missing",
-            child_agent_id: child.agent_id,
-          });
-        }
-
-        const intendedParentId = child.parent_agent_id;
-        const directMessage = dispatch(
-          intendedParentId,
-          {
-            from: child.agent_id,
-            reply_to: child.agent_id,
-            via: child.surface_id,
-            observed_at: new Date().toISOString(),
-            to: intendedParentId,
-            tag: "parent_blocker",
-            task: args.blocker,
-          },
-          inboxOpts,
-        );
-        context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
-
-        const parent =
-          registry.get(intendedParentId) ??
-          stateMgr.readState(intendedParentId);
-        let directError = "parent is absent from the lifecycle registry";
-        if (parent) {
-          try {
-            const wake = await deliverReportInboxPointer(parent, directMessage);
-            return okFormatted(
-              `report_to_parent ${parent.agent_id}: ${wake.delivery}`,
-              {
-                child_agent_id: child.agent_id,
-                parent_agent_id: intendedParentId,
-                notified_agent_id: parent.agent_id,
-                route: "direct",
-                durable: true,
-                ...wake,
-              },
-            );
-          } catch (error) {
-            directError =
-              error instanceof Error ? error.message : String(error);
+        try {
+          await awaitLifecycleStart();
+          const child = resolveCurrentCallerAgent();
+          if (!child) {
+            return err("report_to_parent requires a managed calling agent", {
+              error_code: "report_caller_unmanaged",
+            });
           }
-        }
+          if (!child.parent_agent_id) {
+            return err(`Agent ${child.agent_id} has no parent`, {
+              error_code: "report_parent_missing",
+              child_agent_id: child.agent_id,
+            });
+          }
 
-        const visited = new Set<string>([child.agent_id, intendedParentId]);
-        let ancestorId = parent?.parent_agent_id ?? null;
-        while (ancestorId && !visited.has(ancestorId)) {
-          visited.add(ancestorId);
-          const ancestor =
-            registry.get(ancestorId) ?? stateMgr.readState(ancestorId);
-          if (!ancestor) break;
-          const prefix =
-            `Delivery to parent ${intendedParentId} failed (${directError}). ` +
-            `Child ${child.agent_id} reports: `;
-          const fallbackTask = `${prefix}${args.blocker}`.slice(0, 500);
-          const fallbackMessage = dispatch(
-            ancestor.agent_id,
+          const intendedParentId = child.parent_agent_id;
+          const directMessage = dispatch(
+            intendedParentId,
             {
               from: child.agent_id,
               reply_to: child.agent_id,
               via: child.surface_id,
               observed_at: new Date().toISOString(),
-              to: ancestor.agent_id,
-              tag: "parent_delivery_failed",
-              task: fallbackTask,
+              to: intendedParentId,
+              tag: "parent_blocker",
+              task: args.blocker,
             },
             inboxOpts,
           );
-          try {
-            const wake = await deliverReportInboxPointer(
-              ancestor,
-              fallbackMessage,
-            );
-            return okFormatted(
-              `report_to_parent ${intendedParentId}: fallback ${ancestor.agent_id} ${wake.delivery}`,
-              {
-                child_agent_id: child.agent_id,
-                parent_agent_id: intendedParentId,
-                notified_agent_id: ancestor.agent_id,
-                route: "fallback",
-                durable: true,
-                ...wake,
-              },
-            );
-          } catch (error) {
-            directError =
-              error instanceof Error ? error.message : String(error);
-            ancestorId = ancestor.parent_agent_id;
-          }
-        }
+          context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
 
-        return err(
-          `Blocker was written to ${intendedParentId}'s inbox, but no parent or ancestor could be woken: ${directError}`,
-          {
-            error_code: "report_parent_unreachable",
-            child_agent_id: child.agent_id,
-            parent_agent_id: intendedParentId,
-            durable: true,
-          },
-        );
+          const parent =
+            registry.get(intendedParentId) ??
+            stateMgr.readState(intendedParentId);
+          let directError = "parent is absent from the lifecycle registry";
+          if (parent) {
+            try {
+              const wake = await deliverReportInboxPointer(parent, directMessage);
+              return okFormatted(
+                `report_to_parent ${parent.agent_id}: ${wake.delivery}`,
+                {
+                  child_agent_id: child.agent_id,
+                  parent_agent_id: intendedParentId,
+                  notified_agent_id: parent.agent_id,
+                  route: "direct",
+                  durable: true,
+                  ...wake,
+                },
+              );
+            } catch (error) {
+              directError =
+                error instanceof Error ? error.message : String(error);
+            }
+          }
+
+          const visited = new Set<string>([child.agent_id, intendedParentId]);
+          let ancestorId = parent?.parent_agent_id ?? null;
+          while (ancestorId && !visited.has(ancestorId)) {
+            visited.add(ancestorId);
+            const ancestor =
+              registry.get(ancestorId) ?? stateMgr.readState(ancestorId);
+            if (!ancestor) break;
+            const prefix =
+              `Delivery to parent ${intendedParentId} failed (${directError}). ` +
+              `Child ${child.agent_id} reports: `;
+            const fallbackTask = `${prefix}${args.blocker}`.slice(0, 500);
+            const fallbackMessage = dispatch(
+              ancestor.agent_id,
+              {
+                from: child.agent_id,
+                reply_to: child.agent_id,
+                via: child.surface_id,
+                observed_at: new Date().toISOString(),
+                to: ancestor.agent_id,
+                tag: "parent_delivery_failed",
+                task: fallbackTask,
+              },
+              inboxOpts,
+            );
+            try {
+              const wake = await deliverReportInboxPointer(
+                ancestor,
+                fallbackMessage,
+              );
+              return okFormatted(
+                `report_to_parent ${intendedParentId}: fallback ${ancestor.agent_id} ${wake.delivery}`,
+                {
+                  child_agent_id: child.agent_id,
+                  parent_agent_id: intendedParentId,
+                  notified_agent_id: ancestor.agent_id,
+                  route: "fallback",
+                  durable: true,
+                  ...wake,
+                },
+              );
+            } catch (error) {
+              directError =
+                error instanceof Error ? error.message : String(error);
+              ancestorId = ancestor.parent_agent_id;
+            }
+          }
+
+          return err(
+            `Blocker was written to ${intendedParentId}'s inbox, but no parent or ancestor could be woken: ${directError}`,
+            {
+              error_code: "report_parent_unreachable",
+              child_agent_id: child.agent_id,
+              parent_agent_id: intendedParentId,
+              durable: true,
+            },
+          );
+        } catch (error) {
+          // #530 (CodeRabbit): the initial awaitLifecycleStart() used to run
+          // OUTSIDE any error path, so a bounded lifecycle-start timeout escaped
+          // the handler entirely and lost the structured error_code / waited_ms /
+          // retryable payload that err() attaches. Wrapping the whole body also
+          // closes the escaping inbox-write exceptions noted as D36.
+          return err(error);
+        }
       },
     );
     engine.setDeliverySnapshotReader(async (receipt: AgentDeliveryReceipt) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3498,6 +3498,9 @@ export interface CmuxServerContext {
   /** #529 observability: when lifecycle init began and whether it settled. */
   lifecycleStartStartedAtMs: number | null;
   lifecycleStartSettledAtMs: number | null;
+  /** #530 review P2-4: callers that gave up on the bounded lifecycle wait. */
+  lifecycleStartTimeouts: number;
+  lifecycleStartLastTimeoutAt: string | null;
   /** Lifecycle-lock truth for `control_health`, published by the live engine. */
   lifecycleLockStateProvider: (() => LifecycleLockState) | null;
   lifecycleSweepEngine: AgentEngine | null;
@@ -3646,6 +3649,8 @@ export function createServerContext(
     lifecycleStartError: null,
     lifecycleStartStartedAtMs: null,
     lifecycleStartSettledAtMs: null,
+    lifecycleStartTimeouts: 0,
+    lifecycleStartLastTimeoutAt: null,
     lifecycleLockStateProvider: null,
     lifecycleSweepEngine: null,
     lifecycleAgentInputDeliverer: null,
@@ -3685,6 +3690,8 @@ export function createServerContext(
       context.lifecycleStartError = null;
       context.lifecycleStartStartedAtMs = null;
       context.lifecycleStartSettledAtMs = null;
+      context.lifecycleStartTimeouts = 0;
+      context.lifecycleStartLastTimeoutAt = null;
       context.lifecycleLockStateProvider = null;
       if (autoVitestStateDir) {
         removeAutoVitestTempDir(autoVitestStateDir);
@@ -4990,6 +4997,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : Date.now() - context.lifecycleStartStartedAtMs,
       timeout_ms: resolveLifecycleStartTimeoutMs(),
       error: context.lifecycleStartError?.message ?? null,
+      timeouts: context.lifecycleStartTimeouts,
+      last_timeout_at: context.lifecycleStartLastTimeoutAt,
     };
   };
 
@@ -11363,10 +11372,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
      */
     const awaitLifecycleStart = async (): Promise<void> => {
       if (context.lifecycleStartPromise) {
-        await awaitBoundedLifecycleStart(
-          context.lifecycleStartPromise,
-          lifecycleStartTimeoutMs,
-        );
+        try {
+          await awaitBoundedLifecycleStart(
+            context.lifecycleStartPromise,
+            lifecycleStartTimeoutMs,
+          );
+        } catch (error) {
+          // #530 review P2-4: record the bound this PR added, so control_health
+          // warns instead of the new timeout being silent in its turn. Do NOT
+          // set lifecycleStartError — init may still be in flight and succeed.
+          if (error instanceof LifecycleStartTimeoutError) {
+            context.lifecycleStartTimeouts += 1;
+            context.lifecycleStartLastTimeoutAt = new Date().toISOString();
+          }
+          throw error;
+        }
       }
       if (context.lifecycleStartError) {
         throw context.lifecycleStartError;

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@ import {
 import {
   AgentEngine,
   AgentLaunchError,
+  LifecycleLockTimeoutError,
   RetryableDeliveryError,
   buildLaunchCommand,
   resolveSweepTiming,
@@ -1409,6 +1410,27 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     error.code === PLACEMENT_WORKSPACE_UNRESOLVED
       ? { error_code: PLACEMENT_WORKSPACE_UNRESOLVED }
       : {};
+  // #530 review (CodeRabbit): the lifecycle timeouts this PR adds carried a
+  // `code` that never reached the tool payload, so automated callers saw only
+  // free text and could not tell a bounded control-plane wait from any other
+  // failure. Both are retryable and both point at the same diagnostic.
+  const lifecycleTimeoutExtra =
+    error instanceof LifecycleStartTimeoutError
+      ? {
+          error_code: error.code,
+          waited_ms: error.waitedMs,
+          retryable: true,
+        }
+      : error instanceof LifecycleLockTimeoutError
+        ? {
+            error_code: error.code,
+            waited_ms: error.waitedMs,
+            lock_holder: error.holder,
+            held_for_ms: error.heldForMs,
+            queue_depth: error.queueDepth,
+            retryable: true,
+          }
+        : {};
   const readinessTimeout = findErrorInChain(
     error,
     (candidate): candidate is BootPromptTimeoutError | LauncherReadinessError =>
@@ -1445,6 +1467,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     ...deliverySafetyExtra,
     ...submitVerificationExtra,
     ...placementWorkspaceExtra,
+    ...lifecycleTimeoutExtra,
     ...readinessExtra,
     ...extra,
     ...createdIdentityFromError(error),
@@ -3409,7 +3432,8 @@ export class LifecycleStartTimeoutError extends Error {
   constructor(waitedMs: number) {
     super(
       `cmuxlayer lifecycle initialization did not complete within ${waitedMs}ms; ` +
-        "the daemon or its startup sweep is wedged (see control_health.daemon_lifecycle)",
+        "the daemon or its startup sweep is wedged. " +
+        "Retry; if it persists, see control_health.daemon_lifecycle.lifecycle_start.",
     );
     this.name = "LifecycleStartTimeoutError";
     this.waitedMs = waitedMs;

--- a/tests/daemon-deadlock-529-behaviour.test.ts
+++ b/tests/daemon-deadlock-529-behaviour.test.ts
@@ -1,0 +1,227 @@
+/**
+ * #529 BEHAVIOURAL bite tests — the reviewer's round-2 requirement.
+ *
+ * These deliberately import ONLY symbols that already existed on `main`
+ * (`CmuxLayerDaemon`, `AgentEngine`, `StateManager`, `AgentRegistry`) and steer
+ * the new bounds through ENVIRONMENT VARIABLES rather than new options. So they
+ * keep failing on the unfixed tree, and they survive any later refactor or
+ * rename of the symbols this PR introduced.
+ *
+ * TEST1 (ENOTSOCK bite): a dead-owner leftover at the socket path must be
+ *   reaped, not fataled on. Pre-fix: `daemon.start()` rejects with ENOTSOCK.
+ * TEST4 (unbounded acquire): a wedged lifecycle holder must not make later
+ *   callers wait forever. Pre-fix: the queued call never settles and this test
+ *   fails by timeout.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CmuxLayerDaemon } from "../src/daemon.js";
+import { AgentEngine } from "../src/agent-engine.js";
+import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { CmuxClient, ExecFn } from "../src/cmux-client.js";
+
+// Unix socket paths cap near 104 bytes on macOS; keep the root short.
+const TEST_ROOT = join(tmpdir(), "cmux529b");
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+  vi.restoreAllMocks();
+});
+
+function listWorkspacesExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  }) as unknown as ExecFn;
+}
+
+describe("#529 behavioural bite", () => {
+  it("TEST1: starts over a dead-owner leftover instead of fataling on ENOTSOCK", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = join(TEST_ROOT, `bite1-${process.pid}.sock`);
+    rmSync(path, { force: true });
+    // Exactly what a clean daemon shutdown leaves behind: an empty REGULAR
+    // FILE at the socket path. connect(2) answers ENOTSOCK.
+    writeFileSync(path, "");
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listWorkspacesExec(),
+      skipAgentLifecycle: true,
+    });
+    cleanups.push(async () => {
+      await daemon.shutdown();
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    await expect(daemon.start()).resolves.toBeUndefined();
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("TEST4: a wedged lifecycle holder does not make a later caller wait forever", async () => {
+    const baseDir = join(tmpdir(), `cmux529b-engine-${process.pid}`);
+    rmSync(baseDir, { recursive: true, force: true });
+    mkdirSync(baseDir, { recursive: true });
+
+    // Steer the bound through env only — no symbol this PR added.
+    const priorAcquire =
+      process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+    const priorHold = process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = "60";
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = "150";
+
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    const engine = new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+    });
+
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+      if (priorAcquire === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = priorAcquire;
+      }
+      if (priorHold === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = priorHold;
+      }
+    });
+
+    // The wedge: an operation that never settles.
+    void engine
+      .runLifecycleMutation(() => new Promise<void>(() => {}))
+      .catch(() => {});
+
+    const settled = await Promise.race([
+      engine
+        .runLifecycleMutation(async () => "queued")
+        .then(() => "resolved")
+        .catch(() => "rejected"),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve("never-settled"), 2_000),
+      ),
+    ]);
+
+    // The point is only that it SETTLES. Which way is the bound's business.
+    expect(settled).not.toBe("never-settled");
+  }, 10_000);
+
+  it("TEST4b: the acquire timeout does not let a waiter run beside the live holder", async () => {
+    // #530 review P1-1: releasing the timed-out waiter's own tail slot let the
+    // NEXT caller chain off an already-resolved promise and execute
+    // concurrently with the still-live holder. Mutual exclusion must hold.
+    const baseDir = join(tmpdir(), `cmux529b-excl-${process.pid}`);
+    rmSync(baseDir, { recursive: true, force: true });
+    mkdirSync(baseDir, { recursive: true });
+
+    const priorAcquire =
+      process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+    const priorHold = process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = "40";
+    // Hold bound far beyond the test: the holder stays live throughout.
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = "60000";
+
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    const engine = new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+    });
+
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+      if (priorAcquire === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = priorAcquire;
+      }
+      if (priorHold === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = priorHold;
+      }
+    });
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    let releaseHolder!: () => void;
+
+    const holder = engine.runLifecycleMutation(async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise<void>((resolve) => (releaseHolder = resolve));
+      concurrent -= 1;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // This one gives up on the acquire while the holder is still live.
+    const abandoned = engine
+      .runLifecycleMutation(async () => {
+        concurrent += 1;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        concurrent -= 1;
+      })
+      .catch(() => "timed-out");
+
+    // Queued behind the abandoned waiter. It must NOT start early.
+    const follower = engine.runLifecycleMutation(async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      concurrent -= 1;
+      return "follower";
+    });
+    follower.catch(() => {});
+
+    await abandoned;
+    // Give a broken implementation ample room to run the follower early.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(maxConcurrent).toBe(1);
+
+    releaseHolder();
+    await holder;
+    await Promise.allSettled([follower]);
+    expect(maxConcurrent).toBe(1);
+  }, 10_000);
+});

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Regression suite for #529 — the control-plane daemon deadlock.
+ *
+ * Incident shape (2026-08-24, packaged 0.4.56): a leftover file at the daemon
+ * socket path made `unlinkStaleSocket` throw instead of reaping it, the daemon
+ * exited code 1 immediately after the proxy spawned it, that exit was never
+ * propagated to the readiness waiters, and every daemon-dependent tool
+ * (`list_agents`, `spawn_agent`) deadlocked forever while lock-free tools kept
+ * answering in milliseconds.
+ *
+ * Each test here must fail (hang, throw the wrong shape, or fail to import)
+ * against the pre-fix code.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CmuxLayerDaemon, unlinkStaleSocket } from "../src/daemon.js";
+import {
+  DaemonSocketInUseError,
+  DaemonStartupFailedError,
+  DaemonReadinessTimeoutError,
+  daemonLifecycleSnapshot,
+  resetDaemonLifecycleState,
+} from "../src/daemon-lifecycle-state.js";
+import { awaitDaemonReadiness } from "../src/entry.js";
+import { AgentEngine, LifecycleLockTimeoutError } from "../src/agent-engine.js";
+import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { collectControlHealth } from "../src/control-health.js";
+import type { CmuxClient } from "../src/cmux-client.js";
+import type { ExecFn } from "../src/cmux-client.js";
+
+// Unix socket paths are capped near 104 bytes on macOS, so keep the test root short.
+const TEST_ROOT = join(tmpdir(), "cmux529");
+
+function testSocketPath(name: string): string {
+  mkdirSync(TEST_ROOT, { recursive: true });
+  return join(TEST_ROOT, `${name}-${process.pid}.sock`);
+}
+
+function listSurfacesExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  }) as unknown as ExecFn;
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+  vi.restoreAllMocks();
+  resetDaemonLifecycleState();
+});
+
+describe("#529 daemon socket path handling", () => {
+  it("reaps a dead-owner leftover at the socket path and starts", async () => {
+    // A clean daemon shutdown leaves an empty REGULAR FILE at the socket path
+    // (`detachOwnedSocketPath` writes the placeholder and never removes it), so
+    // a reboot-time SIGTERM leaves exactly this shape. connect(2) on it returns
+    // ENOTSOCK, which the pre-fix probe re-threw: the successor daemon fataled
+    // instead of reaping a leftover that provably has no live owner.
+    const path = testSocketPath("dead-owner-leftover");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    expect(statSync(path).isSocket()).toBe(false);
+
+    const outcome = await unlinkStaleSocket(path);
+    expect(outcome).toBe("reaped");
+    expect(existsSync(path)).toBe(false);
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    cleanups.push(async () => {
+      await daemon.shutdown();
+      rmSync(path, { force: true });
+    });
+    await daemon.start();
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("refuses a LIVE owner with a structured error instead of a bare throw", async () => {
+    const path = testSocketPath("live-owner");
+    rmSync(path, { force: true });
+    const owner = net.createServer(() => {});
+    await new Promise<void>((resolve) => owner.listen(path, () => resolve()));
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          owner.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).code).toBe("EDAEMONSOCKETINUSE");
+    expect((error as DaemonSocketInUseError).socketPath).toBe(path);
+    // The live owner's socket must survive — this is the "connect to it" case.
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+});
+
+describe("#529 daemon readiness propagation", () => {
+  it("rejects with exit code and stderr when the daemon child dies before ready", async () => {
+    const child = new EventEmitter() as EventEmitter & { pid?: number };
+    child.pid = 4242;
+    const stderr =
+      "[cmuxlayer-daemon] fatal Error: cmuxlayer daemon socket is already in use";
+
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/never-ready.sock",
+      child,
+      readStderr: () => stderr,
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 5_000,
+      pollMs: 5,
+    });
+    setTimeout(() => child.emit("exit", 1, null), 10);
+
+    const error = await readiness.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonStartupFailedError);
+    expect((error as DaemonStartupFailedError).exitCode).toBe(1);
+    expect((error as DaemonStartupFailedError).stderrExcerpt).toContain(
+      "socket is already in use",
+    );
+    // The failure is recorded, so a dead daemon no longer looks like a healthy one.
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.last_exit?.code).toBe(1);
+    expect(snapshot.last_exit?.stderr_excerpt).toContain(
+      "socket is already in use",
+    );
+  });
+
+  it("bounds readiness so a silent daemon never leaves the promise unsettled", async () => {
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/silent.sock",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 20,
+      pollMs: 5,
+    });
+    await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+  }, 2_000);
+});
+
+describe("#529 bounded lifecycle lock", () => {
+  function createEngine(baseDir: string): AgentEngine {
+    mkdirSync(baseDir, { recursive: true });
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    return new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+      lifecycleLockAcquireTimeoutMs: 40,
+      lifecycleLockHoldTimeoutMs: 80,
+    });
+  }
+
+  it("fails a queued caller fast and names the holder instead of waiting forever", async () => {
+    const baseDir = join(tmpdir(), `cmux529-engine-${process.pid}`);
+    const engine = createEngine(baseDir);
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    // A wedged holder: an operation that never settles.
+    const wedged = engine.runLifecycleMutation(
+      () => new Promise<void>(() => {}),
+      { label: "wedged-op" },
+    );
+    void wedged.catch(() => {});
+
+    const error = await engine
+      .runLifecycleMutation(async () => "queued", { label: "queued-op" })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+    expect(error).toBeInstanceOf(LifecycleLockTimeoutError);
+    const timeout = error as LifecycleLockTimeoutError;
+    expect(timeout.holder).toBe("wedged-op");
+    expect(timeout.waiter).toBe("queued-op");
+    expect(timeout.heldForMs).toBeGreaterThanOrEqual(0);
+    expect(timeout.message).toContain("wedged-op");
+
+    // A wedged operation must not poison the tail: once the hold guard fires,
+    // later callers get the lock instead of inheriting the deadlock.
+    await expect(
+      engine.runLifecycleMutation(async () => "later", { label: "later-op" }),
+    ).resolves.toBe("later");
+  }, 5_000);
+
+  it("reports lock holder, held-for-ms and queue depth", async () => {
+    const baseDir = join(tmpdir(), `cmux529-engine2-${process.pid}`);
+    const engine = createEngine(baseDir);
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    let release!: () => void;
+    const held = engine.runLifecycleMutation(
+      () => new Promise<void>((resolve) => (release = resolve)),
+      { label: "held-op" },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const state = engine.lifecycleLockState();
+    expect(state.holder).toBe("held-op");
+    expect(state.held_for_ms).toBeGreaterThanOrEqual(0);
+    expect(state.queue_depth).toBe(0);
+    release();
+    await held;
+    expect(engine.lifecycleLockState().holder).toBeNull();
+  });
+});
+
+describe("#529 control_health observability", () => {
+  it("reports daemon lifecycle state so a dead daemon looks different", async () => {
+    resetDaemonLifecycleState();
+    const health = await collectControlHealth({
+      execFile: async () => ({ stdout: "", stderr: "" }),
+      homeDir: TEST_ROOT,
+      tmpDir: TEST_ROOT,
+    });
+    expect(health.daemon_lifecycle).toBeDefined();
+    expect(health.daemon_lifecycle.spawn_attempts).toBe(0);
+    expect(health.daemon_lifecycle.last_exit).toBeNull();
+  });
+});

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -208,13 +208,17 @@ describe("#529 daemon socket path handling", () => {
     expect(existsSync(path)).toBe(true);
   });
 
-  it("keeps a successor's receipt when it reuses the classified pid", async () => {
-    // Macroscope (#530): comparing only the pid deleted a successor's receipt
-    // when the pid was recycled, destroying the evidence later probes rely on.
-    const path = testSocketPath("receipt-pid-reuse");
+  it("restores, never deletes, a receipt a successor rewrote", async () => {
+    // Macroscope + Codex (#530): comparing the receipt and THEN unlinking left a
+    // window in which a successor could rewrite it and have its brand-new
+    // receipt deleted — which later strips the live-owner evidence protecting
+    // that successor's own shutdown placeholder. Validation and deletion are now
+    // made atomic by the same shelter-and-verify trick used for the socket.
+    const path = testSocketPath("receipt-rewritten");
     rmSync(path, { force: true });
     writeFileSync(path, "");
-    writeFileSync(`${path}.owner`, "999999 111\n");
+    // What is actually on disk is the SUCCESSOR's receipt.
+    writeFileSync(`${path}.owner`, "424242 999\n");
     cleanups.push(() => {
       rmSync(path, { force: true });
       rmSync(`${path}.owner`, { force: true });
@@ -223,20 +227,16 @@ describe("#529 daemon socket path handling", () => {
     await expect(
       unlinkStaleSocket(path, {
         probe: async () => "stale",
-        // The successor rewrites the receipt with the SAME pid but a different
-        // start time between classification and reap.
-        readOwnerReceipt: (() => {
-          let call = 0;
-          return () => {
-            call += 1;
-            return { pid: 999999, startedAtMs: call === 1 ? 111 : 222 };
-          };
-        })(),
+        // We classified a DIFFERENT receipt than the one now on disk.
+        readOwnerReceipt: () => ({ pid: 111111, startedAtMs: 1 }),
         ownerAlive: () => false,
+        logger: { error: () => {} },
       }),
     ).resolves.toBe("reaped");
-    // Socket reaped, but the successor's receipt survives.
+
+    // Socket reaped, but the successor's receipt survives intact.
     expect(existsSync(`${path}.owner`)).toBe(true);
+    expect(readFileSync(`${path}.owner`, "utf8").trim()).toBe("424242 999");
   });
 
   it("F8: refuses a socket that appeared during classification", async () => {
@@ -655,6 +655,50 @@ describe("#530 daemon handoff instead of a competing backend", () => {
 
     expect(attached).toBe(false);
   }, 5_000);
+
+  it("classifies owner-busy from the RECEIPT when stderr never arrived", async () => {
+    // Codex P1: the daemon prints its marker then calls process.exit(1), so the
+    // piped stderr can still be in flight when `exit` fires. If the decision
+    // rested on stderr alone, an empty excerpt made the entry skip the handoff
+    // and start an in-process backend beside a still-draining daemon.
+    const path = testSocketPath("owner-busy-oob");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    writeFileSync(`${path}.owner`, daemonSocketOwnerReceiptText());
+    cleanups.push(() => {
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    const noStderr = new DaemonStartupFailedError({
+      socketPath: path,
+      exitCode: 1,
+      stderrExcerpt: "",
+    });
+    // Out-of-band evidence: a LIVE owner still claims the path.
+    expect(isOwnerBusyFailure(noStderr, path)).toBe(true);
+
+    // A dead owner is not owner-busy, so a genuinely broken daemon still falls
+    // through to the fallback instead of waiting out a handoff that never comes.
+    const deadPath = testSocketPath("owner-busy-dead");
+    rmSync(deadPath, { force: true });
+    writeFileSync(deadPath, "");
+    writeFileSync(`${deadPath}.owner`, "999999 1\n");
+    cleanups.push(() => {
+      rmSync(deadPath, { force: true });
+      rmSync(`${deadPath}.owner`, { force: true });
+    });
+    expect(
+      isOwnerBusyFailure(
+        new DaemonStartupFailedError({
+          socketPath: deadPath,
+          exitCode: 1,
+          stderrExcerpt: "",
+        }),
+        deadPath,
+      ),
+    ).toBe(false);
+  });
 
   it("classifies a socket-in-use daemon exit as owner-busy, not a hard failure", () => {
     const busy = new DaemonStartupFailedError({

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -23,7 +23,11 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { CmuxLayerDaemon, unlinkStaleSocket } from "../src/daemon.js";
+import {
+  CmuxLayerDaemon,
+  daemonSocketOwnerReceiptText,
+  unlinkStaleSocket,
+} from "../src/daemon.js";
 import {
   DaemonSocketInUseError,
   DaemonStartupFailedError,
@@ -88,6 +92,7 @@ describe("#529 daemon socket path handling", () => {
     // instead of reaping a leftover that provably has no live owner.
     const path = testSocketPath("dead-owner-leftover");
     rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
     writeFileSync(path, "");
     expect(statSync(path).isSocket()).toBe(false);
 
@@ -105,6 +110,87 @@ describe("#529 daemon socket path handling", () => {
       rmSync(path, { force: true });
     });
     await daemon.start();
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("F3: refuses a shutdown placeholder whose receipt names a LIVE owner", async () => {
+    // Codex P1: closeListener() parks a regular-file placeholder BEFORE
+    // waitForDrain(), so a daemon still draining in-flight requests presents a
+    // non-socket path for up to 5s. Classifying every non-socket as stale let a
+    // racing autostart reap it and bind a SECOND live daemon over the same
+    // state dir. The receipt must outrank the probe.
+    const path = testSocketPath("live-owner-placeholder");
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+    writeFileSync(path, "");
+    // This process is unquestionably alive, so it stands in for the drainer.
+    writeFileSync(`${path}.owner`, daemonSocketOwnerReceiptText());
+    cleanups.push(() => {
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).ownerPid).toBe(process.pid);
+    // The draining daemon's placeholder survives.
+    expect(existsSync(path)).toBe(true);
+    expect(existsSync(`${path}.owner`)).toBe(true);
+  });
+
+  it("F3: still reaps a placeholder whose receipt names a DEAD owner", async () => {
+    // The #529 reboot case must keep working: leftover placeholder plus a
+    // receipt naming a pid that no longer exists.
+    const path = testSocketPath("dead-owner-placeholder");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    writeFileSync(`${path}.owner`, "999999 1\n");
+    cleanups.push(() => {
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    await expect(unlinkStaleSocket(path)).resolves.toBe("reaped");
+    expect(existsSync(path)).toBe(false);
+    expect(existsSync(`${path}.owner`)).toBe(false);
+  });
+
+  it("F8: refuses a socket that appeared during classification", async () => {
+    // Codex addendum: with the path ABSENT at classification, observedIdentity
+    // is null and the superseded comparison used to be skipped entirely — so a
+    // successor that bound mid-classification was unlinked.
+    const path = testSocketPath("appeared-mid-classify");
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+
+    const successor = net.createServer(() => {});
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          successor.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    // Path is absent now; the successor binds while the probe is "running".
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => {
+        await new Promise<void>((resolve) =>
+          successor.listen(path, () => resolve()),
+        );
+        return "stale";
+      },
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).probe).toBe("superseded");
+    // The successor's live socket survives.
     expect(statSync(path).isSocket()).toBe(true);
   });
 

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -138,6 +138,40 @@ describe("#529 daemon socket path handling", () => {
     expect(readFileSync(path, "utf8")).toBe("important user data\n");
   });
 
+  it("refuses an EMPTY file it cannot prove it created", async () => {
+    // Macroscope (#530): an empty regular file is cmuxlayer's placeholder shape,
+    // but also the shape of an operator's lock or sentinel file. With no owner
+    // receipt AND a non-canonical socket name there is no ownership evidence,
+    // so a mistyped CMUXLAYER_DAEMON_SOCKET must not delete it.
+    const path = join(TEST_ROOT, `operator-lock-${process.pid}.lock`);
+    mkdirSync(TEST_ROOT, { recursive: true });
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+    writeFileSync(path, "");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketPathOccupiedError);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("still reaps a receiptless placeholder at the CANONICAL socket name", async () => {
+    // The #529 upgrade path: 0.4.56 never wrote receipts, so a leftover
+    // placeholder at cmuxlayer's own canonical filename must stay reapable.
+    const dir = join(TEST_ROOT, `canon-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "cmuxlayer-stated.sock");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    await expect(unlinkStaleSocket(path)).resolves.toBe("reaped");
+    expect(existsSync(path)).toBe(false);
+  });
+
   it("F3: refuses a shutdown placeholder whose receipt names a LIVE owner", async () => {
     // Codex P1: closeListener() parks a regular-file placeholder BEFORE
     // waitForDrain(), so a daemon still draining in-flight requests presents a

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -35,7 +35,11 @@ import {
   daemonLifecycleSnapshot,
   resetDaemonLifecycleState,
 } from "../src/daemon-lifecycle-state.js";
-import { awaitDaemonReadiness } from "../src/entry.js";
+import {
+  awaitDaemonHandoff,
+  awaitDaemonReadiness,
+  isOwnerBusyFailure,
+} from "../src/entry.js";
 import { AgentEngine, LifecycleLockTimeoutError } from "../src/agent-engine.js";
 import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
@@ -250,6 +254,50 @@ describe("#529 daemon socket path handling", () => {
     expect(statSync(path).isSocket()).toBe(true);
   });
 
+  it("restores, never deletes, a successor's socket grabbed by the reap", async () => {
+    // Codex P1: a dev/ino check followed by a separate unlink(2) cannot be made
+    // safe — two successors can both validate the old inode and the loser then
+    // deletes the winner's LIVE socket. The reap now moves the object with
+    // rename(2) and verifies identity on a name nobody else knows, so anything
+    // it did not mean to move is put back rather than destroyed.
+    const path = testSocketPath("reap-restores-successor");
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+    writeFileSync(path, "");
+
+    const successor = net.createServer(() => {});
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          successor.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    // Classification sees the placeholder; the successor swaps in its live
+    // socket before the reap runs.
+    let probed = false;
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => {
+        if (!probed) {
+          probed = true;
+          rmSync(path, { force: true });
+          await new Promise<void>((resolve) =>
+            successor.listen(path, () => resolve()),
+          );
+        }
+        return "stale";
+      },
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    // The successor's live socket is still at the well-known path.
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
   it("refuses a LIVE owner with a structured error instead of a bare throw", async () => {
     const path = testSocketPath("live-owner");
     rmSync(path, { force: true });
@@ -443,5 +491,59 @@ describe("#529 control_health observability", () => {
     expect(health.daemon_lifecycle).toBeDefined();
     expect(health.daemon_lifecycle.spawn_attempts).toBe(0);
     expect(health.daemon_lifecycle.last_exit).toBeNull();
+  });
+});
+
+describe("#530 daemon handoff instead of a competing backend", () => {
+  it("waits for a draining owner and attaches instead of falling back in-process", async () => {
+    // Codex P1: when autostart overlaps a clean shutdown, our spawned daemon
+    // refuses (live-owner placeholder) and exits at once. Falling back
+    // in-process there starts a SECOND backend against the same registry while
+    // the old daemon is still draining in-flight mutations.
+    let probes = 0;
+    const attached = await awaitDaemonHandoff({
+      socketPath: "/tmp/cmux529/draining.sock",
+      // The drainer hands off on the third probe.
+      probeDaemon: async () => ++probes >= 3,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 2_000,
+      pollMs: 5,
+      spawnDaemon: vi.fn().mockResolvedValue({ pid: 1 }),
+      awaitReady: vi.fn().mockResolvedValue(undefined),
+      logger: { error: vi.fn() },
+    });
+
+    expect(attached).toBe(true);
+  }, 5_000);
+
+  it("gives up on the handoff instead of waiting forever", async () => {
+    const attached = await awaitDaemonHandoff({
+      socketPath: "/tmp/cmux529/never.sock",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 30,
+      pollMs: 5,
+      spawnDaemon: vi.fn().mockRejectedValue(new Error("nope")),
+      awaitReady: vi.fn(),
+      logger: { error: vi.fn() },
+    });
+
+    expect(attached).toBe(false);
+  }, 5_000);
+
+  it("classifies a socket-in-use daemon exit as owner-busy, not a hard failure", () => {
+    const busy = new DaemonStartupFailedError({
+      socketPath: "/tmp/cmux529/x.sock",
+      exitCode: 1,
+      stderrExcerpt: "[cmuxlayer-daemon] fatal code=EDAEMONSOCKETINUSE",
+    });
+    expect(isOwnerBusyFailure(busy)).toBe(true);
+
+    const broken = new DaemonStartupFailedError({
+      socketPath: "/tmp/cmux529/x.sock",
+      exitCode: 1,
+      stderrExcerpt: "SyntaxError: Unexpected token",
+    });
+    expect(isOwnerBusyFailure(broken)).toBe(false);
   });
 });

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -275,6 +275,44 @@ describe("#529 daemon socket path handling", () => {
     expect(statSync(path).isSocket()).toBe(true);
   });
 
+  it("refuses when a successor REUSES the classified inode number", async () => {
+    // #530 CI: this is the real Linux failure, made deterministic.
+    //
+    // dev/ino alone cannot identify an object across delete-and-recreate.
+    // Linux hands the freed inode number straight back, so the successor's new
+    // SOCKET carried the exact dev/ino of the regular-file placeholder we had
+    // classified — `sameIdentity` said "still ours" and the reap deleted a LIVE
+    // socket. macOS allocated a different inode, which is the only reason this
+    // passed locally. Identity now includes the node type, which is stable
+    // across rename(2) and cannot collide.
+    const path = testSocketPath("inode-reuse");
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+    writeFileSync(path, "");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    let call = 0;
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => "stale",
+      // Same dev AND same ino both times — only the kind differs, exactly as
+      // an inode-reusing filesystem reports it.
+      readIdentity: async () => {
+        call += 1;
+        return call === 1
+          ? { dev: 1, ino: 42, kind: "file" as const }
+          : { dev: 1, ino: 42, kind: "socket" as const };
+      },
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).probe).toBe("superseded");
+    // Nothing was deleted.
+    expect(existsSync(path)).toBe(true);
+  });
+
   it("restores, never deletes, a successor's socket grabbed by the reap", async () => {
     // Codex P1: a dev/ino check followed by a separate unlink(2) cannot be made
     // safe — two successors can both validate the old inode and the loser then
@@ -562,6 +600,44 @@ describe("#530 daemon handoff instead of a competing backend", () => {
     expect(spawnDaemon).toHaveBeenCalledTimes(1);
     // Proof it waited rather than firing immediately.
     expect(clearChecks).toBeGreaterThan(3);
+  }, 5_000);
+
+  it("treats only ENOENT as a cleared placeholder", async () => {
+    // Macroscope (#530): every stat() error read as "placeholder gone", so an
+    // EACCES/EIO path burned the single respawn on a daemon that would refuse.
+    const { mkdirSync: mk, rmSync: rm } = await import("node:fs");
+    const dir = join(tmpdir(), `cmux529-perm-${process.pid}`);
+    rm(dir, { recursive: true, force: true });
+    mk(dir, { recursive: true });
+    const guarded = join(dir, "sub", "daemon.sock");
+    mk(join(dir, "sub"), { recursive: true });
+    // Make the parent directory unreadable so stat() fails with EACCES.
+    const { chmodSync } = await import("node:fs");
+    chmodSync(join(dir, "sub"), 0o000);
+    cleanups.push(() => {
+      try {
+        chmodSync(join(dir, "sub"), 0o755);
+      } catch {
+        /* best effort */
+      }
+      rm(dir, { recursive: true, force: true });
+    });
+
+    const spawnDaemon = vi.fn().mockResolvedValue({ pid: 9 });
+    const attached = await awaitDaemonHandoff({
+      socketPath: guarded,
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 60,
+      pollMs: 5,
+      spawnDaemon,
+      awaitReady: vi.fn().mockResolvedValue(undefined),
+      logger: { error: vi.fn() },
+    });
+
+    expect(attached).toBe(false);
+    // EACCES is not "cleared", so the respawn attempt was never spent.
+    expect(spawnDaemon).not.toHaveBeenCalled();
   }, 5_000);
 
   it("gives up on the handoff instead of waiting forever", async () => {

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -158,6 +158,62 @@ describe("#529 daemon socket path handling", () => {
     expect(existsSync(`${path}.owner`)).toBe(false);
   });
 
+  it("fails closed on an inconclusive probe even with a dead-pid receipt", async () => {
+    // Macroscope (#530, post-cf2f66c): the receipt write is best-effort and an
+    // fd-activated daemon never writes one, so a stale receipt naming a dead
+    // pid can coexist with a LIVE owner. Reaping on that combination orphans a
+    // running daemon and lets a second one bind the same control plane.
+    const path = testSocketPath("unknown-dead-receipt");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    writeFileSync(`${path}.owner`, "999999 1\n");
+    cleanups.push(() => {
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => "unknown",
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).probe).toBe("unknown");
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("keeps a successor's receipt when it reuses the classified pid", async () => {
+    // Macroscope (#530): comparing only the pid deleted a successor's receipt
+    // when the pid was recycled, destroying the evidence later probes rely on.
+    const path = testSocketPath("receipt-pid-reuse");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    writeFileSync(`${path}.owner`, "999999 111\n");
+    cleanups.push(() => {
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    await expect(
+      unlinkStaleSocket(path, {
+        probe: async () => "stale",
+        // The successor rewrites the receipt with the SAME pid but a different
+        // start time between classification and reap.
+        readOwnerReceipt: (() => {
+          let call = 0;
+          return () => {
+            call += 1;
+            return { pid: 999999, startedAtMs: call === 1 ? 111 : 222 };
+          };
+        })(),
+        ownerAlive: () => false,
+      }),
+    ).resolves.toBe("reaped");
+    // Socket reaped, but the successor's receipt survives.
+    expect(existsSync(`${path}.owner`)).toBe(true);
+  });
+
   it("F8: refuses a socket that appeared during classification", async () => {
     // Codex addendum: with the path ABSENT at classification, observedIdentity
     // is null and the superseded comparison used to be skipped entirely — so a

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -529,12 +529,39 @@ describe("#530 daemon handoff instead of a competing backend", () => {
       sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
       timeoutMs: 2_000,
       pollMs: 5,
+      isPathClear: async () => false,
       spawnDaemon: vi.fn().mockResolvedValue({ pid: 1 }),
       awaitReady: vi.fn().mockResolvedValue(undefined),
       logger: { error: vi.fn() },
     });
 
     expect(attached).toBe(true);
+  }, 5_000);
+
+  it("defers the respawn until the drainer's placeholder is gone", async () => {
+    // Macroscope (#530): firing the single respawn on the first probe failure
+    // spent it while the placeholder was still present, so that daemon refused
+    // too and nothing started once the path finally cleared.
+    let clearChecks = 0;
+    const spawnDaemon = vi.fn().mockResolvedValue({ pid: 7 });
+
+    const attached = await awaitDaemonHandoff({
+      socketPath: "/tmp/cmux529/deferred.sock",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 2_000,
+      pollMs: 5,
+      // The placeholder survives the first three checks.
+      isPathClear: async () => ++clearChecks > 3,
+      spawnDaemon,
+      awaitReady: vi.fn().mockResolvedValue(undefined),
+      logger: { error: vi.fn() },
+    });
+
+    expect(attached).toBe(true);
+    expect(spawnDaemon).toHaveBeenCalledTimes(1);
+    // Proof it waited rather than firing immediately.
+    expect(clearChecks).toBeGreaterThan(3);
   }, 5_000);
 
   it("gives up on the handoff instead of waiting forever", async () => {
@@ -544,6 +571,7 @@ describe("#530 daemon handoff instead of a competing backend", () => {
       sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
       timeoutMs: 30,
       pollMs: 5,
+      isPathClear: async () => true,
       spawnDaemon: vi.fn().mockRejectedValue(new Error("nope")),
       awaitReady: vi.fn(),
       logger: { error: vi.fn() },

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -168,6 +168,38 @@ describe("#529 daemon readiness propagation", () => {
     );
   });
 
+  it("reports the exit code of a daemon that died BEFORE readiness attached", async () => {
+    // #530 review (Macroscope): node never replays a missed `exit`, so a child
+    // that failed fast used to surface as a readiness TIMEOUT after the full
+    // deadline instead of the exit code that explains it.
+    const child = Object.assign(new EventEmitter(), {
+      pid: 5150,
+      exitCode: 1,
+      signalCode: null,
+    });
+    const alreadyDead = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/died-early.sock",
+      child,
+      readStderr: () =>
+        "[cmuxlayer-daemon] fatal Error: socket is already in use",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      // A deadline far beyond the test: reaching it would be the bug.
+      timeoutMs: 30_000,
+      pollMs: 5,
+    });
+
+    const error = await alreadyDead.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonStartupFailedError);
+    expect((error as DaemonStartupFailedError).exitCode).toBe(1);
+    expect((error as DaemonStartupFailedError).stderrExcerpt).toContain(
+      "socket is already in use",
+    );
+  }, 3_000);
+
   it("bounds readiness so a silent daemon never leaves the promise unsettled", async () => {
     const readiness = awaitDaemonReadiness({
       socketPath: "/tmp/cmux529/silent.sock",

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -17,6 +17,7 @@ import { EventEmitter } from "node:events";
 import {
   existsSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -30,6 +31,7 @@ import {
 } from "../src/daemon.js";
 import {
   DaemonSocketInUseError,
+  DaemonSocketPathOccupiedError,
   DaemonStartupFailedError,
   DaemonReadinessTimeoutError,
   daemonLifecycleSnapshot,
@@ -115,6 +117,25 @@ describe("#529 daemon socket path handling", () => {
     });
     await daemon.start();
     expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("never deletes a non-empty file at the socket path", async () => {
+    // Codex P1: a mistyped CMUXLAYER_DAEMON_SOCKET pointing at real data used to
+    // classify as a stale daemon artifact and get deleted. Only cmuxlayer's own
+    // shape — an EMPTY regular placeholder, or a dead socket — is reapable.
+    const path = testSocketPath("user-data");
+    rmSync(path, { force: true });
+    rmSync(`${path}.owner`, { force: true });
+    writeFileSync(path, "important user data\n");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketPathOccupiedError);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("important user data\n");
   });
 
   it("F3: refuses a shutdown placeholder whose receipt names a LIVE owner", async () => {

--- a/tests/daemon-lifecycle-state.test.ts
+++ b/tests/daemon-lifecycle-state.test.ts
@@ -1,0 +1,108 @@
+/**
+ * #530 round-2 review P2-3: daemon lifecycle state is GENERATION-scoped.
+ *
+ * Carrying a dead generation's exit forward made `control_health` warn "this
+ * runtime is not daemon-backed" permanently, even after a healthy successor
+ * daemon was serving — a false alarm that trains readers to ignore the warning
+ * that actually matters.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DaemonReadinessTimeoutError,
+  DaemonSocketInUseError,
+  DaemonStartupFailedError,
+  daemonLifecycleSnapshot,
+  daemonStderrExcerpt,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+  recordDaemonSocketInUse,
+  recordDaemonSocketReap,
+  recordDaemonSpawnAttempt,
+  resetDaemonLifecycleState,
+} from "../src/daemon-lifecycle-state.js";
+
+describe("daemon lifecycle state", () => {
+  beforeEach(() => {
+    resetDaemonLifecycleState();
+  });
+
+  it("starts empty", () => {
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.spawn_attempts).toBe(0);
+    expect(snapshot.last_exit).toBeNull();
+    expect(snapshot.last_error).toBeNull();
+    expect(snapshot.socket_path).toBeNull();
+  });
+
+  it("clears the previous generation's failure state on a new spawn attempt", () => {
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 100 });
+    recordDaemonExit({
+      code: 1,
+      signal: null,
+      pid: 100,
+      stderrExcerpt: "boom",
+    });
+    recordDaemonLifecycleError("spawn failed");
+    recordDaemonSocketInUse({ path: "/tmp/gen.sock", ownerPid: 100 });
+
+    const failed = daemonLifecycleSnapshot();
+    expect(failed.last_exit?.code).toBe(1);
+    expect(failed.last_error).toBe("spawn failed");
+    expect(failed.last_socket_in_use).not.toBeNull();
+
+    // A healthy successor generation starts here.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+
+    const successor = daemonLifecycleSnapshot();
+    expect(successor.last_exit).toBeNull();
+    expect(successor.last_error).toBeNull();
+    expect(successor.last_socket_in_use).toBeNull();
+    // Cumulative facts survive: the counter is how you see spawn churn.
+    expect(successor.spawn_attempts).toBe(2);
+    expect(successor.last_spawn_pid).toBe(200);
+  });
+
+  it("keeps reap history across generations", () => {
+    recordDaemonSocketReap({
+      path: "/tmp/gen.sock",
+      reason: "dead-owner-leftover",
+    });
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 300 });
+    expect(daemonLifecycleSnapshot().last_socket_reap?.reason).toBe(
+      "dead-owner-leftover",
+    );
+  });
+
+  it("bounds the stderr excerpt from the tail", () => {
+    const excerpt = daemonStderrExcerpt(`${"x".repeat(5_000)}TAIL`);
+    expect(excerpt.length).toBeLessThanOrEqual(4_000);
+    expect(excerpt.endsWith("TAIL")).toBe(true);
+    expect(daemonStderrExcerpt(undefined)).toBe("");
+  });
+
+  it("carries structured detail on every daemon failure error", () => {
+    const inUse = new DaemonSocketInUseError({
+      socketPath: "/tmp/a.sock",
+      ownerPid: 42,
+      probe: "superseded",
+    });
+    expect(inUse.code).toBe("EDAEMONSOCKETINUSE");
+    expect(inUse.ownerPid).toBe(42);
+    expect(inUse.message).toContain("superseded");
+
+    const failed = new DaemonStartupFailedError({
+      socketPath: "/tmp/a.sock",
+      exitCode: 1,
+      stderrExcerpt: "fatal: socket is already in use",
+    });
+    expect(failed.exitCode).toBe(1);
+    expect(failed.message).toContain("fatal: socket is already in use");
+
+    const timedOut = new DaemonReadinessTimeoutError({
+      socketPath: "/tmp/a.sock",
+      waitedMs: 5_000,
+    });
+    expect(timedOut.waitedMs).toBe(5_000);
+    expect(timedOut.code).toBe("EDAEMONREADINESSTIMEOUT");
+  });
+});

--- a/tests/daemon-lifecycle-state.test.ts
+++ b/tests/daemon-lifecycle-state.test.ts
@@ -7,11 +7,16 @@
  * that actually matters.
  */
 import { beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   DaemonReadinessTimeoutError,
   DaemonSocketInUseError,
   DaemonStartupFailedError,
   daemonLifecycleSnapshot,
+  daemonLifecycleSnapshotFor,
+  daemonLifecycleSidecarPath,
   daemonStderrExcerpt,
   recordDaemonExit,
   recordDaemonLifecycleError,
@@ -98,6 +103,41 @@ describe("daemon lifecycle state", () => {
     recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
     recordDaemonExit({ code: 1, signal: null, stderrExcerpt: "no pid" });
     expect(daemonLifecycleSnapshot().last_exit?.code).toBe(1);
+  });
+
+  it("crosses the process boundary through the sidecar", () => {
+    // Codex P2 (#530): the PROXY spawns the daemon and records its exits, but
+    // `control_health` is served by the detached DAEMON — a different process
+    // with its own module-local snapshot. Without a sidecar the health block
+    // reported zeros in exactly the normal topology.
+    const dir = mkdtempSync(join(tmpdir(), "cmux530-sidecar-"));
+    const socketPath = join(dir, "cmuxlayer-stated.sock");
+
+    // Proxy side.
+    recordDaemonSpawnAttempt({ socketPath, pid: 4242 });
+    recordDaemonExit({ code: 1, signal: null, pid: 4242, stderrExcerpt: "boom" });
+    expect(existsSync(daemonLifecycleSidecarPath(socketPath))).toBe(true);
+
+    // Daemon side: a fresh process with an empty local record.
+    resetDaemonLifecycleState();
+    expect(daemonLifecycleSnapshot().spawn_attempts).toBe(0);
+
+    const merged = daemonLifecycleSnapshotFor(socketPath);
+    expect(merged.spawn_attempts).toBe(1);
+    expect(merged.last_exit?.code).toBe(1);
+    expect(merged.last_exit?.stderr_excerpt).toBe("boom");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("prefers this process's own record over the sidecar", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmux530-sidecar2-"));
+    const socketPath = join(dir, "cmuxlayer-stated.sock");
+    recordDaemonSpawnAttempt({ socketPath, pid: 1 });
+    recordDaemonExit({ code: 9, signal: null, pid: 1, stderrExcerpt: "local" });
+    // Local activity exists, so the sidecar must not override it.
+    expect(daemonLifecycleSnapshotFor(socketPath).last_exit?.code).toBe(9);
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("keeps reap history across generations", () => {

--- a/tests/daemon-lifecycle-state.test.ts
+++ b/tests/daemon-lifecycle-state.test.ts
@@ -62,6 +62,44 @@ describe("daemon lifecycle state", () => {
     expect(successor.last_spawn_pid).toBe(200);
   });
 
+  it("ignores a late exit from a superseded daemon generation", () => {
+    // #530 final pass F9 (Codex addendum): the OLD child's `exit` can land
+    // AFTER a healthy successor has spawned. Recording it re-poisoned
+    // `last_exit` and re-raised the "not daemon-backed" warning against a
+    // daemon that is serving fine.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 100 });
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({
+      code: 1,
+      signal: null,
+      pid: 100,
+      stderrExcerpt: "late",
+    });
+
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.last_exit).toBeNull();
+    expect(snapshot.last_spawn_pid).toBe(200);
+  });
+
+  it("still records an exit from the CURRENT generation", () => {
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({
+      code: 3,
+      signal: null,
+      pid: 200,
+      stderrExcerpt: "boom",
+    });
+    expect(daemonLifecycleSnapshot().last_exit?.code).toBe(3);
+  });
+
+  it("records an exit whose pid is unknown rather than dropping it", () => {
+    // An unknown pid cannot be attributed to a generation; dropping it would
+    // reintroduce silence, so it is recorded.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({ code: 1, signal: null, stderrExcerpt: "no pid" });
+    expect(daemonLifecycleSnapshot().last_exit?.code).toBe(1);
+  });
+
   it("keeps reap history across generations", () => {
     recordDaemonSocketReap({
       path: "/tmp/gen.sock",


### PR DESCRIPTION
Fixes #529.

> **Round-2 correction.** An earlier version of this body claimed "Resume-path parity — spawn and resume enter through the same two gates". **That was false.** The reviewer caught it; I verified it and the correct statement is in [Lifecycle gating — what is and is not covered](#lifecycle-gating--what-is-and-is-not-covered) below. Follow-up filed as #531.

## Root cause — proven, not assumed

`CmuxLayerDaemon.detachOwnedSocketPath()` parks an **empty regular file** at the socket path on every clean shutdown (`writeFile(this.socketPath, "", { flag: "wx" })`) so a racing daemon cannot bind mid-shutdown — and nothing ever removed it. `connect(2)` on a regular file answers `ENOTSOCK`, which `probeSocket` re-threw and `unlinkStaleSocket` propagated. A reboot's SIGTERM therefore leaves exactly the leftover the successor daemon cannot reap, it exits code 1, and nothing propagated that exit to the readiness waiters.

Measured on a short-path socket (macOS, node 22.22):

```
regular file: ERR:ENOTSOCK
missing:      ERR:ENOENT
```

## Failing-before / passing-after

Harness-free probe against the **unfixed** sources:

```
BEFORE
A: daemon.start() FATALED code=ENOTSOCK message=connect ENOTSOCK .../leftover.sock
B: queued runLifecycleMutation -> STILL PENDING after 3000ms (unbounded wait)

AFTER
A: daemon.start() SUCCEEDED (leftover reaped)
B2: queued runLifecycleMutation (200ms bound) -> REJECTED:LifecycleLockTimeoutError: lifecycle lock
    acquire timed out after 202ms for "queued-op"; holder="wedged-op" held_for_ms=202 queue_depth=1
```

Committed behavioural bites (`tests/daemon-deadlock-529-behaviour.test.ts`) import **only symbols that exist on `main`** and steer the new bounds through environment variables, so they keep biting on the unfixed tree and survive any later rename of the symbols this PR adds.

`tests/daemon-deadlock-529.test.ts` against the unfixed tree: `Cannot find module '../src/daemon-lifecycle-state.js'` → `Test Files 1 failed (1)`.

## What changed

1. **`unlinkStaleSocket` distinguishes a live owner from a dead-owner leftover** (`src/daemon.ts`). A path that exists and is not a socket is stale by construction. Connect errors that prove no listener (`ECONNREFUSED`/`ECONNRESET`/`ENOTSOCK`/`ENOTCONN`/`EPIPE`) reap. An inconclusive probe is no longer guessed as "live": it is resolved against a `<socket>.owner` pid receipt the daemon writes on listen, and fails closed when the receipt is absent or names a live pid. dev/ino is captured at classification and revalidated immediately before unlink, so a path replaced under us raises `DaemonSocketInUseError` (probe `superseded`) instead of deleting a successor's socket. `closeListener()` now removes the placeholder, and the owner receipt only when it still names this pid.
2. **Daemon readiness always settles** (`src/entry.ts`, `src/daemon-spawn.ts`). `awaitDaemonReadiness()` wires the child's `exit`/`error` events into the rejection path and hard-bounds the deadline: `DaemonStartupFailedError` carries exit code, signal and captured stderr; `DaemonReadinessTimeoutError` carries waited-ms. An abort flag stops polling the moment the failure path wins. `spawnDaemonProcess` pipes stderr (still forwarded, now honoring backpressure), and both the daemon and the spawner guard `process.stderr` against async EPIPE.
3. **No unbounded wait on the path** (`src/agent-engine.ts`, `src/server.ts`). `runLifecycleMutation` bounds the acquire (default **45s**) and fails fast with `LifecycleLockTimeoutError` naming holder, held-for-ms and queue depth. A waiter that gives up chains its abandoned slot behind `previous` rather than resolving it, so **mutual exclusion holds**; the hold guard (default **120s**) is the only liveness path past a holder that never settles. `awaitLifecycleStart` is bounded the same way (default 60s). Both bounds sit inside the ~120s harness inactivity window. Call sites carry labels so the holder in an error is a name, not "unknown".
4. **`control_health` reports daemon lifecycle state** (`src/control-health.ts`, `src/server.ts`). New `daemon_lifecycle` block: spawn attempts, last spawn at/pid, last daemon exit code + signal + stderr excerpt, last socket reap and reason, last socket-in-use decision, last error, plus `lifecycle_lock` (holder, held-for-ms, queue depth, timeouts, forced releases, last timeout) and `lifecycle_start` (started/settled/waiting-for-ms/timeouts/error). Failure state is **generation-scoped**: a new spawn attempt clears the dead generation's exit/error so a healthy successor stops warning "not daemon-backed", while counters and reap history survive.

## Lifecycle gating — what is and is not covered

Verified by grep over the full handler span, not inferred:

| Path | `awaitLifecycleStart` | `runLifecycleMutation` |
|---|---|---|
| `spawn_agent` resume branch (`src/server.ts:12829`, inside `if (args.resume_agent_id)` at `12798`) | yes — bounded by this PR | no |
| `spawn_agent` new-spawn branch | **no gate at all** | no |
| `engine.resumeAgent()` | n/a | no |

`spawn_agent` spans `12607-13683` at head `cf2f66c`; `12829` is its only `awaitLifecycleStart()`.

So: **the resume branch is covered by the bound this PR adds. The new-spawn branch is not** — it is protected only indirectly, by readiness propagation falling back to the in-process runtime when the daemon dies before ready. That is a weaker and different guarantee. The missing gate is **pre-existing**, not introduced here, and is filed as **#531** rather than fixed in this PR.

Corrected wording elsewhere: `DaemonSocketInUseError` does **not** mean "the caller connects to it" inside the daemon — `daemon.start()` fatals, readiness rejects, and the entry re-probes and either attaches to the winner or falls back in-process. The "connect to it" outcome happens at the entry layer, not in `unlinkStaleSocket`.

## Gates

- `npx tsc -p tsconfig.json --noEmit` — clean, no output.
- `bash scripts/run_tests.sh` env-stripped via `.githooks/pre-push` (not bypassed): **145 files, 3319 passed, 1 skipped**.
- `npx vitest run` plain env: **145 files, 3319 passed, 1 skipped**.

## Reviewer notes

- Force-releasing the tail after the **hold** bound still trades strict mutual exclusion for liveness, by design. What round 2 fixed is the **acquire** path, which broke exclusion with no bound involved at all — a plain bug, now covered by TEST4b.
- The repo's prettier hook reformatted a few unrelated lines in the touched files. Whitespace only.

## Backlog appended

D40 (no MCP `notifications/cancelled` handling), D41 (`probeDaemonSocket` reads a 250ms connect timeout as "daemon absent"), D42 (socket paths over the ~104-byte macOS limit have no dedicated diagnostic) — in `orchestrator/collab/2026-08-23-cmuxlayer-golden-path.md`.

Worker endpoint per the brief: **do not merge** — the lead rules ACCEPT or BLOCK.

— cmuxlayer-worker (worker) · claude-code/unknown
<!-- golem-id v1 {"seat":"cmuxlayer-worker","role":"worker","harness":"claude-code","model":"unknown","model_source":"unavailable","session":"9aca6d01","ts":"2026-08-24T13:00:00Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound daemon lifecycle lock and readiness waits to prevent deadlock
> - Bounds the lifecycle lock in `AgentEngine.runLifecycleMutation` with acquire (45s) and hold (120s) timeouts; a wedged holder is force-released so queued callers proceed instead of waiting forever
> - Bounds lifecycle start waits to 60s via `awaitBoundedLifecycleStart` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/530/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595), throwing `LifecycleStartTimeoutError` instead of hanging
> - Replaces unbounded daemon readiness polling with `awaitDaemonReadiness` in [entry.ts](https://github.com/EtanHey/cmuxlayer/pull/530/files#diff-f85e80d35f2c16b6ccf2dc6bb1214be34f47e879e725e53055b1902a4900dab7), which fails fast on child exit/error with structured errors (`DaemonStartupFailedError`, `DaemonReadinessTimeoutError`)
> - Reworks stale-socket cleanup in [daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/530/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539) to use atomic identity checks and owner receipts, refusing to delete occupied or live-owner paths instead of blindly unlinking
> - Adds daemon lifecycle state tracking with sidecar persistence and surfaces it in `control_health` output via [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/530/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d)
> - Risk: `unlinkStaleSocket` now throws `DaemonSocketInUseError` or `DaemonSocketPathOccupiedError` instead of silently removing non-empty or live-owner socket paths; callers that relied on unconditional cleanup will see refusals. Lock timeouts are configurable via `CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS` and `CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS` env vars, defaulting to 45s and 120s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff1de7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches daemon socket bind/reap, process spawn/readiness, and the lifecycle mutex that serializes agent registry mutations. Incorrect reaping or lock release can delete a live socket or allow concurrent registry writes.
> 
> **Overview**
> Stops the control-plane deadlock where a leftover shutdown placeholder at the daemon socket made autostart exit code 1, readiness never settled, and `list_agents` / `spawn_agent` hung forever.
> 
> **Daemon socket reaping** now classifies live vs stale vs occupied, writes a pid+start-time owner receipt, and reaps only dead leftovers via atomic rename-verify-or-restore. Non-empty files and live owners are refused with structured errors instead of being deleted.
> 
> **Readiness always settles.** Child `exit`/`error` (including already-dead children) reject waiters with stderr excerpts. Owner-busy refusals wait for drain/handoff instead of starting a second in-process backend. Stderr is piped with EPIPE guards.
> 
> **Lifecycle mutex is bounded** (default 45s acquire / 120s hold). Timed-out waiters fail fast with `LifecycleLockTimeoutError` while remaining chained behind the live holder. A hold guard force-releases a never-settling operation. Lifecycle start waits are similarly bounded.
> 
> `control_health` now exposes daemon spawn/exit/reap facts, lock holder/queue, and start timeouts so a dead daemon no longer looks healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1de7e26de62442e2676440422ff0c2c63455b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Final pass (head `cf2f66c`)

F1–F9 closed. Notably **F1 was a hang I introduced in round 2** — pausing the child's stderr on backpressure and resuming only on `drain`, which an errored writable never emits. F3 and CodeRabbit's ECONNRESET/EPIPE finding shared one root and got one fix: the `stale` path now consults the owner receipt, and a live owner outranks the probe. Owner receipts carry pid **and process start time**, so a pid recycled across a reboot cannot veto the reap that #529 depends on.

Empirical note on the ECONNRESET finding: 200/200 trials against a live server that destroys on accept returned `live`, never `ECONNRESET` — `connect()` wins on AF_UNIX backlog landing. The specific path CodeRabbit described is **not reproducible**, but the receipt gate closes it regardless, so the fix does not rest on that measurement.
