### PR TITLE
fix: bound and surface the daemon lifecycle deadlock (#529) — minimal scope

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -694,6 +694,19 @@ export interface AgentEngineOptions {
   fleetSidebarPublisher?: FleetSidebarPublisherLike;
   /** Render-only timeout for a working seat whose transcript/output stops advancing. */
   fleetWorkingNoProgressTimeoutMs?: number;
+  /**
+   * Bound how long a queued lifecycle mutation waits for the lock before it
+   * fails fast with a structured error naming the holder (#529).
+   * Env: CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS. 0 disables the bound.
+   */
+  lifecycleLockAcquireTimeoutMs?: number;
+  /**
+   * Bound how long one lifecycle mutation may HOLD the lock before its tail
+   * slot is force-released, so a wedged operation degrades one call instead of
+   * poisoning every later caller (#529).
+   * Env: CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS. 0 disables the guard.
+   */
+  lifecycleLockHoldTimeoutMs?: number;
   /** Bound one queued terminal submission so lifecycle sweeps cannot hang forever. */
   deliverySubmitTimeoutMs?: number;
   /** Bound one background verify observation so a hung reader cannot wedge later sweeps. */
@@ -935,6 +948,73 @@ function parsePositiveInteger(
   if (raw === undefined) return fallback;
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * #529: the lifecycle mutex used to be an unbounded chained promise. One hung
+ * holder queued every later caller forever, and an operation that never
+ * settled never ran its `finally`, permanently poisoning the tail for
+ * `list_agents`, `spawn_agent`, `send_to` and the periodic sweep. Both waits
+ * are bounded now, and the tail slot is released no matter what.
+ */
+/**
+ * #530 review P2-1: both bounds must land INSIDE the ~120s harness inactivity
+ * window, so a wedged control plane returns a structured error the caller can
+ * still read rather than being cut off mid-wait.
+ */
+export const DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = 45_000;
+export const DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = 120_000;
+
+export interface LifecycleLockTimeoutRecord {
+  holder: string | null;
+  waiter: string;
+  waited_ms: number;
+  held_for_ms: number | null;
+  queue_depth: number;
+  at: string;
+}
+
+export interface LifecycleLockState {
+  holder: string | null;
+  held_for_ms: number | null;
+  queue_depth: number;
+  acquire_timeout_ms: number;
+  hold_timeout_ms: number;
+  forced_releases: number;
+  timeouts: number;
+  last_timeout: LifecycleLockTimeoutRecord | null;
+}
+
+/** A queued lifecycle mutation gave up instead of waiting forever. */
+export class LifecycleLockTimeoutError extends Error {
+  readonly code = "ELIFECYCLELOCKTIMEOUT";
+  readonly holder: string | null;
+  readonly waiter: string;
+  readonly waitedMs: number;
+  readonly heldForMs: number | null;
+  readonly queueDepth: number;
+
+  constructor(opts: {
+    holder: string | null;
+    waiter: string;
+    waitedMs: number;
+    heldForMs: number | null;
+    queueDepth: number;
+  }) {
+    super(
+      `lifecycle lock acquire timed out after ${opts.waitedMs}ms for "${opts.waiter}"; ` +
+        `holder="${opts.holder ?? "unknown"}" held_for_ms=${
+          opts.heldForMs ?? "unknown"
+        } queue_depth=${opts.queueDepth}. ` +
+        "Retry; if it persists, see control_health.daemon_lifecycle.lifecycle_lock.",
+    );
+    this.name = "LifecycleLockTimeoutError";
+    this.holder = opts.holder;
+    this.waiter = opts.waiter;
+    this.waitedMs = opts.waitedMs;
+    this.heldForMs = opts.heldForMs;
+    this.queueDepth = opts.queueDepth;
+  }
 }
 
 export function resolveSweepTiming(
@@ -1521,6 +1601,22 @@ export class AgentEngine {
   private fleetWorkingNoProgressTimeoutMs: number;
   private startupInitializePromise: Promise<void> | null = null;
   private lifecycleMutationTail: Promise<void> = Promise.resolve();
+  private readonly lifecycleLockAcquireTimeoutMs: number;
+  private readonly lifecycleLockHoldTimeoutMs: number;
+  private lifecycleLockHolder: string | null = null;
+  /**
+   * #530 review (Macroscope/CodeRabbit): labels are shared strings like
+   * "sweep", so an orphaned operation's `finally` could clear a NEWER holder's
+   * state and blank the diagnostics this PR exists to add. Ownership is tracked
+   * by a per-acquisition token instead.
+   */
+  private lifecycleLockAcquisitionSeq = 0;
+  private lifecycleLockAcquisitionId: number | null = null;
+  private lifecycleLockAcquiredAtMs: number | null = null;
+  private lifecycleLockQueueDepth = 0;
+  private lifecycleLockForcedReleases = 0;
+  private lifecycleLockTimeouts = 0;
+  private lifecycleLockLastTimeout: LifecycleLockTimeoutRecord | null = null;
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
   private deliveryReceiptsPath: string;
   private deliverySubmitter: DeliverySubmitter | null = null;
@@ -1566,6 +1662,22 @@ export class AgentEngine {
     this.deliveryQueueDeadlineMs = Math.max(
       1,
       opts?.deliveryQueueDeadlineMs ?? DEFAULT_DELIVERY_QUEUE_DEADLINE_MS,
+    );
+    this.lifecycleLockAcquireTimeoutMs = Math.max(
+      0,
+      opts?.lifecycleLockAcquireTimeoutMs ??
+        parseNonNegativeInteger(
+          process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS,
+          DEFAULT_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS,
+        ),
+    );
+    this.lifecycleLockHoldTimeoutMs = Math.max(
+      0,
+      opts?.lifecycleLockHoldTimeoutMs ??
+        parseNonNegativeInteger(
+          process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS,
+          DEFAULT_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS,
+        ),
     );
     this.deliveryTicketDir = opts?.deliveryTicketDir ?? null;
     this.deliveryIssueFiler = opts?.deliveryIssueFiler ?? null;
@@ -2926,8 +3038,7 @@ export class AgentEngine {
 
   private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
     return (
-      agent.cli !== "codex" &&
-      this.canUseSelfRegistrationProcessEvidence(agent)
+      agent.cli !== "codex" && this.canUseSelfRegistrationProcessEvidence(agent)
     );
   }
 
@@ -3275,8 +3386,8 @@ export class AgentEngine {
     const identity = this.normalizeCapturedSessionIdentity(capturedIdentity);
     const hasCapturedProcessEvidence = Boolean(
       agent.surface_provenance === "cmuxlayer_spawn" &&
-        identity.pid &&
-        identity.pid_registered_at,
+      identity.pid &&
+      identity.pid_registered_at,
     );
     const capturedProcessEvidence = hasCapturedProcessEvidence
       ? {
@@ -3458,10 +3569,7 @@ export class AgentEngine {
         canResolveSelfRegistration &&
         Boolean(agent.pid) &&
         agentProcessLiveness(agent) === "gone";
-      if (
-        canResolveSelfRegistration &&
-        (!agent.pid || recordedProcessGone)
-      ) {
+      if (canResolveSelfRegistration && (!agent.pid || recordedProcessGone)) {
         try {
           const registered = this.selfRegistrationSessionResolver?.(agent);
           if (registered) {
@@ -6063,22 +6171,154 @@ export class AgentEngine {
    * records carried over from the previous cmux session while retaining any
    * records that this startup's own topology scan just marked surfaceless.
    */
-  async runLifecycleMutation<T>(operation: () => Promise<T>): Promise<T> {
+  /**
+   * Serialize a lifecycle mutation behind a BOUNDED mutex.
+   *
+   * #529: both waits used to be unbounded. `await previous` queued every later
+   * caller behind a hung holder forever, and an `operation()` that never
+   * settled never reached its `finally`, so `release()` never fired and the
+   * tail stayed poisoned for the life of the process — `list_agents` and
+   * `spawn_agent` deadlocked from cold. Now the acquire is bounded and fails
+   * fast with a structured error naming the holder, and this call's tail slot
+   * is released unconditionally: on acquire timeout, on operation settle, and
+   * by a hold guard if the operation never settles at all.
+   */
+  async runLifecycleMutation<T>(
+    operation: () => Promise<T>,
+    opts?: { label?: string },
+  ): Promise<T> {
+    const label = opts?.label ?? "lifecycle-mutation";
     const previous = this.lifecycleMutationTail;
-    let release!: () => void;
-    this.lifecycleMutationTail = new Promise<void>((resolve) => {
-      release = resolve;
+    let released = false;
+    let resolveTail!: () => void;
+    const tail = new Promise<void>((resolve) => {
+      resolveTail = resolve;
     });
-    await previous;
+    const release = () => {
+      if (released) return;
+      released = true;
+      resolveTail();
+    };
+    this.lifecycleMutationTail = tail;
+
+    const waitStartedAt = Date.now();
+    this.lifecycleLockQueueDepth += 1;
+    try {
+      await this.awaitLifecycleLock(previous, label, waitStartedAt);
+    } catch (error) {
+      // #530 review P1-1: resolving our own slot HERE broke mutual exclusion —
+      // the next caller chained off an already-resolved promise and ran
+      // concurrently with the live holder (proven: a concurrent list-agents
+      // evict racing a sweep writeState resurrected a durably deleted agent
+      // dir). Chain the abandoned slot behind `previous` instead, so the queue
+      // still advances but only once the real holder is done. The hold guard
+      // is now the ONLY liveness path past a holder that never settles.
+      void previous.then(release, release);
+      throw error;
+    } finally {
+      this.lifecycleLockQueueDepth = Math.max(
+        0,
+        this.lifecycleLockQueueDepth - 1,
+      );
+    }
+
+    const acquisitionId = ++this.lifecycleLockAcquisitionSeq;
+    this.lifecycleLockHolder = label;
+    this.lifecycleLockAcquisitionId = acquisitionId;
+    this.lifecycleLockAcquiredAtMs = Date.now();
+    const holdGuard =
+      this.lifecycleLockHoldTimeoutMs > 0
+        ? setTimeout(() => {
+            if (released) return;
+            this.lifecycleLockForcedReleases += 1;
+            console.error(
+              `[cmuxlayer] lifecycle lock force-released after ${this.lifecycleLockHoldTimeoutMs}ms; holder="${label}" never settled`,
+            );
+            release();
+          }, this.lifecycleLockHoldTimeoutMs)
+        : null;
+    holdGuard?.unref?.();
+
     try {
       return await operation();
     } finally {
+      if (holdGuard) clearTimeout(holdGuard);
+      if (this.lifecycleLockAcquisitionId === acquisitionId) {
+        this.lifecycleLockHolder = null;
+        this.lifecycleLockAcquisitionId = null;
+        this.lifecycleLockAcquiredAtMs = null;
+      }
       release();
     }
   }
 
+  private async awaitLifecycleLock(
+    previous: Promise<void>,
+    waiter: string,
+    waitStartedAt: number,
+  ): Promise<void> {
+    if (this.lifecycleLockAcquireTimeoutMs <= 0) {
+      await previous;
+      return;
+    }
+    let timer: NodeJS.Timeout | null = null;
+    try {
+      await Promise.race([
+        previous,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            const record: LifecycleLockTimeoutRecord = {
+              holder: this.lifecycleLockHolder,
+              waiter,
+              waited_ms: Date.now() - waitStartedAt,
+              held_for_ms:
+                this.lifecycleLockAcquiredAtMs === null
+                  ? null
+                  : Date.now() - this.lifecycleLockAcquiredAtMs,
+              queue_depth: this.lifecycleLockQueueDepth,
+              at: new Date().toISOString(),
+            };
+            this.lifecycleLockTimeouts += 1;
+            this.lifecycleLockLastTimeout = record;
+            reject(
+              new LifecycleLockTimeoutError({
+                holder: record.holder,
+                waiter,
+                waitedMs: record.waited_ms,
+                heldForMs: record.held_for_ms,
+                queueDepth: record.queue_depth,
+              }),
+            );
+          }, this.lifecycleLockAcquireTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Lifecycle-lock truth for `control_health` — holder, age, queue depth. */
+  lifecycleLockState(): LifecycleLockState {
+    return {
+      holder: this.lifecycleLockHolder,
+      held_for_ms:
+        this.lifecycleLockAcquiredAtMs === null
+          ? null
+          : Date.now() - this.lifecycleLockAcquiredAtMs,
+      queue_depth: this.lifecycleLockQueueDepth,
+      acquire_timeout_ms: this.lifecycleLockAcquireTimeoutMs,
+      hold_timeout_ms: this.lifecycleLockHoldTimeoutMs,
+      forced_releases: this.lifecycleLockForcedReleases,
+      timeouts: this.lifecycleLockTimeouts,
+      last_timeout: this.lifecycleLockLastTimeout,
+    };
+  }
+
   async runSweep(): Promise<void> {
-    await this.runLifecycleMutation(() => this.runSweepOnce());
+    await this.runLifecycleMutation(() => this.runSweepOnce(), {
+      label: "sweep",
+    });
     await this.drainDeliveryQueue();
     await this.verifyPendingDeliveries();
   }
@@ -6549,9 +6789,7 @@ export class AgentEngine {
    * timers, not a defect. The local evidence ticket is still written either
    * way, so the verdict keeps citing its evidence; only the escalation stops.
    */
-  private deliveryFailureEscalationDecline(
-    reason: string,
-  ): string | null {
+  private deliveryFailureEscalationDecline(reason: string): string | null {
     if (reason === "verify_deadline_elapsed") {
       return (
         "background verify ran out of deadline before observing an outcome; " +
@@ -6869,7 +7107,9 @@ export class AgentEngine {
       void (this.startupInitializePromise ?? Promise.resolve())
         .then(() => {
           if (this.fleetSidebarWakeRepublishTimer !== timer) return;
-          return this.runLifecycleMutation(() => this.syncSidebar());
+          return this.runLifecycleMutation(() => this.syncSidebar(), {
+            label: "sync-sidebar",
+          });
         })
         .catch((error) => {
           console.error(
@@ -7080,7 +7320,11 @@ export class AgentEngine {
 
     let screenText: string | null = null;
     let readError: unknown = null;
-    for (let attempt = 0; attempt < WATCH_OBSERVATION_READ_ATTEMPTS; attempt++) {
+    for (
+      let attempt = 0;
+      attempt < WATCH_OBSERVATION_READ_ATTEMPTS;
+      attempt++
+    ) {
       try {
         const screen = await this.client.readScreen(agent.surface_id, {
           ...(agent.workspace_id ? { workspace: agent.workspace_id } : {}),
@@ -8076,12 +8320,12 @@ export class AgentEngine {
             current &&
             INTERACTIVE_AGENT_STATES.has(targetState) &&
             timeoutInteractiveEvidenceIsGated
-            ? await this.getTargetStateEvidenceSource(
-                current,
-                targetState,
-                timeoutState,
-              )
-            : null;
+              ? await this.getTargetStateEvidenceSource(
+                  current,
+                  targetState,
+                  timeoutState,
+                )
+              : null;
           if (current && timeoutEvidence) {
             finish({
               matched: true,
@@ -8465,11 +8709,14 @@ export class AgentEngine {
     }
     const normalizedSurfaceUuid = agent.surface_uuid.trim().toLowerCase();
     const routedAgentId = agent.agent_id;
-    const competingRecord = this.registry.list().find(
-      (candidate) =>
-        candidate.agent_id !== routedAgentId &&
-        candidate.surface_uuid?.trim().toLowerCase() === normalizedSurfaceUuid,
-    );
+    const competingRecord = this.registry
+      .list()
+      .find(
+        (candidate) =>
+          candidate.agent_id !== routedAgentId &&
+          candidate.surface_uuid?.trim().toLowerCase() ===
+            normalizedSurfaceUuid,
+      );
     if (competingRecord) {
       throw new Error(
         `Agent "${agent.agent_id}" cannot use socketless teardown because ` +
@@ -8930,7 +9177,8 @@ export class AgentEngine {
         finalRoute.surface_id,
         finalRoute.workspace_id,
       );
-      const confirmedRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
+      const confirmedRoute =
+        await this.resolveAgentStopIoRoute(canonicalAgentId);
       if (!this.sameSurfaceRoute(finalRoute, confirmedRoute)) {
         throw new Error(
           `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +
@@ -9060,7 +9308,8 @@ export class AgentEngine {
           closeRoute.surface_id,
           closeRoute.workspace_id,
         );
-        confirmedCloseRoute = await this.resolveAgentStopIoRoute(canonicalAgentId);
+        confirmedCloseRoute =
+          await this.resolveAgentStopIoRoute(canonicalAgentId);
         if (!this.sameSurfaceRoute(closeRoute, confirmedCloseRoute)) {
           throw new Error(
             `Agent "${canonicalAgentId}" surface route changed repeatedly while ` +

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -15,6 +15,11 @@ import {
   type MonitorRegistryOptions,
 } from "./monitor-registry.js";
 import type { SurfaceWriteLivenessTracker } from "./surface-write-liveness.js";
+import {
+  daemonLifecycleSnapshot,
+  type DaemonLifecycleSnapshot,
+} from "./daemon-lifecycle-state.js";
+import type { LifecycleLockState } from "./agent-engine.js";
 
 const MAX_SELF_HEAL_DETAILS = 100;
 const MAX_MONITOR_REGISTRY_BYTES = 1024 * 1024;
@@ -57,6 +62,12 @@ export interface ControlHealthOptions {
   surfaceIds?: readonly string[];
   panePtyDeadSince?: ReadonlyMap<string, number>;
   monitorRegistryPath?: string;
+  /**
+   * #529: daemon spawn/exit/reap facts. Defaults to this process's record,
+   */
+  daemonLifecycle?: DaemonLifecycleSnapshot;
+  lifecycleLock?: LifecycleLockState | null;
+  lifecycleStart?: LifecycleStartHealth | null;
 }
 
 export interface ControlHealthSelfHeal {
@@ -112,6 +123,29 @@ export interface CmuxInstanceHealth {
   processes: Array<{ pid: number | null; command: string }>;
 }
 
+/**
+ * #529 observability. A dead daemon and a wedged lifecycle lock used to look
+ * exactly like a healthy control plane to every tool that did not need them.
+ */
+export interface LifecycleStartHealth {
+  started: boolean;
+  settled: boolean;
+  waiting_for_ms: number | null;
+  timeout_ms: number;
+  error: string | null;
+  /**
+   * #530 review P2-4: how many callers gave up on the bound this PR added.
+   * Without it the new timeout was itself silent — the exact defect class.
+   */
+  timeouts: number;
+  last_timeout_at: string | null;
+}
+
+export interface ControlHealthDaemonLifecycle extends DaemonLifecycleSnapshot {
+  lifecycle_lock: LifecycleLockState | null;
+  lifecycle_start: LifecycleStartHealth | null;
+}
+
 export interface ControlHealth {
   generated_at: string;
   current_process: {
@@ -139,15 +173,18 @@ export interface ControlHealth {
     nightly: CmuxInstanceHealth;
   };
   self_heal: ControlHealthSelfHeal;
+  daemon_lifecycle: ControlHealthDaemonLifecycle;
   warnings: string[];
 }
 
-export function collectSelfHealHealth(opts: {
-  surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
-  surfaceIds?: readonly string[];
-  panePtyDeadSince?: ReadonlyMap<string, number>;
-  monitorRegistry?: MonitorRegistryOptions;
-} = {}): ControlHealthSelfHeal {
+export function collectSelfHealHealth(
+  opts: {
+    surfaceWriteLiveness?: SurfaceWriteLivenessTracker;
+    surfaceIds?: readonly string[];
+    panePtyDeadSince?: ReadonlyMap<string, number>;
+    monitorRegistry?: MonitorRegistryOptions;
+  } = {},
+): ControlHealthSelfHeal {
   const surfaceIds = [...new Set(opts.surfaceIds ?? [])];
   const deadSurfaces: ControlHealthSelfHeal["pane_pty_dead"]["surfaces"] = [];
   let deadSurfaceCount = 0;
@@ -164,9 +201,7 @@ export function collectSelfHealHealth(opts: {
           ...(sinceAt === undefined
             ? {}
             : { since_at: new Date(sinceAt).toISOString() }),
-          last_attempt_at: new Date(
-            observation.last_attempt_at,
-          ).toISOString(),
+          last_attempt_at: new Date(observation.last_attempt_at).toISOString(),
         });
       } catch {
         // One malformed/stale surface observation must not break control_health.
@@ -195,13 +230,9 @@ export function collectSelfHealHealth(opts: {
       ) {
         throw new Error("monitor registry JSON has invalid shape");
       }
-      const registryQuery = queryMonitorRegistryForGates(
-        opts.monitorRegistry,
-      );
+      const registryQuery = queryMonitorRegistryForGates(opts.monitorRegistry);
       if (
-        registryQuery.monitors.some(
-          (monitor) => monitor.liveness === "invalid",
-        )
+        registryQuery.monitors.some((monitor) => monitor.liveness === "invalid")
       ) {
         throw new Error("monitor registry contains invalid records");
       }
@@ -241,7 +272,8 @@ export function collectSelfHealHealth(opts: {
       available: monitorRegistryAvailable,
       ...(monitorRegistryError ? { error: monitorRegistryError } : {}),
       total: monitors.length,
-      rearming: monitors.filter((monitor) => monitor.state === "rearming").length,
+      rearming: monitors.filter((monitor) => monitor.state === "rearming")
+        .length,
       collapsed: collapsedMonitors.length,
       collapsed_monitors: collapsedMonitors.slice(0, MAX_SELF_HEAL_DETAILS),
       truncated: collapsedMonitors.length > MAX_SELF_HEAL_DETAILS,
@@ -488,6 +520,50 @@ function describeClient(client: unknown): ControlHealth["selected_transport"] {
 
 function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
   const warnings: string[] = [];
+  // #529: never let a dead daemon or a wedged lifecycle lock stay silent.
+  const lifecycle = health.daemon_lifecycle;
+  if (lifecycle?.last_exit && lifecycle.last_exit.code !== 0) {
+    warnings.push(
+      `cmuxlayer daemon exited with code ${lifecycle.last_exit.code ?? "none"} at ${lifecycle.last_exit.at}; this runtime is not daemon-backed.`,
+    );
+  }
+  if (lifecycle?.lifecycle_lock?.last_timeout) {
+    const timeout = lifecycle.lifecycle_lock.last_timeout;
+    warnings.push(
+      `lifecycle lock acquire timed out for "${timeout.waiter}" after ${timeout.waited_ms}ms (holder "${timeout.holder ?? "unknown"}").`,
+    );
+  }
+  if (
+    lifecycle?.lifecycle_lock &&
+    lifecycle.lifecycle_lock.forced_releases > 0
+  ) {
+    warnings.push(
+      `lifecycle lock was force-released ${lifecycle.lifecycle_lock.forced_releases} time(s); an operation never settled.`,
+    );
+  }
+  // #530: a stranded/unrestorable socket, or any recorded daemon lifecycle
+  // error, must be visible rather than living only in a log line.
+  if (lifecycle?.last_error) {
+    warnings.push(`daemon lifecycle error: ${lifecycle.last_error}`);
+  }
+  if (lifecycle?.lifecycle_start?.error) {
+    warnings.push(
+      `lifecycle initialization failed: ${lifecycle.lifecycle_start.error}`,
+    );
+  }
+  // #530 final pass F5: gating on `timeouts > 0` alone latched the warning
+  // forever, the same never-clearing class as P2-3. Once initialization has
+  // settled cleanly, past timeouts are history, not a current degradation.
+  const startHealth = lifecycle?.lifecycle_start;
+  if (
+    startHealth &&
+    startHealth.timeouts > 0 &&
+    (!startHealth.settled || startHealth.error !== null)
+  ) {
+    warnings.push(
+      `lifecycle initialization wait timed out ${startHealth.timeouts} time(s) (last at ${startHealth.last_timeout_at ?? "unknown"}); lifecycle-gated tools are degraded.`,
+    );
+  }
   const envSocket = health.current_process.env.CMUX_SOCKET_PATH;
   const bundledCli = health.current_process.env.CMUX_BUNDLED_CLI_PATH;
   const firstCmux = health.current_process.cmux_resolution[0];
@@ -687,6 +763,11 @@ export async function collectControlHealth(
         ? { registryPath: opts.monitorRegistryPath }
         : undefined,
     }),
+    daemon_lifecycle: {
+      ...(opts.daemonLifecycle ?? daemonLifecycleSnapshot()),
+      lifecycle_lock: opts.lifecycleLock ?? null,
+      lifecycle_start: opts.lifecycleStart ?? null,
+    },
   };
 
   return { ...base, warnings: buildWarnings(base) };
@@ -709,6 +790,71 @@ function formatInstance(instance: CmuxInstanceHealth): string[] {
     `  app: ${instance.app_binary_path}`,
     `  pids: ${processSummary}`,
   ];
+}
+
+function formatDaemonLifecycle(
+  lifecycle: ControlHealthDaemonLifecycle | undefined,
+): string[] {
+  if (!lifecycle) return [];
+  const lines = [
+    `daemon lifecycle: spawn_attempts=${lifecycle.spawn_attempts}${
+      lifecycle.last_spawn_at ? ` last_spawn_at=${lifecycle.last_spawn_at}` : ""
+    }`,
+  ];
+  if (lifecycle.last_exit) {
+    lines.push(
+      `  last daemon exit: code=${lifecycle.last_exit.code ?? "none"} signal=${
+        lifecycle.last_exit.signal ?? "none"
+      } at=${lifecycle.last_exit.at}`,
+    );
+    for (const line of lifecycle.last_exit.stderr_excerpt
+      .split("\n")
+      .filter((entry) => entry.trim().length > 0)
+      .slice(-5)) {
+      lines.push(`    stderr: ${line}`);
+    }
+  }
+  if (lifecycle.last_socket_reap) {
+    lines.push(
+      `  socket reaped: ${lifecycle.last_socket_reap.path} (${lifecycle.last_socket_reap.reason})`,
+    );
+  }
+  if (lifecycle.last_socket_in_use) {
+    lines.push(
+      `  socket in use: ${lifecycle.last_socket_in_use.path} owner_pid=${
+        lifecycle.last_socket_in_use.owner_pid ?? "unknown"
+      }`,
+    );
+  }
+  if (lifecycle.last_error) {
+    lines.push(`  last daemon error: ${lifecycle.last_error}`);
+  }
+  const lock = lifecycle.lifecycle_lock;
+  if (lock) {
+    lines.push(
+      `lifecycle lock: holder=${lock.holder ?? "none"} held_for_ms=${
+        lock.held_for_ms ?? 0
+      } queue_depth=${lock.queue_depth} timeouts=${lock.timeouts} forced_releases=${lock.forced_releases}`,
+    );
+    if (lock.last_timeout) {
+      lines.push(
+        `  last lock timeout: waiter=${lock.last_timeout.waiter} holder=${
+          lock.last_timeout.holder ?? "unknown"
+        } waited_ms=${lock.last_timeout.waited_ms} at=${lock.last_timeout.at}`,
+      );
+    }
+  }
+  const start = lifecycle.lifecycle_start;
+  if (start) {
+    lines.push(
+      `lifecycle start: started=${start.started} settled=${start.settled} timeouts=${start.timeouts}${
+        start.waiting_for_ms === null
+          ? ""
+          : ` waiting_for_ms=${start.waiting_for_ms}`
+      }${start.error ? ` error=${start.error}` : ""}`,
+    );
+  }
+  return lines;
 }
 
 export function formatControlHealth(health: ControlHealth): string {
@@ -758,6 +904,7 @@ export function formatControlHealth(health: ControlHealth): string {
     ...health.self_heal.monitor_registry.collapsed_monitors.map(
       (monitor) => `  ${monitor.monitor_id}: ${monitor.reason}`,
     ),
+    ...formatDaemonLifecycle(health.daemon_lifecycle),
   ];
 
   if (health.current_process.cmux_resolution.length === 0) {

--- a/src/daemon-lifecycle-state.ts
+++ b/src/daemon-lifecycle-state.ts
@@ -1,0 +1,280 @@
+/**
+ * Daemon lifecycle truth: the structured failures every daemon-dependent
+ * waiter must see, plus the in-process record that makes a dead daemon look
+ * different from a healthy one.
+ *
+ * #529: a leftover file at the daemon socket path made socket reaping throw,
+ * the daemon exited code 1 right after being spawned, and nothing propagated
+ * that exit to the readiness waiters — so `list_agents` and `spawn_agent`
+ * deadlocked forever while lock-free tools kept answering in milliseconds.
+ * Every failure below is deliberately typed and recorded so the same shape can
+ * never be silent again.
+ */
+
+/**
+ * How the socket path was classified. `superseded` is not a probe verdict: it
+ * means the path changed between classification and reap.
+ */
+export type DaemonSocketProbe =
+  "live" | "missing" | "stale" | "unknown" | "superseded" | "occupied";
+
+export const DAEMON_SOCKET_IN_USE_CODE = "EDAEMONSOCKETINUSE";
+export const DAEMON_SOCKET_PATH_OCCUPIED_CODE = "EDAEMONSOCKETPATHOCCUPIED";
+export const DAEMON_STARTUP_FAILED_CODE = "EDAEMONSTARTUPFAILED";
+export const DAEMON_READINESS_TIMEOUT_CODE = "EDAEMONREADINESSTIMEOUT";
+
+const STDERR_EXCERPT_LIMIT = 4_000;
+
+export function daemonStderrExcerpt(text: string | undefined | null): string {
+  if (!text) return "";
+  const trimmed = text.trimEnd();
+  return trimmed.length > STDERR_EXCERPT_LIMIT
+    ? trimmed.slice(-STDERR_EXCERPT_LIMIT)
+    : trimmed;
+}
+
+/**
+ * The socket path is owned by a daemon that is accepting connections, or the
+ * probe was inconclusive. Either way the caller must not reap it.
+ */
+export class DaemonSocketInUseError extends Error {
+  readonly code = DAEMON_SOCKET_IN_USE_CODE;
+  readonly socketPath: string;
+  readonly ownerPid: number | null;
+  readonly probe: DaemonSocketProbe;
+
+  constructor(opts: {
+    socketPath: string;
+    ownerPid?: number | null;
+    probe: DaemonSocketProbe;
+  }) {
+    const owner =
+      opts.ownerPid !== null && opts.ownerPid !== undefined
+        ? ` (owner pid ${opts.ownerPid})`
+        : "";
+    super(
+      `cmuxlayer daemon socket is already in use: ${opts.socketPath}${owner} [probe=${opts.probe}]`,
+    );
+    this.name = "DaemonSocketInUseError";
+    this.socketPath = opts.socketPath;
+    this.ownerPid = opts.ownerPid ?? null;
+    this.probe = opts.probe;
+  }
+}
+
+/**
+ * The socket path holds something cmuxlayer did not create. Never reaped: a
+ * mistyped `CMUXLAYER_DAEMON_SOCKET` must fail loudly, not delete user data.
+ */
+export class DaemonSocketPathOccupiedError extends Error {
+  readonly code = DAEMON_SOCKET_PATH_OCCUPIED_CODE;
+  readonly socketPath: string;
+
+  constructor(opts: { socketPath: string; detail: string }) {
+    super(
+      `cmuxlayer daemon socket path is occupied by ${opts.detail}: ${opts.socketPath}. ` +
+        "Refusing to delete it. Point CMUXLAYER_DAEMON_SOCKET at a free path, " +
+        "or remove that file yourself if it is genuinely disposable.",
+    );
+    this.name = "DaemonSocketPathOccupiedError";
+    this.socketPath = opts.socketPath;
+  }
+}
+
+/** The spawned daemon child died (or failed to spawn) before it was ready. */
+export class DaemonStartupFailedError extends Error {
+  readonly code = DAEMON_STARTUP_FAILED_CODE;
+  readonly socketPath: string;
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly stderrExcerpt: string;
+
+  constructor(opts: {
+    socketPath: string;
+    exitCode?: number | null;
+    signal?: string | null;
+    stderrExcerpt?: string;
+    reason?: string;
+    cause?: unknown;
+  }) {
+    const stderr = daemonStderrExcerpt(opts.stderrExcerpt);
+    const detail =
+      opts.reason ??
+      `exited (code=${opts.exitCode ?? "none"}, signal=${opts.signal ?? "none"})`;
+    super(
+      `cmuxlayer daemon failed to start at ${opts.socketPath}: ${detail}${
+        stderr ? `\ndaemon stderr:\n${stderr}` : ""
+      }`,
+    );
+    this.name = "DaemonStartupFailedError";
+    this.socketPath = opts.socketPath;
+    this.exitCode = opts.exitCode ?? null;
+    this.signal = opts.signal ?? null;
+    this.stderrExcerpt = stderr;
+    if (opts.cause !== undefined) {
+      this.cause = opts.cause;
+    }
+  }
+}
+
+/** The daemon never became ready and never died — bounded, never unsettled. */
+export class DaemonReadinessTimeoutError extends Error {
+  readonly code = DAEMON_READINESS_TIMEOUT_CODE;
+  readonly socketPath: string;
+  readonly waitedMs: number;
+  readonly stderrExcerpt: string;
+
+  constructor(opts: {
+    socketPath: string;
+    waitedMs: number;
+    stderrExcerpt?: string;
+  }) {
+    const stderr = daemonStderrExcerpt(opts.stderrExcerpt);
+    super(
+      `cmuxlayer daemon did not become ready at ${opts.socketPath} within ${opts.waitedMs}ms${
+        stderr ? `\ndaemon stderr:\n${stderr}` : ""
+      }`,
+    );
+    this.name = "DaemonReadinessTimeoutError";
+    this.socketPath = opts.socketPath;
+    this.waitedMs = opts.waitedMs;
+    this.stderrExcerpt = stderr;
+  }
+}
+
+export interface DaemonExitRecord {
+  code: number | null;
+  signal: string | null;
+  at: string;
+  pid: number | null;
+  stderr_excerpt: string;
+}
+
+export interface DaemonSocketReapRecord {
+  path: string;
+  reason: string;
+  at: string;
+}
+
+export interface DaemonLifecycleSnapshot {
+  socket_path: string | null;
+  spawn_attempts: number;
+  last_spawn_at: string | null;
+  last_spawn_pid: number | null;
+  last_exit: DaemonExitRecord | null;
+  last_socket_reap: DaemonSocketReapRecord | null;
+  last_socket_in_use: {
+    path: string;
+    owner_pid: number | null;
+    at: string;
+  } | null;
+  last_error: string | null;
+}
+
+function emptySnapshot(): DaemonLifecycleSnapshot {
+  return {
+    socket_path: null,
+    spawn_attempts: 0,
+    last_spawn_at: null,
+    last_spawn_pid: null,
+    last_exit: null,
+    last_socket_reap: null,
+    last_socket_in_use: null,
+    last_error: null,
+  };
+}
+
+let state: DaemonLifecycleSnapshot = emptySnapshot();
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function recordDaemonSpawnAttempt(opts: {
+  socketPath: string;
+  pid?: number | null;
+}): void {
+  // A new spawn starts a new daemon GENERATION. Carrying the previous
+  // generation's exit/error forward made control_health warn "not
+  // daemon-backed" forever, even once a healthy successor was serving. The
+  // cumulative counter and the reap history survive; the failure state does not.
+  state = {
+    ...state,
+    socket_path: opts.socketPath,
+    spawn_attempts: state.spawn_attempts + 1,
+    last_spawn_at: nowIso(),
+    last_spawn_pid: opts.pid ?? null,
+    last_exit: null,
+    last_socket_in_use: null,
+    last_error: null,
+  };
+}
+
+export function recordDaemonExit(opts: {
+  code?: number | null;
+  signal?: string | null;
+  pid?: number | null;
+  stderrExcerpt?: string;
+}): void {
+  // A SUPERSEDED generation's exit can land after a healthy successor spawned.
+  // Recording it re-poisons `last_exit` and re-raises the "not daemon-backed"
+  // warning against a daemon that is serving fine. Only drop it when both pids
+  // are known and differ — an unknown pid cannot be attributed, and dropping it
+  // would reintroduce silence.
+  const currentGeneration = state.last_spawn_pid;
+  if (
+    currentGeneration !== null &&
+    opts.pid !== null &&
+    opts.pid !== undefined &&
+    opts.pid !== currentGeneration
+  ) {
+    return;
+  }
+  state = {
+    ...state,
+    last_exit: {
+      code: opts.code ?? null,
+      signal: opts.signal ?? null,
+      pid: opts.pid ?? null,
+      at: nowIso(),
+      stderr_excerpt: daemonStderrExcerpt(opts.stderrExcerpt),
+    },
+  };
+}
+
+export function recordDaemonSocketReap(opts: {
+  path: string;
+  reason: string;
+}): void {
+  state = {
+    ...state,
+    last_socket_reap: { path: opts.path, reason: opts.reason, at: nowIso() },
+  };
+}
+
+export function recordDaemonSocketInUse(opts: {
+  path: string;
+  ownerPid: number | null;
+}): void {
+  state = {
+    ...state,
+    last_socket_in_use: {
+      path: opts.path,
+      owner_pid: opts.ownerPid,
+      at: nowIso(),
+    },
+  };
+}
+
+export function recordDaemonLifecycleError(message: string): void {
+  state = { ...state, last_error: message };
+}
+
+export function daemonLifecycleSnapshot(): DaemonLifecycleSnapshot {
+  return { ...state };
+}
+
+/** Test-only reset so lifecycle observability is deterministic per test. */
+export function resetDaemonLifecycleState(): void {
+  state = emptySnapshot();
+}

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -2,12 +2,90 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  daemonStderrExcerpt,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+  recordDaemonSpawnAttempt,
+} from "./daemon-lifecycle-state.js";
 
 export interface SpawnDaemonOptions {
   socketPath: string;
   env: NodeJS.ProcessEnv;
   daemonScriptPath?: string;
   logger: Pick<Console, "error">;
+  /**
+   * Capture the daemon's stderr so a startup failure can be reported to the
+   * readiness waiters instead of vanishing (#529). Defaults to true; the
+   * captured text is still forwarded to this process's stderr.
+   */
+  captureStderr?: boolean;
+  /** Test seam for the stderr forwarder. */
+  stderrSink?: (chunk: string) => void;
+}
+
+const STDERR_BUFFER_LIMIT = 8_000;
+const capturedStderr = new WeakMap<object, { text: string }>();
+
+/** Bounded excerpt of what a spawned daemon printed on stderr. */
+export function capturedDaemonStderr(child: unknown): string {
+  if (!child || typeof child !== "object") return "";
+  return daemonStderrExcerpt(capturedStderr.get(child as object)?.text ?? "");
+}
+
+interface Settled {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createSettled(): Settled {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const stderrDrained = new WeakMap<object, Promise<void>>();
+
+/**
+ * Wait, briefly, for a dead child's stderr to finish arriving (#530).
+ *
+ * A daemon that refuses the socket prints its marker and calls
+ * `process.exit(1)` immediately, so `exit` can beat the pipe and leave the
+ * excerpt empty. `close` fires only once stdio is done — this waits for that,
+ * bounded, so a child that never closes cannot stall readiness.
+ */
+export async function awaitDaemonStderrDrained(
+  child: unknown,
+  timeoutMs = 300,
+): Promise<void> {
+  if (!child || typeof child !== "object") return;
+  const drained = stderrDrained.get(child as object);
+  if (!drained) return;
+  let timer: NodeJS.Timeout | null = null;
+  await Promise.race([
+    drained,
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs);
+      timer.unref?.();
+    }),
+  ]);
+  if (timer) clearTimeout(timer);
+}
+
+let parentStderrGuardInstalled = false;
+
+/**
+ * Install exactly ONE `error` listener on this process's stderr. Async EPIPE
+ * (the MCP client going away while the daemon is still writing) would
+ * otherwise surface as an unhandled 'error' event and kill the spawner. Guarded
+ * by a module flag so repeated spawns cannot leak listeners.
+ */
+function installParentStderrErrorGuard(): void {
+  if (parentStderrGuardInstalled) return;
+  parentStderrGuardInstalled = true;
+  process.stderr.on("error", () => {});
 }
 
 function defaultDaemonScriptPath(): string {
@@ -30,17 +108,98 @@ export async function spawnDaemonProcess(
       env.CMUXLAYER_NODE_MAX_OLD_SPACE_MB ?? "1536"
     }`.trim();
   }
+  const captureStderr = opts.captureStderr !== false;
   const child = spawn(process.execPath, [daemonScriptPath], {
     detached: true,
     env,
-    stdio: ["ignore", "ignore", "inherit"],
+    stdio: ["ignore", "ignore", captureStderr ? "pipe" : "inherit"],
   });
+  recordDaemonSpawnAttempt({
+    socketPath: opts.socketPath,
+    pid: child.pid ?? null,
+  });
+
+  const buffer = { text: "" };
+  capturedStderr.set(child, buffer);
+  const stderrSettled = createSettled();
+  stderrDrained.set(child, stderrSettled.promise);
+  if (captureStderr && child.stderr) {
+    const stderrStream = child.stderr;
+    // #530 review P2-5: EPIPE on process.stderr arrives ASYNCHRONOUSLY, so a
+    // try/catch around write() never sees it. Guard the stream itself, once.
+    installParentStderrErrorGuard();
+    // #530 final pass F1: pausing on backpressure and resuming ONLY on `drain`
+    // introduced a NEW hang. An errored writable never emits `drain`, and the
+    // error guard swallows the error — so the child stayed paused forever, its
+    // 64KB stderr pipe filled, and the daemon blocked in write(2). Resume on
+    // `error` and `close` too, and stop forwarding once the destination is
+    // broken (capture is unaffected: the excerpt buffer is fed separately).
+    let forwardingBroken = false;
+    const resumeStderr = () => {
+      if (!stderrStream.destroyed) stderrStream.resume();
+    };
+    const breakForwarding = () => {
+      forwardingBroken = true;
+      resumeStderr();
+    };
+    process.stderr.once("error", breakForwarding);
+    process.stderr.once("close", breakForwarding);
+    // #530 (CodeRabbit): these fire only on a BROKEN destination, so after a
+    // normal child exit they would stay attached forever. runDaemonFirstEntry
+    // can spawn several times (autostart, handoff respawn, version bump), and
+    // ten spawns would trip MaxListenersExceededWarning on the very stderr
+    // channel that carries daemon diagnostics. Detach when the child's stderr
+    // closes.
+    const detachParentStderrListeners = () => {
+      process.stderr.off("error", breakForwarding);
+      process.stderr.off("close", breakForwarding);
+      process.stderr.off("drain", resumeStderr);
+    };
+    stderrStream.once("close", detachParentStderrListeners);
+    stderrStream.once("end", detachParentStderrListeners);
+    const sink =
+      opts.stderrSink ??
+      ((chunk: string) => {
+        if (forwardingBroken) return;
+        try {
+          if (!process.stderr.write(chunk)) {
+            // Honor backpressure rather than buffering the daemon's output
+            // without bound: pause the child until the parent drains.
+            stderrStream.pause();
+            process.stderr.once("drain", resumeStderr);
+          }
+        } catch {
+          // A closed stderr must never take the spawning process down.
+          breakForwarding();
+        }
+      });
+    stderrStream.setEncoding("utf8");
+    stderrStream.on("data", (chunk: string) => {
+      buffer.text = `${buffer.text}${chunk}`.slice(-STDERR_BUFFER_LIMIT);
+      sink(chunk);
+    });
+    stderrStream.on("error", () => {});
+    (stderrStream as unknown as { unref?: () => void }).unref?.();
+  }
+
   child.once("error", (error) => {
+    recordDaemonLifecycleError(error.message);
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon failed (pid=${child.pid ?? "unknown"}): ${error.message}`,
     );
   });
+  child.once("close", () => {
+    // #530 (Codex P1): `close` fires only after the stdio streams are done, so
+    // by here the captured excerpt is complete. `exit` alone can beat the pipe.
+    stderrSettled.resolve();
+  });
   child.once("exit", (code, signal) => {
+    recordDaemonExit({
+      code,
+      signal,
+      pid: child.pid ?? null,
+      stderrExcerpt: buffer.text,
+    });
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,
     );

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -55,6 +55,13 @@ import {
   type StaleBuildResult,
 } from "./version.js";
 import { isMainModule } from "./is-main.js";
+import {
+  DaemonSocketInUseError,
+  DaemonSocketPathOccupiedError,
+  recordDaemonSocketInUse,
+  recordDaemonSocketReap,
+  type DaemonSocketProbe,
+} from "./daemon-lifecycle-state.js";
 import { loadCmuxlayerConfigFile } from "./config-file.js";
 import { FleetSidebarPublisher } from "./fleet-sidebar.js";
 
@@ -331,31 +338,98 @@ function isJsonRpcResponse(
   );
 }
 
-async function unlinkStaleSocket(path: string): Promise<void> {
-  const status = await probeSocket(path);
-  if (status === "live") {
-    throw new Error(`cmuxlayer daemon socket is already in use: ${path}`);
-  }
-  if (status === "missing") {
-    return;
-  }
+const DAEMON_SOCKET_PROBE_TIMEOUT_MS = 250;
 
-  await unlink(path).catch((error: NodeJS.ErrnoException) => {
-    if (error.code !== "ENOENT") {
-      throw error;
-    }
-  });
+/**
+ * connect(2) failures meaning NOTHING ANSWERED on the path.
+ *
+ * ENOTSOCK is the reboot shape: `detachOwnedSocketPath()` leaves an empty
+ * regular file at the socket path on every clean shutdown, so a SIGTERM at
+ * logout/reboot leaves a leftover no daemon can own. Re-throwing it is what
+ * made the successor daemon fatal instead of reaping (#529).
+ */
+const NO_LISTENER_CONNECT_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTSOCK",
+  "ENOTCONN",
+  "EPIPE",
+]);
+
+interface DaemonSocketIdentity {
+  dev: number;
+  ino: number;
+  /**
+   * Node type. dev/ino alone cannot identify an object across a
+   * delete-and-recreate — Linux hands the freed inode number straight back, so
+   * a successor's new SOCKET can carry the placeholder's exact dev/ino (#530
+   * CI: green on macOS, red on Linux). The type cannot collide.
+   */
+  kind: "socket" | "file" | "other";
 }
 
-function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
-  return new Promise((resolve, reject) => {
+/** Identity of the path now, or null when it genuinely does not exist. */
+async function socketIdentity(
+  path: string,
+): Promise<DaemonSocketIdentity | null> {
+  try {
+    const s = await lstat(path);
+    return {
+      dev: s.dev,
+      ino: s.ino,
+      kind: s.isSocket() ? "socket" : s.isFile() ? "file" : "other",
+    };
+  } catch (error) {
+    // Absence is ENOENT ONLY. Any other errno is a real failure, not "gone".
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function sameIdentity(
+  a: DaemonSocketIdentity | null,
+  b: DaemonSocketIdentity | null,
+): boolean {
+  return (
+    a !== null &&
+    b !== null &&
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.kind === b.kind
+  );
+}
+
+/**
+ * Classify the socket path without ever collapsing "someone is listening" into
+ * "something is in the way", and without re-throwing an unexpected errno —
+ * that re-throw is what fataled the daemon in #529.
+ */
+export async function probeDaemonSocketPath(
+  path: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<DaemonSocketProbe> {
+  try {
+    const stats = await lstat(path);
+    if (!stats.isSocket()) {
+      // Only cmuxlayer's OWN artifact shape is reapable: the shutdown
+      // placeholder is an EMPTY regular file. Anything with content, or any
+      // other node type, is the operator's data at a mistyped socket path and
+      // must fail loudly rather than be deleted.
+      return stats.isFile() && stats.size === 0 ? "stale" : "occupied";
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "missing";
+    }
+    // Anything else falls through to the connect probe.
+  }
+
+  return new Promise<DaemonSocketProbe>((resolve) => {
     const socket = net.createConnection(path);
     let settled = false;
     const ignoreLateError = () => {};
-    const settle = (value: "live" | "missing" | "stale") => {
-      if (settled) {
-        return;
-      }
+    const settle = (value: DaemonSocketProbe) => {
+      if (settled) return;
       settled = true;
       socket.removeAllListeners();
       socket.on("error", ignoreLateError);
@@ -363,20 +437,76 @@ function probeSocket(path: string): Promise<"live" | "missing" | "stale"> {
       resolve(value);
     };
 
-    socket.setTimeout(250, () => settle("live"));
+    socket.setTimeout(opts.timeoutMs ?? DAEMON_SOCKET_PROBE_TIMEOUT_MS, () =>
+      settle("unknown"),
+    );
     socket.once("connect", () => settle("live"));
     socket.once("error", (error: NodeJS.ErrnoException) => {
-      if (error.code === "ENOENT") {
-        settle("missing");
-        return;
+      if (error.code === "ENOENT") return settle("missing");
+      if (error.code && NO_LISTENER_CONNECT_CODES.has(error.code)) {
+        return settle("stale");
       }
-      if (error.code === "ECONNREFUSED") {
-        settle("stale");
-        return;
-      }
-      reject(error);
+      // Never re-throw out of the probe (#529).
+      settle("unknown");
     });
   });
+}
+
+export type UnlinkStaleSocketOutcome = "absent" | "reaped";
+
+export interface UnlinkStaleSocketOptions {
+  probe?: (path: string) => Promise<DaemonSocketProbe>;
+}
+
+/**
+ * Reap a dead-owner leftover; refuse anything else.
+ *
+ * - `missing`  -> nothing to do.
+ * - `occupied` -> not a daemon artifact. NEVER deleted.
+ * - `live`     -> a daemon is accepting connections. Refuse; the entry layer
+ *                 re-probes and attaches to it (or falls back in-process).
+ * - `unknown`  -> inconclusive. Fail closed: an unanswered probe is not
+ *                 evidence that the path is free.
+ * - `stale`    -> nothing is listening and the object is our own shape. Reap.
+ */
+export async function unlinkStaleSocket(
+  path: string,
+  opts: UnlinkStaleSocketOptions = {},
+): Promise<UnlinkStaleSocketOutcome> {
+  const probe = opts.probe ?? probeDaemonSocketPath;
+
+  const observedIdentity = await socketIdentity(path);
+  const status = await probe(path);
+
+  if (status === "missing") return "absent";
+  if (status === "occupied") {
+    throw new DaemonSocketPathOccupiedError({
+      socketPath: path,
+      detail: "a file cmuxlayer did not create",
+    });
+  }
+  if (status === "live" || status === "unknown") {
+    recordDaemonSocketInUse({ path, ownerPid: null });
+    throw new DaemonSocketInUseError({ socketPath: path, probe: status });
+  }
+
+  // Revalidate immediately before the unlink so a successor that bound the
+  // path while we were classifying does not lose its socket (#530 P2-2).
+  const current = await socketIdentity(path);
+  if (current === null) {
+    recordDaemonSocketReap({ path, reason: "dead-owner-leftover-vanished" });
+    return "reaped";
+  }
+  if (!sameIdentity(current, observedIdentity)) {
+    recordDaemonSocketInUse({ path, ownerPid: null });
+    throw new DaemonSocketInUseError({ socketPath: path, probe: "superseded" });
+  }
+
+  await unlink(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error;
+  });
+  recordDaemonSocketReap({ path, reason: "dead-owner-leftover" });
+  return "reaped";
 }
 
 function positiveEnvMs(value: string | undefined): number | null {
@@ -1054,7 +1184,9 @@ export class CmuxLayerDaemon {
     });
     if (detachedSocket?.restore) {
       await rename(detachedSocket.path, this.socketPath);
-    } else if (detachedSocket) {
+      return;
+    }
+    if (detachedSocket) {
       await unlink(detachedSocket.path).catch(
         (error: NodeJS.ErrnoException) => {
           if (error.code !== "ENOENT") {
@@ -1062,6 +1194,30 @@ export class CmuxLayerDaemon {
           }
         },
       );
+    }
+    await this.removeOwnedSocketPlaceholder();
+  }
+
+  /**
+   * #529 ROOT CAUSE: `detachOwnedSocketPath()` parks an empty REGULAR FILE at
+   * the socket path so a racing daemon cannot bind mid-shutdown, and nothing
+   * ever removed it. connect(2) answers ENOTSOCK there, which the old probe
+   * re-threw — so every clean shutdown, a reboot's SIGTERM included, left a
+   * leftover the successor daemon could not reap. Remove it once the listener
+   * is closed, and never touch a real socket a successor already bound.
+   */
+  private async removeOwnedSocketPlaceholder(): Promise<void> {
+    if (this.listenFd !== undefined || !this.ownedSocketIdentity) {
+      return;
+    }
+    try {
+      const stats = await lstat(this.socketPath);
+      if (stats.isSocket()) {
+        return;
+      }
+      await unlink(this.socketPath);
+    } catch {
+      // Best effort: a placeholder we cannot remove is reaped by the successor.
     }
   }
 
@@ -1200,6 +1356,10 @@ if (isMainModule(import.meta.url, process.argv[1])) {
   // A GUI-launched client starts the daemon without a login shell, so the
   // config file is read here too rather than only in the CLI entrypoint.
   loadCmuxlayerConfigFile();
+  // The spawning proxy now PIPES daemon stderr so a startup failure can be
+  // reported to its waiters. A piped stderr breaks when that parent exits; an
+  // unhandled EPIPE there would kill an otherwise healthy shared daemon.
+  process.stderr.on("error", () => {});
   runDaemon().catch((error) => {
     console.error("[cmuxlayer-daemon] fatal", error);
     process.exit(1);

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -8,7 +8,18 @@ import {
   type CmuxLayerProxyOptions,
 } from "./proxy.js";
 import { defaultDaemonSocketPath as resolveDefaultDaemonSocketPath } from "./daemon-socket-path.js";
-import { spawnDaemonProcess, type SpawnDaemonOptions } from "./daemon-spawn.js";
+import {
+  awaitDaemonStderrDrained,
+  capturedDaemonStderr,
+  spawnDaemonProcess,
+  type SpawnDaemonOptions,
+} from "./daemon-spawn.js";
+import {
+  DaemonReadinessTimeoutError,
+  DaemonStartupFailedError,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+} from "./daemon-lifecycle-state.js";
 import { callerContextFromEnv } from "./caller-context.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
@@ -101,27 +112,191 @@ export async function probeDaemonSocket(socketPath: string): Promise<boolean> {
   });
 }
 
-async function waitForDaemon(
-  socketPath: string,
-  opts: Required<
-    Pick<
-      DaemonFirstEntryOptions,
-      "probeDaemon" | "sleep" | "autostartTimeoutMs" | "autostartPollMs"
-    >
-  >,
-): Promise<boolean> {
-  const deadline = Date.now() + opts.autostartTimeoutMs;
-  do {
-    if (await opts.probeDaemon(socketPath)) {
-      return true;
-    }
-    if (opts.autostartTimeoutMs === 0) {
-      return false;
-    }
-    await opts.sleep(opts.autostartPollMs);
-  } while (Date.now() < deadline);
+/** The subset of a spawned daemon child that readiness needs to observe. */
+export interface DaemonChildLike {
+  once?(event: string, listener: (...args: any[]) => void): unknown;
+  off?(event: string, listener: (...args: any[]) => void): unknown;
+  removeListener?(event: string, listener: (...args: any[]) => void): unknown;
+  /**
+   * Settled exit state. A child that died before readiness attached its
+   * listeners will never emit `exit` again, so these fields are the only
+   * evidence of why it is gone (#530 review).
+   */
+  exitCode?: number | null;
+  signalCode?: string | null;
+  /** Generation marker for lifecycle exit recording (#530 F9). */
+  pid?: number | null;
+}
 
-  return opts.probeDaemon(socketPath);
+export interface DaemonReadinessOptions {
+  socketPath: string;
+  probeDaemon: (socketPath: string) => Promise<boolean>;
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  pollMs: number;
+  /** The spawned daemon, when this process is the one that spawned it. */
+  child?: DaemonChildLike | null;
+  /** Bounded excerpt of what the child printed on stderr. */
+  readStderr?: () => string;
+  now?: () => number;
+}
+
+/**
+ * Wait for the daemon to answer on its socket, ALWAYS settling.
+ *
+ * #529: the old poll loop watched only the socket. When the spawned daemon
+ * fataled on a leftover socket file and exited code 1, nothing rejected — the
+ * readiness promise simply never settled and every daemon-dependent tool
+ * deadlocked. The child's `exit`/`error` events are now wired straight into
+ * the rejection path, and the deadline is a hard bound.
+ */
+export async function awaitDaemonReadiness(
+  opts: DaemonReadinessOptions,
+): Promise<void> {
+  const now = opts.now ?? Date.now;
+  const startedAt = now();
+  const readStderr = () => {
+    try {
+      return opts.readStderr?.() ?? "";
+    } catch {
+      return "";
+    }
+  };
+
+  let onExit: ((code: number | null, signal: string | null) => void) | null =
+    null;
+  let onError: ((error: Error) => void) | null = null;
+  const child = opts.child;
+  // #530 review P2-7: once childFailure wins the race, the polling loop must
+  // stop. Without this it kept probing and sleeping to the deadline behind an
+  // already-settled promise.
+  let aborted = false;
+
+  const childFailure = new Promise<never>((_, reject) => {
+    if (!child) {
+      return;
+    }
+    // #530 review (Macroscope, src/entry.ts:189): a daemon that dies BEFORE we
+    // attach listeners is already gone — node never replays the missed `exit`,
+    // so the old wiring reported a readiness TIMEOUT after the full deadline
+    // instead of the exit code that actually explains it. Read the settled
+    // fields first.
+    if (child.exitCode !== null && child.exitCode !== undefined) {
+      recordDaemonExit({
+        code: child.exitCode,
+        signal: child.signalCode ?? null,
+        pid: child.pid ?? null,
+        stderrExcerpt: readStderr(),
+      });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: child.exitCode,
+          signal: child.signalCode ?? null,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+      return;
+    }
+    if (child.signalCode !== null && child.signalCode !== undefined) {
+      recordDaemonExit({
+        code: null,
+        signal: child.signalCode,
+        pid: child.pid ?? null,
+        stderrExcerpt: readStderr(),
+      });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: null,
+          signal: child.signalCode,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+      return;
+    }
+    if (typeof child.once !== "function") {
+      return;
+    }
+    onExit = (code, signal) => {
+      // #530 (Codex P1): give the piped stderr a bounded moment to finish
+      // arriving before we classify the failure — the daemon prints its refusal
+      // marker and exits immediately, so `exit` can beat the pipe.
+      void awaitDaemonStderrDrained(child).then(() => {
+        rejectWithExit(code, signal);
+      });
+    };
+    const rejectWithExit = (code: number | null, signal: string | null) => {
+      // Record here as well as in the spawner: readiness is the authority on
+      // "the daemon died before it could serve", whoever spawned it.
+      recordDaemonExit({
+        code,
+        signal,
+        pid: child.pid ?? null,
+        stderrExcerpt: readStderr(),
+      });
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          exitCode: code,
+          signal,
+          stderrExcerpt: readStderr(),
+        }),
+      );
+    };
+    onError = (error) => {
+      recordDaemonLifecycleError(error.message);
+      reject(
+        new DaemonStartupFailedError({
+          socketPath: opts.socketPath,
+          reason: `spawn failed: ${error.message}`,
+          stderrExcerpt: readStderr(),
+          cause: error,
+        }),
+      );
+    };
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+  // Nothing else may observe this promise until the race below.
+  childFailure.catch(() => {});
+
+  const polling = (async (): Promise<void> => {
+    const deadline = startedAt + opts.timeoutMs;
+    for (;;) {
+      if (aborted) return;
+      if (await opts.probeDaemon(opts.socketPath)) {
+        return;
+      }
+      if (aborted) return;
+      if (opts.timeoutMs === 0 || now() >= deadline) {
+        throw new DaemonReadinessTimeoutError({
+          socketPath: opts.socketPath,
+          waitedMs: Math.max(0, now() - startedAt),
+          stderrExcerpt: readStderr(),
+        });
+      }
+      await opts.sleep(opts.pollMs);
+    }
+  })();
+
+  try {
+    await Promise.race([polling, childFailure]);
+  } finally {
+    aborted = true;
+    polling.catch(() => {});
+    const detach =
+      child &&
+      (typeof child.off === "function"
+        ? child.off.bind(child)
+        : typeof child.removeListener === "function"
+          ? child.removeListener.bind(child)
+          : null);
+    if (detach) {
+      if (onExit) detach("exit", onExit);
+      if (onError) detach("error", onError);
+    }
+  }
 }
 
 export async function startInProcessRuntime(
@@ -158,8 +333,7 @@ export async function startInProcessRuntime(
   const explicitStateDir = runtimeEnv.CMUXLAYER_STATE_DIR?.trim();
   const serverOpts: CreateServerOptions = {
     client,
-    safetyCallerContextProvider: () =>
-      callerContextFromEnv(runtimeEnv),
+    safetyCallerContextProvider: () => callerContextFromEnv(runtimeEnv),
     outboxDrain: () => drainOutbox({ deliver: httpDeliver }),
     monitorRegistryPath: defaultMonitorRegistryPath(),
     monitorRegistryNotify: httpNotifyMonitorDeadman,
@@ -317,22 +491,44 @@ export async function runDaemonFirstEntry(
     );
   }
 
-  const available = await waitForDaemon(socketPath, {
-    probeDaemon,
-    sleep,
-    autostartTimeoutMs,
-    autostartPollMs,
-  });
-  if (available) {
+  let readinessError: unknown = null;
+  try {
+    await awaitDaemonReadiness({
+      socketPath,
+      probeDaemon,
+      sleep,
+      timeoutMs: autostartTimeoutMs,
+      pollMs: autostartPollMs,
+      child: spawnedDaemon as DaemonChildLike | null,
+      readStderr: () => capturedDaemonStderr(spawnedDaemon),
+    });
     return startProxy();
+  } catch (error) {
+    readinessError = error;
   }
 
+  // A daemon that came up on the very last tick still wins the race.
   if (await probeDaemon(socketPath)) {
     return startProxy();
   }
 
   terminateSpawnedDaemon(spawnedDaemon, logger);
+  const detail =
+    readinessError instanceof DaemonStartupFailedError
+      ? `daemon exited before ready (code=${readinessError.exitCode ?? "none"}, signal=${
+          readinessError.signal ?? "none"
+        })${
+          readinessError.stderrExcerpt
+            ? `; daemon stderr: ${readinessError.stderrExcerpt}`
+            : ""
+        }`
+      : `daemon autostart timeout${
+          readinessError instanceof DaemonReadinessTimeoutError
+            ? ` after ${readinessError.waitedMs}ms`
+            : ""
+        }`;
+  recordDaemonLifecycleError(detail);
   return fallback(
-    `daemon unavailable; using heavy in-process runtime after daemon autostart timeout at ${socketPath}`,
+    `daemon unavailable; using heavy in-process runtime after ${detail} at ${socketPath}`,
   );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,8 +50,10 @@ import {
   RetryableDeliveryError,
   buildLaunchCommand,
   resolveSweepTiming,
+  LifecycleLockTimeoutError,
   type AgentDeliveryReceipt,
   type AgentLifecycleEvent,
+  type LifecycleLockState,
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
@@ -236,6 +238,7 @@ import {
   collectControlHealth,
   formatControlHealth,
   type ControlHealth,
+  type LifecycleStartHealth,
 } from "./control-health.js";
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
@@ -1419,6 +1422,22 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     error.code === PLACEMENT_WORKSPACE_UNRESOLVED
       ? { error_code: PLACEMENT_WORKSPACE_UNRESOLVED }
       : {};
+  // #529: the bounded lifecycle timeouts carry a `code` that must reach the
+  // tool payload, or automated callers see only free text and cannot tell a
+  // bounded control-plane wait from any other failure. Both are retryable.
+  const lifecycleTimeoutExtra =
+    error instanceof LifecycleStartTimeoutError
+      ? { error_code: error.code, waited_ms: error.waitedMs, retryable: true }
+      : error instanceof LifecycleLockTimeoutError
+        ? {
+            error_code: error.code,
+            waited_ms: error.waitedMs,
+            lock_holder: error.holder,
+            held_for_ms: error.heldForMs,
+            queue_depth: error.queueDepth,
+            retryable: true,
+          }
+        : {};
   const readinessTimeout = findErrorInChain(
     error,
     (candidate): candidate is BootPromptTimeoutError | LauncherReadinessError =>
@@ -1455,6 +1474,7 @@ function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
     ...deliverySafetyExtra,
     ...submitVerificationExtra,
     ...placementWorkspaceExtra,
+    ...lifecycleTimeoutExtra,
     ...readinessExtra,
     ...extra,
     ...createdIdentityFromError(error),
@@ -3409,6 +3429,60 @@ export type LifecycleAgentInputDeliverer = (args: {
   delivery_id?: string;
 }) => Promise<PublicDeliveryReceipt & { bytes: number }>;
 
+export const DEFAULT_LIFECYCLE_START_TIMEOUT_MS = 60_000;
+
+/** Lifecycle initialization never settled inside its bound (#529). */
+export class LifecycleStartTimeoutError extends Error {
+  readonly code = "ELIFECYCLESTARTTIMEOUT";
+  readonly waitedMs: number;
+
+  constructor(waitedMs: number) {
+    super(
+      `cmuxlayer lifecycle initialization did not complete within ${waitedMs}ms; ` +
+        "the daemon or its startup sweep is wedged. " +
+        "Retry; if it persists, see control_health.daemon_lifecycle.lifecycle_start.",
+    );
+    this.name = "LifecycleStartTimeoutError";
+    this.waitedMs = waitedMs;
+  }
+}
+
+export function resolveLifecycleStartTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.CMUXLAYER_LIFECYCLE_START_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_LIFECYCLE_START_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_LIFECYCLE_START_TIMEOUT_MS;
+}
+
+export async function awaitBoundedLifecycleStart(
+  promise: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  if (timeoutMs <= 0) {
+    await promise;
+    return;
+  }
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new LifecycleStartTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export interface CmuxServerContext {
   client: CmuxLayerClient;
   /** Persisted stable socket-node owner identity. */
@@ -3452,6 +3526,14 @@ export interface CmuxServerContext {
   lifecycleStarted: boolean;
   lifecycleStartPromise: Promise<void> | null;
   lifecycleStartError: Error | null;
+  /** #529 observability: when lifecycle init began and whether it settled. */
+  lifecycleStartStartedAtMs: number | null;
+  lifecycleStartSettledAtMs: number | null;
+  /** Callers that gave up on the bounded lifecycle wait. */
+  lifecycleStartTimeouts: number;
+  lifecycleStartLastTimeoutAt: string | null;
+  /** Lifecycle-lock truth for `control_health`, published by the live engine. */
+  lifecycleLockStateProvider: (() => LifecycleLockState) | null;
   lifecycleSweepEngine: AgentEngine | null;
   lifecycleAgentInputDeliverer: LifecycleAgentInputDeliverer | null;
   lifecycleAgentInputDelivererReadyListeners: Set<() => void>;
@@ -3596,6 +3678,11 @@ export function createServerContext(
     lifecycleStarted: false,
     lifecycleStartPromise: null,
     lifecycleStartError: null,
+    lifecycleStartStartedAtMs: null,
+    lifecycleStartSettledAtMs: null,
+    lifecycleStartTimeouts: 0,
+    lifecycleStartLastTimeoutAt: null,
+    lifecycleLockStateProvider: null,
     lifecycleSweepEngine: null,
     lifecycleAgentInputDeliverer: null,
     lifecycleAgentInputDelivererReadyListeners: new Set(),
@@ -3632,6 +3719,11 @@ export function createServerContext(
       context.lifecycleStarted = false;
       context.lifecycleStartPromise = null;
       context.lifecycleStartError = null;
+      context.lifecycleStartStartedAtMs = null;
+      context.lifecycleStartSettledAtMs = null;
+      context.lifecycleStartTimeouts = 0;
+      context.lifecycleStartLastTimeoutAt = null;
+      context.lifecycleLockStateProvider = null;
       if (autoVitestStateDir) {
         removeAutoVitestTempDir(autoVitestStateDir);
       }
@@ -4919,10 +5011,32 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     });
   };
 
+  const describeLifecycleStart = (): LifecycleStartHealth => {
+    const settled =
+      context.lifecycleStartPromise === null ||
+      context.lifecycleStartSettledAtMs !== null;
+    return {
+      started: context.lifecycleStarted,
+      settled,
+      waiting_for_ms:
+        settled || context.lifecycleStartStartedAtMs === null
+          ? null
+          : Date.now() - context.lifecycleStartStartedAtMs,
+      timeout_ms: resolveLifecycleStartTimeoutMs(),
+      error: context.lifecycleStartError?.message ?? null,
+      timeouts: context.lifecycleStartTimeouts,
+      last_timeout_at: context.lifecycleStartLastTimeoutAt,
+    };
+  };
+
   const appendControlHealthSnapshot = async (): Promise<ControlHealth> => {
     const rawHealth = controlHealthCollector
       ? await controlHealthCollector()
-      : await collectControlHealth({ client });
+      : await collectControlHealth({
+          client,
+          lifecycleLock: context.lifecycleLockStateProvider?.() ?? null,
+          lifecycleStart: describeLifecycleStart(),
+        });
     const knownSurfaceIds = [
       ...stateMgr.listStates().map((record) => record.surface_id),
       ...roleSurfaceOverrides.keys(),
@@ -4930,8 +5044,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ...activeSurfaceWrites.keys(),
       ...surfaceWriteLivenessCandidates,
     ];
+    // #529: a dead daemon and a wedged lifecycle lock used to look identical
+    // to a healthy control plane. Publish both, always.
     const healthWithSelfHeal: ControlHealth = {
       ...rawHealth,
+      daemon_lifecycle: {
+        ...rawHealth.daemon_lifecycle,
+        lifecycle_lock: context.lifecycleLockStateProvider?.() ?? null,
+        lifecycle_start: describeLifecycleStart(),
+      },
       self_heal: collectSelfHealHealth({
         surfaceWriteLiveness,
         surfaceIds: knownSurfaceIds,
@@ -11268,9 +11389,28 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return null;
       }
     };
+    const lifecycleStartTimeoutMs = resolveLifecycleStartTimeoutMs();
+    /**
+     * #529: this used to `await context.lifecycleStartPromise` with no bound.
+     * When the daemon died before ready that promise never settled, so every
+     * tool gated on it deadlocked in silence. The wait is bounded now, and a
+     * timeout is COUNTED so the new bound is not itself invisible. It must NOT
+     * set lifecycleStartError: init may still be in flight and succeed.
+     */
     const awaitLifecycleStart = async (): Promise<void> => {
       if (context.lifecycleStartPromise) {
-        await context.lifecycleStartPromise;
+        try {
+          await awaitBoundedLifecycleStart(
+            context.lifecycleStartPromise,
+            lifecycleStartTimeoutMs,
+          );
+        } catch (error) {
+          if (error instanceof LifecycleStartTimeoutError) {
+            context.lifecycleStartTimeouts += 1;
+            context.lifecycleStartLastTimeoutAt = new Date().toISOString();
+          }
+          throw error;
+        }
       }
       if (context.lifecycleStartError) {
         throw context.lifecycleStartError;
@@ -11660,19 +11800,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     lifecycleEnsureRegistered = async () => {
       await awaitLifecycleStart();
-      await engine.runLifecycleMutation(() =>
-        registry.listMerged(discovery, { force: true }).then(() => undefined),
+      await engine.runLifecycleMutation(
+        () =>
+          registry.listMerged(discovery, { force: true }).then(() => undefined),
+        { label: "lifecycle-ensure-registered" },
       );
     };
     lifecycleRefreshManagedMetadata = async (agentId?: string) => {
       await awaitLifecycleStart();
-      await engine.runLifecycleMutation(() =>
-        registry
-          .refreshManagedSurfaceMetadata(discovery, {
-            agentId,
-            force: true,
-          })
-          .then(() => undefined),
+      await engine.runLifecycleMutation(
+        () =>
+          registry
+            .refreshManagedSurfaceMetadata(discovery, {
+              agentId,
+              force: true,
+            })
+            .then(() => undefined),
+        { label: "lifecycle-refresh-managed-metadata" },
       );
     };
 
@@ -12234,113 +12378,122 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       },
       ANNOTATIONS.mutating,
       async (args) => {
-        await awaitLifecycleStart();
-        const child = resolveCurrentCallerAgent();
-        if (!child) {
-          return err("report_to_parent requires a managed calling agent", {
-            error_code: "report_caller_unmanaged",
-          });
-        }
-        if (!child.parent_agent_id) {
-          return err(`Agent ${child.agent_id} has no parent`, {
-            error_code: "report_parent_missing",
-            child_agent_id: child.agent_id,
-          });
-        }
-
-        const intendedParentId = child.parent_agent_id;
-        const directMessage = dispatch(
-          intendedParentId,
-          {
-            from: child.agent_id,
-            reply_to: child.agent_id,
-            via: child.surface_id,
-            observed_at: new Date().toISOString(),
-            to: intendedParentId,
-            tag: "parent_blocker",
-            task: args.blocker,
-          },
-          inboxOpts,
-        );
-        context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
-
-        const parent =
-          registry.get(intendedParentId) ?? stateMgr.readState(intendedParentId);
-        let directError = "parent is absent from the lifecycle registry";
-        if (parent) {
-          try {
-            const wake = await deliverReportInboxPointer(parent, directMessage);
-            return okFormatted(
-              `report_to_parent ${parent.agent_id}: ${wake.delivery}`,
-              {
-                child_agent_id: child.agent_id,
-                parent_agent_id: intendedParentId,
-                notified_agent_id: parent.agent_id,
-                route: "direct",
-                durable: true,
-                ...wake,
-              },
-            );
-          } catch (error) {
-            directError = error instanceof Error ? error.message : String(error);
+        try {
+          await awaitLifecycleStart();
+          const child = resolveCurrentCallerAgent();
+          if (!child) {
+            return err("report_to_parent requires a managed calling agent", {
+              error_code: "report_caller_unmanaged",
+            });
           }
-        }
+          if (!child.parent_agent_id) {
+            return err(`Agent ${child.agent_id} has no parent`, {
+              error_code: "report_parent_missing",
+              child_agent_id: child.agent_id,
+            });
+          }
 
-        const visited = new Set<string>([child.agent_id, intendedParentId]);
-        let ancestorId = parent?.parent_agent_id ?? null;
-        while (ancestorId && !visited.has(ancestorId)) {
-          visited.add(ancestorId);
-          const ancestor =
-            registry.get(ancestorId) ?? stateMgr.readState(ancestorId);
-          if (!ancestor) break;
-          const prefix =
-            `Delivery to parent ${intendedParentId} failed (${directError}). ` +
-            `Child ${child.agent_id} reports: `;
-          const fallbackTask = `${prefix}${args.blocker}`.slice(0, 500);
-          const fallbackMessage = dispatch(
-            ancestor.agent_id,
+          const intendedParentId = child.parent_agent_id;
+          const directMessage = dispatch(
+            intendedParentId,
             {
               from: child.agent_id,
               reply_to: child.agent_id,
               via: child.surface_id,
               observed_at: new Date().toISOString(),
-              to: ancestor.agent_id,
-              tag: "parent_delivery_failed",
-              task: fallbackTask,
+              to: intendedParentId,
+              tag: "parent_blocker",
+              task: args.blocker,
             },
             inboxOpts,
           );
-          try {
-            const wake = await deliverReportInboxPointer(
-              ancestor,
-              fallbackMessage,
-            );
-            return okFormatted(
-              `report_to_parent ${intendedParentId}: fallback ${ancestor.agent_id} ${wake.delivery}`,
-              {
-                child_agent_id: child.agent_id,
-                parent_agent_id: intendedParentId,
-                notified_agent_id: ancestor.agent_id,
-                route: "fallback",
-                durable: true,
-                ...wake,
-              },
-            );
-          } catch (error) {
-            directError = error instanceof Error ? error.message : String(error);
-            ancestorId = ancestor.parent_agent_id;
-          }
-        }
+          context.lifecycleSweepEngine?.requestFleetSidebarRepublish();
 
-        return err(
-          `Blocker was written to ${intendedParentId}'s inbox, but no parent or ancestor could be woken: ${directError}`,
-          {
-            error_code: "report_parent_unreachable",
-            child_agent_id: child.agent_id,
-            parent_agent_id: intendedParentId,
-            durable: true,
-          },
-        );
+          const parent =
+            registry.get(intendedParentId) ?? stateMgr.readState(intendedParentId);
+          let directError = "parent is absent from the lifecycle registry";
+          if (parent) {
+            try {
+              const wake = await deliverReportInboxPointer(parent, directMessage);
+              return okFormatted(
+                `report_to_parent ${parent.agent_id}: ${wake.delivery}`,
+                {
+                  child_agent_id: child.agent_id,
+                  parent_agent_id: intendedParentId,
+                  notified_agent_id: parent.agent_id,
+                  route: "direct",
+                  durable: true,
+                  ...wake,
+                },
+              );
+            } catch (error) {
+              directError = error instanceof Error ? error.message : String(error);
+            }
+          }
+
+          const visited = new Set<string>([child.agent_id, intendedParentId]);
+          let ancestorId = parent?.parent_agent_id ?? null;
+          while (ancestorId && !visited.has(ancestorId)) {
+            visited.add(ancestorId);
+            const ancestor =
+              registry.get(ancestorId) ?? stateMgr.readState(ancestorId);
+            if (!ancestor) break;
+            const prefix =
+              `Delivery to parent ${intendedParentId} failed (${directError}). ` +
+              `Child ${child.agent_id} reports: `;
+            const fallbackTask = `${prefix}${args.blocker}`.slice(0, 500);
+            const fallbackMessage = dispatch(
+              ancestor.agent_id,
+              {
+                from: child.agent_id,
+                reply_to: child.agent_id,
+                via: child.surface_id,
+                observed_at: new Date().toISOString(),
+                to: ancestor.agent_id,
+                tag: "parent_delivery_failed",
+                task: fallbackTask,
+              },
+              inboxOpts,
+            );
+            try {
+              const wake = await deliverReportInboxPointer(
+                ancestor,
+                fallbackMessage,
+              );
+              return okFormatted(
+                `report_to_parent ${intendedParentId}: fallback ${ancestor.agent_id} ${wake.delivery}`,
+                {
+                  child_agent_id: child.agent_id,
+                  parent_agent_id: intendedParentId,
+                  notified_agent_id: ancestor.agent_id,
+                  route: "fallback",
+                  durable: true,
+                  ...wake,
+                },
+              );
+            } catch (error) {
+              directError = error instanceof Error ? error.message : String(error);
+              ancestorId = ancestor.parent_agent_id;
+            }
+          }
+
+          return err(
+            `Blocker was written to ${intendedParentId}'s inbox, but no parent or ancestor could be woken: ${directError}`,
+            {
+              error_code: "report_parent_unreachable",
+              child_agent_id: child.agent_id,
+              parent_agent_id: intendedParentId,
+              durable: true,
+            },
+          );
+        } catch (error) {
+          // #530 (CodeRabbit): the initial awaitLifecycleStart() used to run
+          // OUTSIDE any error path, so a bounded lifecycle-start timeout escaped
+          // the handler entirely and lost the structured error_code / waited_ms /
+          // retryable payload that err() attaches. Wrapping the whole body also
+          // closes the escaping inbox-write exceptions noted as D36.
+          return err(error);
+        }
       },
     );
     engine.setDeliverySnapshotReader(async (receipt: AgentDeliveryReceipt) => {
@@ -12416,6 +12569,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!context.lifecycleStarted) {
       context.lifecycleStarted = true;
       context.lifecycleStartError = null;
+      context.lifecycleStartStartedAtMs = Date.now();
+      context.lifecycleStartSettledAtMs = null;
       const lifecycleInitialization = lifecycleInitializer
         ? Promise.resolve().then(() => lifecycleInitializer())
         : engine.initialize(discovery);
@@ -12429,6 +12584,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         })
         .then(() => {
+          context.lifecycleStartSettledAtMs = Date.now();
           if (
             !context.lifecycleStartError &&
             context.lifecycleStarted &&
@@ -12438,6 +12594,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         });
     }
+    context.lifecycleLockStateProvider = () => engine.lifecycleLockState();
     // The daemon may immediately use this relay for monitor recovery. Publish
     // it only after persisted lifecycle state has been reconstituted so route
     // resolution is ready, then wake any boot-time recovery claim.
@@ -15123,7 +15280,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 (!requestedIds || requestedIds.has(agent.agent_id)),
             );
             return { merged: scoped, discovered, observedAtMs };
-          });
+          }, { label: "list-agents" });
           return await buildListAgentsResponse(
             live.merged,
             topology,
@@ -15239,7 +15396,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             discovery.invalidate();
             return registry.listMerged(discovery, { force: true });
           }
-        });
+        }, { label: "collect-target-records" });
       } catch (e) {
         if (isSurfaceEnumerationError(e)) {
           throw new Error(
@@ -16800,8 +16957,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           await awaitLifecycleStart();
-          const merged = await engine.runLifecycleMutation(() =>
-            registry.listMerged(discovery),
+          const merged = await engine.runLifecycleMutation(
+            () => registry.listMerged(discovery),
+            { label: "list-agent-hierarchy" },
           );
           const agents = args.parent_agent_id
             ? (() => {

--- a/tests/daemon-deadlock-529-behaviour.test.ts
+++ b/tests/daemon-deadlock-529-behaviour.test.ts
@@ -1,0 +1,227 @@
+/**
+ * #529 BEHAVIOURAL bite tests — the reviewer's round-2 requirement.
+ *
+ * These deliberately import ONLY symbols that already existed on `main`
+ * (`CmuxLayerDaemon`, `AgentEngine`, `StateManager`, `AgentRegistry`) and steer
+ * the new bounds through ENVIRONMENT VARIABLES rather than new options. So they
+ * keep failing on the unfixed tree, and they survive any later refactor or
+ * rename of the symbols this PR introduced.
+ *
+ * TEST1 (ENOTSOCK bite): a dead-owner leftover at the socket path must be
+ *   reaped, not fataled on. Pre-fix: `daemon.start()` rejects with ENOTSOCK.
+ * TEST4 (unbounded acquire): a wedged lifecycle holder must not make later
+ *   callers wait forever. Pre-fix: the queued call never settles and this test
+ *   fails by timeout.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CmuxLayerDaemon } from "../src/daemon.js";
+import { AgentEngine } from "../src/agent-engine.js";
+import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import type { CmuxClient, ExecFn } from "../src/cmux-client.js";
+
+// Unix socket paths cap near 104 bytes on macOS; keep the root short.
+const TEST_ROOT = join(tmpdir(), "cmux529b");
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+  vi.restoreAllMocks();
+});
+
+function listWorkspacesExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  }) as unknown as ExecFn;
+}
+
+describe("#529 behavioural bite", () => {
+  it("TEST1: starts over a dead-owner leftover instead of fataling on ENOTSOCK", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = join(TEST_ROOT, `bite1-${process.pid}.sock`);
+    rmSync(path, { force: true });
+    // Exactly what a clean daemon shutdown leaves behind: an empty REGULAR
+    // FILE at the socket path. connect(2) answers ENOTSOCK.
+    writeFileSync(path, "");
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listWorkspacesExec(),
+      skipAgentLifecycle: true,
+    });
+    cleanups.push(async () => {
+      await daemon.shutdown();
+      rmSync(path, { force: true });
+      rmSync(`${path}.owner`, { force: true });
+    });
+
+    await expect(daemon.start()).resolves.toBeUndefined();
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("TEST4: a wedged lifecycle holder does not make a later caller wait forever", async () => {
+    const baseDir = join(tmpdir(), `cmux529b-engine-${process.pid}`);
+    rmSync(baseDir, { recursive: true, force: true });
+    mkdirSync(baseDir, { recursive: true });
+
+    // Steer the bound through env only — no symbol this PR added.
+    const priorAcquire =
+      process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+    const priorHold = process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = "60";
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = "150";
+
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    const engine = new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+    });
+
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+      if (priorAcquire === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = priorAcquire;
+      }
+      if (priorHold === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = priorHold;
+      }
+    });
+
+    // The wedge: an operation that never settles.
+    void engine
+      .runLifecycleMutation(() => new Promise<void>(() => {}))
+      .catch(() => {});
+
+    const settled = await Promise.race([
+      engine
+        .runLifecycleMutation(async () => "queued")
+        .then(() => "resolved")
+        .catch(() => "rejected"),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve("never-settled"), 2_000),
+      ),
+    ]);
+
+    // The point is only that it SETTLES. Which way is the bound's business.
+    expect(settled).not.toBe("never-settled");
+  }, 10_000);
+
+  it("TEST4b: the acquire timeout does not let a waiter run beside the live holder", async () => {
+    // #530 review P1-1: releasing the timed-out waiter's own tail slot let the
+    // NEXT caller chain off an already-resolved promise and execute
+    // concurrently with the still-live holder. Mutual exclusion must hold.
+    const baseDir = join(tmpdir(), `cmux529b-excl-${process.pid}`);
+    rmSync(baseDir, { recursive: true, force: true });
+    mkdirSync(baseDir, { recursive: true });
+
+    const priorAcquire =
+      process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+    const priorHold = process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = "40";
+    // Hold bound far beyond the test: the holder stays live throughout.
+    process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = "60000";
+
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    const engine = new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+    });
+
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+      if (priorAcquire === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS = priorAcquire;
+      }
+      if (priorHold === undefined) {
+        delete process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS;
+      } else {
+        process.env.CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS = priorHold;
+      }
+    });
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    let releaseHolder!: () => void;
+
+    const holder = engine.runLifecycleMutation(async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise<void>((resolve) => (releaseHolder = resolve));
+      concurrent -= 1;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // This one gives up on the acquire while the holder is still live.
+    const abandoned = engine
+      .runLifecycleMutation(async () => {
+        concurrent += 1;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        concurrent -= 1;
+      })
+      .catch(() => "timed-out");
+
+    // Queued behind the abandoned waiter. It must NOT start early.
+    const follower = engine.runLifecycleMutation(async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      concurrent -= 1;
+      return "follower";
+    });
+    follower.catch(() => {});
+
+    await abandoned;
+    // Give a broken implementation ample room to run the follower early.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(maxConcurrent).toBe(1);
+
+    releaseHolder();
+    await holder;
+    await Promise.allSettled([follower]);
+    expect(maxConcurrent).toBe(1);
+  }, 10_000);
+});

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Regression suite for #529 — the control-plane daemon deadlock.
+ *
+ * Incident shape (2026-08-24, packaged 0.4.56): a leftover file at the daemon
+ * socket path made `unlinkStaleSocket` throw instead of reaping it, the daemon
+ * exited code 1 immediately after the proxy spawned it, that exit was never
+ * propagated to its readiness waiters, and every daemon-dependent tool
+ * (`list_agents`, `spawn_agent`) deadlocked forever while lock-free tools kept
+ * answering in milliseconds.
+ *
+ * Each test here must fail (hang, throw the wrong shape, or fail to import)
+ * against the pre-fix code.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CmuxLayerDaemon, unlinkStaleSocket } from "../src/daemon.js";
+import {
+  DaemonReadinessTimeoutError,
+  DaemonSocketInUseError,
+  DaemonSocketPathOccupiedError,
+  DaemonStartupFailedError,
+  daemonLifecycleSnapshot,
+  resetDaemonLifecycleState,
+} from "../src/daemon-lifecycle-state.js";
+import { awaitDaemonReadiness } from "../src/entry.js";
+import { AgentEngine, LifecycleLockTimeoutError } from "../src/agent-engine.js";
+import { StateManager } from "../src/state-manager.js";
+import { AgentRegistry } from "../src/agent-registry.js";
+import { collectControlHealth } from "../src/control-health.js";
+import type { CmuxClient, ExecFn } from "../src/cmux-client.js";
+
+// Unix socket paths are capped near 104 bytes on macOS, so keep the root short.
+const TEST_ROOT = join(tmpdir(), "cmux529");
+
+function testSocketPath(name: string): string {
+  mkdirSync(TEST_ROOT, { recursive: true });
+  return join(TEST_ROOT, `${name}-${process.pid}.sock`);
+}
+
+function listSurfacesExec(): ExecFn {
+  return vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args.includes("list-workspaces")) {
+      return {
+        stdout: JSON.stringify({
+          workspaces: [
+            {
+              ref: "workspace:1",
+              title: "Main",
+              index: 0,
+              selected: true,
+              pinned: false,
+            },
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "{}", stderr: "" };
+  }) as unknown as ExecFn;
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+  vi.restoreAllMocks();
+  resetDaemonLifecycleState();
+});
+
+describe("#529 daemon socket path handling", () => {
+  it("reaps a dead-owner leftover at the socket path and starts", async () => {
+    // A clean daemon shutdown leaves an empty REGULAR FILE at the socket path
+    // (`detachOwnedSocketPath` writes the placeholder and never removed it), so
+    // a reboot-time SIGTERM leaves exactly this shape. connect(2) on it returns
+    // ENOTSOCK, which the pre-fix probe re-threw: the successor daemon fataled
+    // instead of reaping a leftover that provably has no live owner.
+    const path = testSocketPath("dead-owner-leftover");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    expect(statSync(path).isSocket()).toBe(false);
+
+    const outcome = await unlinkStaleSocket(path);
+    expect(outcome).toBe("reaped");
+    expect(existsSync(path)).toBe(false);
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    cleanups.push(async () => {
+      await daemon.shutdown();
+      rmSync(path, { force: true });
+    });
+    await daemon.start();
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("never deletes a non-empty file at the socket path", async () => {
+    // A mistyped CMUXLAYER_DAEMON_SOCKET pointing at real data must not be
+    // treated as a stale daemon artifact. Only cmuxlayer's own shape — an EMPTY
+    // regular placeholder, or a dead socket — is reapable.
+    const path = testSocketPath("user-data");
+    rmSync(path, { force: true });
+    writeFileSync(path, "important user data\n");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketPathOccupiedError);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("important user data\n");
+  });
+
+  it("fails closed on an inconclusive probe", async () => {
+    // An unanswered probe is not evidence that the path is free.
+    const path = testSocketPath("inconclusive");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => "unknown",
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).probe).toBe("unknown");
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("refuses a LIVE owner with a structured error instead of a bare throw", async () => {
+    const path = testSocketPath("live-owner");
+    rmSync(path, { force: true });
+    const owner = net.createServer(() => {});
+    await new Promise<void>((resolve) => owner.listen(path, () => resolve()));
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          owner.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    const error = await unlinkStaleSocket(path).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).code).toBe("EDAEMONSOCKETINUSE");
+    expect((error as DaemonSocketInUseError).socketPath).toBe(path);
+    // The live owner's socket must survive — this is the "connect to it" case.
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+
+  it("refuses when the path is replaced between classification and reap", async () => {
+    // dev/ino ALONE cannot identify an object across delete-and-recreate: Linux
+    // hands the freed inode number straight back, so a successor's new SOCKET
+    // can carry the placeholder's exact dev/ino. Identity includes the node
+    // type, which cannot collide.
+    const path = testSocketPath("superseded");
+    rmSync(path, { force: true });
+    writeFileSync(path, "");
+
+    const successor = net.createServer(() => {});
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          successor.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    let probed = false;
+    const error = await unlinkStaleSocket(path, {
+      probe: async () => {
+        if (!probed) {
+          probed = true;
+          rmSync(path, { force: true });
+          await new Promise<void>((resolve) =>
+            successor.listen(path, () => resolve()),
+          );
+        }
+        return "stale";
+      },
+    }).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(DaemonSocketInUseError);
+    expect((error as DaemonSocketInUseError).probe).toBe("superseded");
+    // The successor's live socket is still at the well-known path.
+    expect(statSync(path).isSocket()).toBe(true);
+  });
+});
+
+describe("#529 daemon readiness propagation", () => {
+  it("rejects with exit code and stderr when the daemon child dies before ready", async () => {
+    const child = new EventEmitter() as EventEmitter & { pid?: number };
+    child.pid = 4242;
+    const stderr =
+      "[cmuxlayer-daemon] fatal Error: cmuxlayer daemon socket is already in use";
+
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/never-ready.sock",
+      child,
+      readStderr: () => stderr,
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 5_000,
+      pollMs: 5,
+    });
+    setTimeout(() => child.emit("exit", 1, null), 10);
+
+    const error = await readiness.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonStartupFailedError);
+    expect((error as DaemonStartupFailedError).exitCode).toBe(1);
+    expect((error as DaemonStartupFailedError).stderrExcerpt).toContain(
+      "socket is already in use",
+    );
+    // The failure is recorded, so a dead daemon no longer looks like a healthy one.
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.last_exit?.code).toBe(1);
+    expect(snapshot.last_exit?.stderr_excerpt).toContain(
+      "socket is already in use",
+    );
+  });
+
+  it("reports the exit code of a daemon that died BEFORE readiness attached", async () => {
+    // Node never replays a missed `exit`, so a child that failed fast used to
+    // surface as a readiness TIMEOUT after the full deadline instead of the
+    // exit code that explains it.
+    const child = Object.assign(new EventEmitter(), {
+      pid: 5150,
+      exitCode: 1,
+      signalCode: null,
+    });
+    const alreadyDead = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/died-early.sock",
+      child,
+      readStderr: () =>
+        "[cmuxlayer-daemon] fatal Error: socket is already in use",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      // A deadline far beyond the test: reaching it would be the bug.
+      timeoutMs: 30_000,
+      pollMs: 5,
+    });
+
+    const error = await alreadyDead.then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(DaemonStartupFailedError);
+    expect((error as DaemonStartupFailedError).exitCode).toBe(1);
+    expect((error as DaemonStartupFailedError).stderrExcerpt).toContain(
+      "socket is already in use",
+    );
+  }, 3_000);
+
+  it("bounds readiness so a silent daemon never leaves the promise unsettled", async () => {
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/silent.sock",
+      probeDaemon: async () => false,
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 20,
+      pollMs: 5,
+    });
+    await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+  }, 2_000);
+});
+
+describe("#529 bounded lifecycle lock", () => {
+  function createEngine(baseDir: string): AgentEngine {
+    mkdirSync(baseDir, { recursive: true });
+    const stateMgr = new StateManager(baseDir);
+    const client = {
+      listWorkspaces: async () => ({ workspaces: [] }),
+      listPanes: async () => ({ panes: [] }),
+      listPaneSurfaces: async () => ({ surfaces: [] }),
+    } as unknown as CmuxClient;
+    const registry = new AgentRegistry(stateMgr, async () => []);
+    return new AgentEngine(stateMgr, registry, client, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts: { baseDir },
+      lifecycleLockAcquireTimeoutMs: 40,
+      lifecycleLockHoldTimeoutMs: 80,
+    });
+  }
+
+  it("fails a queued caller fast and names the holder instead of waiting forever", async () => {
+    const baseDir = join(tmpdir(), `cmux529-engine-${process.pid}`);
+    const engine = createEngine(baseDir);
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    // A wedged holder: an operation that never settles.
+    const wedged = engine.runLifecycleMutation(
+      () => new Promise<void>(() => {}),
+      { label: "wedged-op" },
+    );
+    void wedged.catch(() => {});
+
+    const error = await engine
+      .runLifecycleMutation(async () => "queued", { label: "queued-op" })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+    expect(error).toBeInstanceOf(LifecycleLockTimeoutError);
+    const timeout = error as LifecycleLockTimeoutError;
+    expect(timeout.holder).toBe("wedged-op");
+    expect(timeout.waiter).toBe("queued-op");
+    expect(timeout.heldForMs).toBeGreaterThanOrEqual(0);
+    expect(timeout.message).toContain("wedged-op");
+
+    // A wedged operation must not poison the tail: once the hold guard fires,
+    // later callers get the lock instead of inheriting the deadlock.
+    await expect(
+      engine.runLifecycleMutation(async () => "later", { label: "later-op" }),
+    ).resolves.toBe("later");
+  }, 5_000);
+
+  it("reports lock holder, held-for-ms and queue depth", async () => {
+    const baseDir = join(tmpdir(), `cmux529-engine2-${process.pid}`);
+    const engine = createEngine(baseDir);
+    cleanups.push(() => {
+      engine.dispose();
+      rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    let release!: () => void;
+    const held = engine.runLifecycleMutation(
+      () => new Promise<void>((resolve) => (release = resolve)),
+      { label: "held-op" },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const state = engine.lifecycleLockState();
+    expect(state.holder).toBe("held-op");
+    expect(state.held_for_ms).toBeGreaterThanOrEqual(0);
+    expect(state.queue_depth).toBe(0);
+    release();
+    await held;
+    expect(engine.lifecycleLockState().holder).toBeNull();
+  });
+});
+
+describe("#529 control_health observability", () => {
+  it("reports daemon lifecycle state so a dead daemon looks different", async () => {
+    resetDaemonLifecycleState();
+    const health = await collectControlHealth({
+      execFile: async () => ({ stdout: "", stderr: "" }),
+      homeDir: TEST_ROOT,
+      tmpDir: TEST_ROOT,
+    });
+    expect(health.daemon_lifecycle).toBeDefined();
+    expect(health.daemon_lifecycle.spawn_attempts).toBe(0);
+    expect(health.daemon_lifecycle.last_exit).toBeNull();
+  });
+});

--- a/tests/daemon-lifecycle-state.test.ts
+++ b/tests/daemon-lifecycle-state.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #530 round-2 review P2-3: daemon lifecycle state is GENERATION-scoped.
+ *
+ * Carrying a dead generation's exit forward made `control_health` warn "this
+ * runtime is not daemon-backed" permanently, even after a healthy successor
+ * daemon was serving — a false alarm that trains readers to ignore the warning
+ * that actually matters.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DaemonReadinessTimeoutError,
+  DaemonSocketInUseError,
+  DaemonStartupFailedError,
+  daemonLifecycleSnapshot,
+  daemonStderrExcerpt,
+  recordDaemonExit,
+  recordDaemonLifecycleError,
+  recordDaemonSocketInUse,
+  recordDaemonSocketReap,
+  recordDaemonSpawnAttempt,
+  resetDaemonLifecycleState,
+} from "../src/daemon-lifecycle-state.js";
+
+describe("daemon lifecycle state", () => {
+  beforeEach(() => {
+    resetDaemonLifecycleState();
+  });
+
+  it("starts empty", () => {
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.spawn_attempts).toBe(0);
+    expect(snapshot.last_exit).toBeNull();
+    expect(snapshot.last_error).toBeNull();
+    expect(snapshot.socket_path).toBeNull();
+  });
+
+  it("clears the previous generation's failure state on a new spawn attempt", () => {
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 100 });
+    recordDaemonExit({
+      code: 1,
+      signal: null,
+      pid: 100,
+      stderrExcerpt: "boom",
+    });
+    recordDaemonLifecycleError("spawn failed");
+    recordDaemonSocketInUse({ path: "/tmp/gen.sock", ownerPid: 100 });
+
+    const failed = daemonLifecycleSnapshot();
+    expect(failed.last_exit?.code).toBe(1);
+    expect(failed.last_error).toBe("spawn failed");
+    expect(failed.last_socket_in_use).not.toBeNull();
+
+    // A healthy successor generation starts here.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+
+    const successor = daemonLifecycleSnapshot();
+    expect(successor.last_exit).toBeNull();
+    expect(successor.last_error).toBeNull();
+    expect(successor.last_socket_in_use).toBeNull();
+    // Cumulative facts survive: the counter is how you see spawn churn.
+    expect(successor.spawn_attempts).toBe(2);
+    expect(successor.last_spawn_pid).toBe(200);
+  });
+
+  it("ignores a late exit from a superseded daemon generation", () => {
+    // #530 final pass F9 (Codex addendum): the OLD child's `exit` can land
+    // AFTER a healthy successor has spawned. Recording it re-poisoned
+    // `last_exit` and re-raised the "not daemon-backed" warning against a
+    // daemon that is serving fine.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 100 });
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({
+      code: 1,
+      signal: null,
+      pid: 100,
+      stderrExcerpt: "late",
+    });
+
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.last_exit).toBeNull();
+    expect(snapshot.last_spawn_pid).toBe(200);
+  });
+
+  it("still records an exit from the CURRENT generation", () => {
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({
+      code: 3,
+      signal: null,
+      pid: 200,
+      stderrExcerpt: "boom",
+    });
+    expect(daemonLifecycleSnapshot().last_exit?.code).toBe(3);
+  });
+
+  it("records an exit whose pid is unknown rather than dropping it", () => {
+    // An unknown pid cannot be attributed to a generation; dropping it would
+    // reintroduce silence, so it is recorded.
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 200 });
+    recordDaemonExit({ code: 1, signal: null, stderrExcerpt: "no pid" });
+    expect(daemonLifecycleSnapshot().last_exit?.code).toBe(1);
+  });
+
+  it("keeps reap history across generations", () => {
+    recordDaemonSocketReap({
+      path: "/tmp/gen.sock",
+      reason: "dead-owner-leftover",
+    });
+    recordDaemonSpawnAttempt({ socketPath: "/tmp/gen.sock", pid: 300 });
+    expect(daemonLifecycleSnapshot().last_socket_reap?.reason).toBe(
+      "dead-owner-leftover",
+    );
+  });
+
+  it("bounds the stderr excerpt from the tail", () => {
+    const excerpt = daemonStderrExcerpt(`${"x".repeat(5_000)}TAIL`);
+    expect(excerpt.length).toBeLessThanOrEqual(4_000);
+    expect(excerpt.endsWith("TAIL")).toBe(true);
+    expect(daemonStderrExcerpt(undefined)).toBe("");
+  });
+
+  it("carries structured detail on every daemon failure error", () => {
+    const inUse = new DaemonSocketInUseError({
+      socketPath: "/tmp/a.sock",
+      ownerPid: 42,
+      probe: "superseded",
+    });
+    expect(inUse.code).toBe("EDAEMONSOCKETINUSE");
+    expect(inUse.ownerPid).toBe(42);
+    expect(inUse.message).toContain("superseded");
+
+    const failed = new DaemonStartupFailedError({
+      socketPath: "/tmp/a.sock",
+      exitCode: 1,
+      stderrExcerpt: "fatal: socket is already in use",
+    });
+    expect(failed.exitCode).toBe(1);
+    expect(failed.message).toContain("fatal: socket is already in use");
+
+    const timedOut = new DaemonReadinessTimeoutError({
+      socketPath: "/tmp/a.sock",
+      waitedMs: 5_000,
+    });
+    expect(timedOut.waitedMs).toBe(5_000);
+    expect(timedOut.code).toBe("EDAEMONREADINESSTIMEOUT");
+  });
+});


### PR DESCRIPTION
Fixes #529. Supersedes #530 (left open as the reference implementation for #535).

Minimal scope by lead ruling: the four #529 items only. The socket-ownership arbitration layer #530 grew — rename/link arbitration, pid+start-time receipts, cross-process sidecar, handoff protocol — is parked in **#535**, because most findings in its last four review rounds were defects introduced by the previous round's fix.

## Root cause — proven, not assumed

`CmuxLayerDaemon.detachOwnedSocketPath()` parks an **empty regular file** at the socket path on every clean shutdown (`writeFile(path, "", { flag: "wx" })`) so a racing daemon cannot bind mid-shutdown — and nothing ever removed it. `connect(2)` on a regular file answers `ENOTSOCK`, which `probeSocket` re-threw and `unlinkStaleSocket` propagated. A reboot's SIGTERM leaves exactly that leftover, the successor daemon exits 1, and nothing propagated that exit to its readiness waiters.

## What changed

1. **Reap the leftover.** `probeDaemonSocketPath` never re-throws an unexpected errno. Absence is **ENOENT only**; every other errno is a real failure, not "gone". An empty regular file (our own placeholder) or a socket with no listener is stale and reaped, and the placeholder is now removed at the end of `closeListener`. A **non-empty** file, or any other node type, is the operator's data at a mistyped `CMUXLAYER_DAEMON_SOCKET` and is never deleted. An inconclusive probe fails closed. dev/ino **and node type** are revalidated immediately before the unlink — Linux recycles inode numbers across delete-and-recreate, which CI caught (red on Linux, green on macOS).
2. **Propagate the exit.** `awaitDaemonReadiness` wires the child's `exit`/`error` into the rejection path, reads already-settled `exitCode`/`signalCode` for a child that died before listeners attached, hard-bounds the deadline, and aborts polling once the failure wins. Daemon stderr is piped and captured, forwarded with backpressure handling that resumes on `drain`/`error`/`close` and stops writing to a broken destination.
3. **Bound the waits.** `runLifecycleMutation` bounds the acquire (45s) and fails with a structured `LifecycleLockTimeoutError` naming holder, held-for-ms and queue depth. A waiter that gives up **chains** its abandoned slot behind `previous` rather than resolving it, so mutual exclusion holds; the hold guard (120s) is the only liveness path past a holder that never settles. `awaitLifecycleStart` is bounded (60s) and counts its timeouts without latching `lifecycleStartError`. Both bounds sit inside the ~120s harness window, and both errors reach callers through `err()` with `error_code`.
4. **Make it visible.** `control_health` gains a `daemon_lifecycle` block: spawn attempts, last daemon exit code + stderr excerpt, socket reap/in-use decisions, lock holder/held-for/queue-depth/timeouts, lifecycle-start state. Failure state is generation-scoped — a new spawn clears the dead generation's record, and a late exit from a superseded pid is dropped — so a healthy successor stops warning.

## Failing-first: kept tests bite on `origin/main`

`src/` reverted to main, tests kept:

```
× TEST1: starts over a dead-owner leftover instead of fataling on ENOTSOCK
  → promise rejected "Error: connect ENOTSOCK …" instead of resolving
× TEST4: a wedged lifecycle holder does not make a later caller wait forever
  → expected 'never-settled' not to be 'never-settled'
× TEST4b: the acquire timeout does not let a waiter run beside the live holder
  → Test timed out in 10000ms
Test Files  1 failed (1) · Tests  3 failed (3)

× reaps a dead-owner leftover …            → (0, unlinkStaleSocket) is not a function
× never deletes a non-empty file …         → (0, unlinkStaleSocket) is not a function
× fails closed on an inconclusive probe    → (0, unlinkStaleSocket) is not a function
× rejects with exit code and stderr …      → (0, awaitDaemonReadiness) is not a function
× fails a queued caller fast …             → Test timed out in 5000ms
```

## Real-daemon smoke — first time this code meets a live daemon

Built `dist`, planted an **empty regular file** at an isolated daemon socket path with no daemon running, then drove a fresh out-of-band stdio MCP client.

**This branch:**

```
planted placeholder: -rw-r--r--  0 …/cmuxlayer-smoke529.sock   is-socket: False

   0.28s  initialize OK serverInfo={"name":"cmuxlayer","version":"0.4.56"}
   0.29s  tools/list OK count=10 · list_agents registered: true
   0.32s  <- RESULT control_health in 31ms
   0.35s  <- RESULT list_surfaces in 38ms
   0.39s  <- RESULT list_agents in 33ms
   0.41s  ALL STEPS RETURNED
--- STDERR --- [cmuxlayer] transport selected: socket

post-run: srwxr-xr-x  …/cmuxlayer-smoke529.sock   is-socket: True
```

`control_health` on the same run:

```
daemon lifecycle: spawn_attempts=0
  socket reaped: …/cmuxlayer-smoke529b.sock (dead-owner-leftover)
lifecycle lock: holder=none held_for_ms=0 queue_depth=0 timeouts=0 forced_releases=0
lifecycle start: started=true settled=true timeouts=0

lifecycle_lock  {"holder":null,"held_for_ms":null,"queue_depth":0,
                 "acquire_timeout_ms":45000,"hold_timeout_ms":120000,
                 "forced_releases":0,"timeouts":0,"last_timeout":null}
lifecycle_start {"started":true,"settled":true,"waiting_for_ms":null,
                 "timeout_ms":60000,"error":null,"timeouts":0,"last_timeout_at":null}
```

**Same probe against `origin/main`'s dist — and this differs from the tests, so read it:**

```
=== built origin/main dist ===
   5.16s  initialize OK …            <-- 5.16s, not 0.28s
   5.31s  ALL STEPS RETURNED
--- STDERR ---
[cmuxlayer-daemon] fatal Error: connect ENOTSOCK …/cmuxlayer-smokemain.sock
[cmuxlayer-proxy] spawned daemon exited (pid=56412, code=1, signal=none)
[cmuxlayer] WARNING: daemon unavailable; using heavy in-process runtime
            after daemon autostart timeout at …
```

**Stated plainly:** on `main` this scenario does **not** hang — it degrades. The daemon fatals on ENOTSOCK, the entry waits out its 5s autostart timeout, and falls back to the heavy in-process runtime. So the smoke proves item 1 and item 4 against a real daemon (leftover reaped, 18× faster startup, shared daemon preserved instead of lost, `daemon_lifecycle` populated) — it does **not** reproduce the original deadlock. The incident's hang came from the lifecycle path inside an already-live daemon, which items 2 and 3 address and which this smoke does not exercise. Those two remain covered by tests only.

## Gates

- `npx tsc -p tsconfig.json --noEmit` — clean.
- `bash scripts/run_tests.sh` env-stripped via `.githooks/pre-push` (not bypassed): **145 files, 3319 passed, 1 skipped**.
- `npx vitest run` plain env: **145 files, 3319 passed, 1 skipped**.

## Size, stated rather than claimed

`git diff --stat origin/main..HEAD` → **10 files, +2318 / −213** (#530 was 11 files, +3575 / −300). Whitespace-normalised the real change is **+2044 / −82**; the remainder is the `report_to_parent` try-wrap re-indent. `src/server.ts` was rebuilt from `main` with targeted edits rather than copied from #530, which removed ~320 lines of unrelated formatter churn.

The brief estimated ~6 files. It is 10: seven source files are what the four items genuinely touch, plus the three test files the brief itself names. Nothing outside the allowlist is present — verified by grep for receipts, sidecar, handoff, and rename/link arbitration.

## Not verified

No release/install/restart against the packaged bottle. The smoke above is a locally built `dist`, not the Homebrew artifact.

**Do not merge** — lead verifies the allowlist diff and this evidence, then rules.

— cmuxlayer-worker (worker) · claude-code/unknown
<!-- golem-id v1 {"seat":"cmuxlayer-worker","role":"worker","harness":"claude-code","model":"unknown","model_source":"unavailable","session":"9aca6d01","ts":"2026-08-24T16:45:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches daemon socket reaping, process spawn/readiness, and the serialized lifecycle mutex that gates spawn/list/sweep. Incorrect timeout or unlink logic can deadlock tools, race concurrent mutations, or delete the wrong path.
> 
> **Overview**
> Fixes the #529 control-plane hang: a leftover empty file at the daemon socket made startup fatal, the child’s exit never reached waiters, and an unbounded lifecycle mutex could poison `list_agents` / `spawn_agent` forever.
> 
> **Socket reaping** now classifies the path (`live` / `stale` / `occupied` / `unknown`) without re-throwing probe errnos. Empty placeholders and dead sockets are unlinked after a dev/ino+kind recheck; non-empty or foreign nodes are refused. Shutdown also removes the placeholder so a reboot leftover is not `ENOTSOCK`.
> 
> **Readiness** always settles. `awaitDaemonReadiness` races the socket poll against child `exit`/`error` (including already-dead children), captures piped stderr, and falls back with a structured `DaemonStartupFailedError` / timeout instead of hanging.
> 
> **Lifecycle mutex** (`runLifecycleMutation`) bounds acquire (45s) and hold (120s). Timed-out waiters chain behind the live holder so exclusion holds; a hold guard is the only force-release. Lifecycle start waits are bounded (60s) and surface `error_code` / `retryable` on tools.
> 
> **Observability:** `control_health.daemon_lifecycle` reports spawn/exit/reap, lock holder/queue/timeouts, and start health. Failure state is generation-scoped so a healthy successor does not keep warning. Regression tests cover leftover reaping, mutual exclusion, and readiness propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b028e835433d733381d577d5280fd419ccf88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound daemon lifecycle and lock waits to prevent deadlock
> - Replaces unbounded waits for lifecycle start and lifecycle lock acquisition with configurable timeouts (defaults: 60s start, 45s lock acquire, 120s lock hold), throwing typed `LifecycleStartTimeoutError` and `LifecycleLockTimeoutError` with structured diagnostics.
> - Rewrites daemon socket probing and stale-socket reaping in [daemon.ts](https://github.com/EtanHey/cmuxlayer/pull/536/files#diff-6094da7279cd2fea9d33b76d9e0cee18b997e3f726f7e6084d488cfeb47cc539) to classify paths as `live`/`stale`/`missing`/`occupied`/`unknown`, refuse to delete non-artifacts, detect superseded owners, and clean up ENOTSOCK placeholder files on shutdown.
> - Adds bounded daemon readiness in [entry.ts](https://github.com/EtanHey/cmuxlayer/pull/536/files#diff-f85e80d35f2c16b6ccf2dc6bb1214be34f47e879e725e53055b1902a4900dab7) that races socket polling against child exit and timeout, rejecting with `DaemonStartupFailedError` or `DaemonReadinessTimeoutError` carrying stderr excerpts.
> - Surfaces daemon lifecycle, lock state, and start status in control health output and in `report_to_parent` error payloads via new structured fields in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/536/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/536/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d).
> - Risk: new default timeouts apply to all lifecycle waits; set env vars `CMUXLAYER_LIFECYCLE_START_TIMEOUT_MS`, `CMUXLAYER_LIFECYCLE_LOCK_ACQUIRE_TIMEOUT_MS`, or `CMUXLAYER_LIFECYCLE_LOCK_HOLD_TIMEOUT_MS` to `0` to disable. `report_to_parent` now returns structured errors for all exceptions instead of leaking raw throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 32b028e. 7 files reviewed, 10 issues evaluated, 4 issues filtered, 5 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/agent-engine.ts — 1 comment posted, 4 evaluated, 3 filtered</summary>
>
> - [line 3460](https://github.com/EtanHey/cmuxlayer/blob/32b028e835433d733381d577d5280fd419ccf88f/src/agent-engine.ts#L3460): `finalizeCapturedSession` copies `capturedProcessEvidence` into any pre-existing `finalAgentId` whose session ID matches, without verifying that the final row has the pending row's stable surface binding/provenance. If a stale final row for the same resumed session is bound to a different surface, line 3460 stamps that stale row with the new live PID, then the pending row holding the actual surface is deleted. Subsequent liveness guards retain/control the wrong surface and can refuse recovery because the recorded PID appears alive. Require matching `surface_uuid` (or merge the pending row's binding) before transferring process evidence and deleting the pending row. <b>[ Out of scope ]</b>
> - [line 8363](https://github.com/EtanHey/cmuxlayer/blob/32b028e835433d733381d577d5280fd419ccf88f/src/agent-engine.ts#L8363): The async `setInterval` callback does not catch failures from the normal polling path. In particular, `await this.registry.reconcile(...)` can reject when reconciliation persistence fails, causing the timer callback's promise to become an unhandled rejection. Under Node's default `unhandled-rejections=throw` behavior this can terminate the daemon instead of returning a failed `WaitResult`; even with a custom rejection handler, that polling iteration is abandoned. Wrap the full callback body in error handling and settle/continue the wait explicitly. <b>[ Out of scope ]</b>
> - [line 8440](https://github.com/EtanHey/cmuxlayer/blob/32b028e835433d733381d577d5280fd419ccf88f/src/agent-engine.ts#L8440): On the polling terminal-state path, `WaitResult.state` is the live reconciled `liveState`, but `agent` is built from the unreconciled `current` record. If the screen newly confirms `error`/`done` while the registry still says `working`, callers receive a failed result whose top-level state is terminal while `result.agent.state` remains `working`. Build the public agent with `{ ...current, state: liveState }`, as the successful and timeout paths already do. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>src/server.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 6227](https://github.com/EtanHey/cmuxlayer/blob/32b028e835433d733381d577d5280fd419ccf88f/src/server.ts#L6227): `runLifecycleMutation` force-releases the tail after `lifecycleLockHoldTimeoutMs` without cancelling or fencing the still-running `operation()`. If that operation is merely slow or resumes after a hung await, the next queued lifecycle mutation starts concurrently and both can mutate registry/state files, defeating the mutex and risking lost or resurrected state. The acquisition-token check only protects diagnostics; it does not prevent the orphaned operation from continuing. A timeout must fence subsequent writes or fail callers without releasing mutual exclusion. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->