### PR TITLE
fix: identity-check placeholder removal, honour readiness deadline (#536 follow-up)

### DIFF
--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -188,18 +188,37 @@ export async function spawnDaemonProcess(
       `[cmuxlayer-proxy] spawned daemon failed (pid=${child.pid ?? "unknown"}): ${error.message}`,
     );
   });
-  child.once("close", () => {
-    // #530 (Codex P1): `close` fires only after the stdio streams are done, so
-    // by here the captured excerpt is complete. `exit` alone can beat the pipe.
-    stderrSettled.resolve();
-  });
-  child.once("exit", (code, signal) => {
+  // #536 review (Macroscope): the lifecycle record used to be written from the
+  // `exit` handler, which snapshots `buffer.text` BEFORE the stderr pipe has
+  // drained — so a daemon that printed its fatal and died immediately left an
+  // empty `stderr_excerpt`, losing exactly the evidence #529 needed. `close`
+  // fires only after stdio is complete, so the record is written there.
+  let exitRecorded = false;
+  const recordExitOnce = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ) => {
+    if (exitRecorded) return;
+    exitRecorded = true;
     recordDaemonExit({
       code,
       signal,
       pid: child.pid ?? null,
       stderrExcerpt: buffer.text,
     });
+  };
+  child.once("close", (code, signal) => {
+    stderrSettled.resolve();
+    recordExitOnce(code ?? child.exitCode, signal ?? child.signalCode);
+  });
+  child.once("exit", (code, signal) => {
+    // `close` never fires when stderr was inherited rather than piped, so the
+    // exit path still records — bounded, and de-duplicated by the flag above.
+    if (!captureStderr) {
+      recordExitOnce(code, signal);
+    } else {
+      setTimeout(() => recordExitOnce(code, signal), 300).unref?.();
+    }
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,
     );

--- a/src/daemon-spawn.ts
+++ b/src/daemon-spawn.ts
@@ -193,13 +193,22 @@ export async function spawnDaemonProcess(
   // drained — so a daemon that printed its fatal and died immediately left an
   // empty `stderr_excerpt`, losing exactly the evidence #529 needed. `close`
   // fires only after stdio is complete, so the record is written there.
-  let exitRecorded = false;
+  //
+  // #537 review (Codex P2): the fallback below must be PROVISIONAL. If the
+  // child's stream is paused by backpressure, `exit` can fire while `close` is
+  // still pending on unread pipe data — and a fallback that marked the exit
+  // permanently recorded would refuse to let `close` replace a partial excerpt
+  // with the fully drained one, dropping exactly the fatal tail this exists to
+  // keep. `close` always upgrades a provisional record.
+  let exitRecordState: "none" | "provisional" | "final" = "none";
   const recordExitOnce = (
     code: number | null,
     signal: NodeJS.Signals | null,
+    final: boolean,
   ) => {
-    if (exitRecorded) return;
-    exitRecorded = true;
+    if (exitRecordState === "final") return;
+    if (exitRecordState === "provisional" && !final) return;
+    exitRecordState = final ? "final" : "provisional";
     recordDaemonExit({
       code,
       signal,
@@ -209,15 +218,15 @@ export async function spawnDaemonProcess(
   };
   child.once("close", (code, signal) => {
     stderrSettled.resolve();
-    recordExitOnce(code ?? child.exitCode, signal ?? child.signalCode);
+    recordExitOnce(code ?? child.exitCode, signal ?? child.signalCode, true);
   });
   child.once("exit", (code, signal) => {
     // `close` never fires when stderr was inherited rather than piped, so the
     // exit path still records — bounded, and de-duplicated by the flag above.
     if (!captureStderr) {
-      recordExitOnce(code, signal);
+      recordExitOnce(code, signal, true);
     } else {
-      setTimeout(() => recordExitOnce(code, signal), 300).unref?.();
+      setTimeout(() => recordExitOnce(code, signal, false), 300).unref?.();
     }
     opts.logger.error(
       `[cmuxlayer-proxy] spawned daemon exited (pid=${child.pid ?? "unknown"}, code=${code ?? "none"}, signal=${signal ?? "none"})`,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1211,8 +1211,20 @@ export class CmuxLayerDaemon {
       return;
     }
     try {
-      const stats = await lstat(this.socketPath);
-      if (stats.isSocket()) {
+      // #536 review (Macroscope Critical / Codex P1): this used to `lstat` and
+      // then `unlink` BY PATHNAME. A successor that removed the placeholder and
+      // bound its own socket between those two calls lost its live endpoint —
+      // and an operator file that replaced the placeholder was deleted too.
+      // Capture the identity we inspected and prove it is still the same object
+      // immediately before removing it.
+      const observed = await socketIdentity(this.socketPath);
+      if (observed === null || observed.kind === "socket") {
+        // Gone already, or a successor bound a real socket here. Either way it
+        // is not our placeholder to remove.
+        return;
+      }
+      if (!sameIdentity(await socketIdentity(this.socketPath), observed)) {
+        // Replaced between the check and the unlink.
         return;
       }
       await unlink(this.socketPath);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -551,6 +551,7 @@ export class CmuxLayerDaemon {
   private readonly monitorReconcileIntervalMs: number;
   private readonly logger: Pick<Console, "error">;
   private ownedSocketIdentity: { dev: number; ino: number } | null = null;
+  private ownedPlaceholderIdentity: DaemonSocketIdentity | null = null;
 
   constructor(private readonly opts: CmuxLayerDaemonOptions = {}) {
     this.context = opts.context ?? null;
@@ -1222,23 +1223,47 @@ export class CmuxLayerDaemon {
       // identity checks and was deleted. The placeholder we create is an EMPTY
       // regular file, so require exactly that shape, matching the same size
       // rule `probeDaemonSocketPath` uses.
-      const stats = await lstat(this.socketPath);
-      if (!stats.isFile() || stats.size !== 0) {
+      const created = this.ownedPlaceholderIdentity;
+      if (created === null) {
+        // We never recorded creating one, so there is nothing of ours here.
         return;
       }
-      const observed: DaemonSocketIdentity = {
-        dev: stats.dev,
-        ino: stats.ino,
-        kind: "file",
-      };
-      if (!sameIdentity(await socketIdentity(this.socketPath), observed)) {
+      const stats = await lstat(this.socketPath);
+      if (!stats.isFile() || stats.size !== 0) {
+        // Not the empty-placeholder shape: a socket, or an operator's file.
+        return;
+      }
+      if (
+        !sameIdentity(
+          { dev: stats.dev, ino: stats.ino, kind: "file" },
+          created,
+        )
+      ) {
+        // Something replaced our placeholder. Not ours to delete.
+        return;
+      }
+      if (!sameIdentity(await socketIdentity(this.socketPath), created)) {
         // Replaced between the check and the unlink.
         return;
       }
       await unlink(this.socketPath);
+      this.ownedPlaceholderIdentity = null;
     } catch {
       // Best effort: a placeholder we cannot remove is reaped by the successor.
     }
+  }
+
+  /**
+   * Create the shutdown placeholder AND remember exactly which object we
+   * created (#537 review, CodeRabbit): comparing two later lookups only proves
+   * they agree with each other, not that either is ours. A replacement that
+   * lands before the first lookup satisfies both.
+   */
+  private async writeOwnedSocketPlaceholder(): Promise<void> {
+    await writeFile(this.socketPath, "", { flag: "wx" });
+    this.ownedPlaceholderIdentity = await socketIdentity(this.socketPath).catch(
+      () => null,
+    );
   }
 
   private async detachOwnedSocketPath(): Promise<{
@@ -1254,7 +1279,7 @@ export class CmuxLayerDaemon {
       current = await lstat(this.socketPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        await writeFile(this.socketPath, "", { flag: "wx" });
+        await this.writeOwnedSocketPlaceholder();
         return null;
       }
       throw error;
@@ -1266,13 +1291,13 @@ export class CmuxLayerDaemon {
     ) {
       const shelteredPath = `${this.socketPath}.foreign-${process.pid}-${Date.now()}`;
       await rename(this.socketPath, shelteredPath);
-      await writeFile(this.socketPath, "", { flag: "wx" });
+      await this.writeOwnedSocketPlaceholder();
       return { path: shelteredPath, restore: true };
     }
 
     const detachedPath = `${this.socketPath}.closing-${process.pid}-${Date.now()}`;
     await rename(this.socketPath, detachedPath);
-    await writeFile(this.socketPath, "", { flag: "wx" });
+    await this.writeOwnedSocketPlaceholder();
     return { path: detachedPath, restore: false };
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1217,12 +1217,20 @@ export class CmuxLayerDaemon {
       // and an operator file that replaced the placeholder was deleted too.
       // Capture the identity we inspected and prove it is still the same object
       // immediately before removing it.
-      const observed = await socketIdentity(this.socketPath);
-      if (observed === null || observed.kind === "socket") {
-        // Gone already, or a successor bound a real socket here. Either way it
-        // is not our placeholder to remove.
+      // #537 review (Macroscope Critical): rejecting only sockets was not
+      // enough — a NON-EMPTY operator file sitting at the path passed both
+      // identity checks and was deleted. The placeholder we create is an EMPTY
+      // regular file, so require exactly that shape, matching the same size
+      // rule `probeDaemonSocketPath` uses.
+      const stats = await lstat(this.socketPath);
+      if (!stats.isFile() || stats.size !== 0) {
         return;
       }
+      const observed: DaemonSocketIdentity = {
+        dev: stats.dev,
+        ino: stats.ino,
+        kind: "file",
+      };
       if (!sameIdentity(await socketIdentity(this.socketPath), observed)) {
         // Replaced between the check and the unlink.
         return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 
 import net from "node:net";
-import { lstat, mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  open,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname } from "node:path";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type {
@@ -1260,10 +1267,23 @@ export class CmuxLayerDaemon {
    * lands before the first lookup satisfies both.
    */
   private async writeOwnedSocketPlaceholder(): Promise<void> {
-    await writeFile(this.socketPath, "", { flag: "wx" });
-    this.ownedPlaceholderIdentity = await socketIdentity(this.socketPath).catch(
-      () => null,
-    );
+    // #537 review (Macroscope): a separate `socketIdentity()` after the write
+    // could observe a REPLACEMENT if another process unlinked and recreated the
+    // path in between, and we would then treat that foreign file as ours.
+    // `open(path, "wx")` creates it exclusively and hands back a descriptor, so
+    // `fstat` on that handle is the identity of the object WE created — taken
+    // from the creation operation itself rather than a follow-up lookup.
+    const handle = await open(this.socketPath, "wx");
+    try {
+      const stats = await handle.stat();
+      this.ownedPlaceholderIdentity = {
+        dev: stats.dev,
+        ino: stats.ino,
+        kind: "file",
+      };
+    } finally {
+      await handle.close();
+    }
   }
 
   private async detachOwnedSocketPath(): Promise<{

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -278,7 +278,11 @@ export async function awaitDaemonReadiness(
    * wait never leaves a pending handle behind.
    */
   const withDeadline = async <T>(work: Promise<T>): Promise<T> => {
-    if (opts.timeoutMs === 0) return work;
+    // #537 review (Macroscope): an early return for `timeoutMs === 0` bypassed
+    // the race entirely, so a never-settling probe hung forever on exactly the
+    // configuration that asks for no waiting at all. A zero deadline yields a
+    // 0ms timer instead: a well-behaved probe still wins on the microtask
+    // queue, a hung one rejects immediately.
     let timer: NodeJS.Timeout | null = null;
     try {
       return await Promise.race([

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -292,7 +292,13 @@ export async function awaitDaemonReadiness(
             () => reject(timedOut()),
             Math.max(0, deadline - now()),
           );
-          timer.unref?.();
+          // #537 review (Codex P2): deliberately NOT unref'd. A never-settling
+          // probe owns no libuv handle, so an unref'd deadline let node exit
+          // before the timeout fired — the standalone CLI would terminate
+          // instead of reaching its in-process fallback, breaking the
+          // always-settles guarantee outside vitest (which keeps other handles
+          // alive and masked it). The timer is cleared in `finally`, so keeping
+          // it referenced cannot leak.
         }),
       ]);
     } finally {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -261,22 +261,56 @@ export async function awaitDaemonReadiness(
   // Nothing else may observe this promise until the race below.
   childFailure.catch(() => {});
 
+  const deadline = startedAt + opts.timeoutMs;
+  const timedOut = () =>
+    new DaemonReadinessTimeoutError({
+      socketPath: opts.socketPath,
+      waitedMs: Math.max(0, now() - startedAt),
+      stderrExcerpt: readStderr(),
+    });
+
+  /**
+   * #536 review (Codex P2): the loop used to `await opts.probeDaemon(...)`
+   * directly, so a probe that NEVER settles blocked before the deadline check
+   * and `Promise.race` stayed pending forever — the helper reproduced the very
+   * deadlock it exists to bound. Every await inside the loop is now raced
+   * against a standalone deadline timer, cleared in `finally` so a resolved
+   * wait never leaves a pending handle behind.
+   */
+  const withDeadline = async <T>(work: Promise<T>): Promise<T> => {
+    if (opts.timeoutMs === 0) return work;
+    let timer: NodeJS.Timeout | null = null;
+    try {
+      return await Promise.race([
+        work,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(timedOut()),
+            Math.max(0, deadline - now()),
+          );
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+
   const polling = (async (): Promise<void> => {
-    const deadline = startedAt + opts.timeoutMs;
     for (;;) {
       if (aborted) return;
-      if (await opts.probeDaemon(opts.socketPath)) {
+      if (await withDeadline(opts.probeDaemon(opts.socketPath))) {
         return;
       }
       if (aborted) return;
       if (opts.timeoutMs === 0 || now() >= deadline) {
-        throw new DaemonReadinessTimeoutError({
-          socketPath: opts.socketPath,
-          waitedMs: Math.max(0, now() - startedAt),
-          stderrExcerpt: readStderr(),
-        });
+        throw timedOut();
       }
-      await opts.sleep(opts.pollMs);
+      // #536 review (Macroscope): cap the sleep to the remaining time, or a
+      // pollMs larger than timeoutMs overshoots the promised hard deadline.
+      await withDeadline(
+        opts.sleep(Math.max(0, Math.min(opts.pollMs, deadline - now()))),
+      );
     }
   })();
 

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -253,6 +253,33 @@ describe("#536 follow-up: placeholder removal is identity-checked", () => {
     expect(existsSync(path)).toBe(false);
   }, 10_000);
 
+  it("never deletes a non-empty operator file at the socket path", async () => {
+    // #537 review (Macroscope Critical): rejecting only sockets let a NON-EMPTY
+    // operator file pass both identity checks and be deleted.
+    const path = testSocketPath("cleanup-operator-file");
+    rmSync(path, { force: true });
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    await daemon.start();
+    await daemon.shutdown();
+
+    writeFileSync(path, "operator data\n");
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    await (
+      daemon as unknown as {
+        removeOwnedSocketPlaceholder(): Promise<void>;
+      }
+    ).removeOwnedSocketPlaceholder();
+
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toBe("operator data\n");
+  }, 10_000);
+
   it("leaves a successor's live socket alone", async () => {
     // Macroscope Critical / Codex P1 asked for identity revalidation between
     // the lstat and the unlink. The narrow interleaving itself is not
@@ -302,6 +329,20 @@ describe("#536 follow-up: readiness honours always-settles", () => {
       probeDaemon: () => new Promise<boolean>(() => {}),
       sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
       timeoutMs: 40,
+      pollMs: 5,
+    });
+    await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+  }, 3_000);
+
+  it("rejects immediately at timeoutMs=0 when the probe never settles", async () => {
+    // #537 review (Macroscope): the zero-timeout path bypassed the deadline
+    // race entirely, so a hung probe hung forever on the configuration that
+    // asks for no waiting at all.
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/zero-timeout.sock",
+      probeDaemon: () => new Promise<boolean>(() => {}),
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 0,
       pollMs: 5,
     });
     await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -127,6 +127,28 @@ describe("#529 daemon socket path handling", () => {
     expect(readFileSync(path, "utf8")).toBe("important user data\n");
   });
 
+  it("the reap boundary is size: 0 bytes reaped, 1 byte preserved", async () => {
+    // Lead ruling on the Codex P1 (#536): an EMPTY regular file at the socket
+    // path IS the reboot leftover #529 exists to clear, and 0 bytes carries no
+    // operator data to destroy. The guarantee is the size check — anything
+    // non-empty is untouchable. This pins both sides of that boundary.
+    const empty = testSocketPath("boundary-empty");
+    rmSync(empty, { force: true });
+    writeFileSync(empty, "");
+    cleanups.push(() => rmSync(empty, { force: true }));
+    await expect(unlinkStaleSocket(empty)).resolves.toBe("reaped");
+    expect(existsSync(empty)).toBe(false);
+
+    const oneByte = testSocketPath("boundary-one-byte");
+    rmSync(oneByte, { force: true });
+    writeFileSync(oneByte, "x");
+    cleanups.push(() => rmSync(oneByte, { force: true }));
+    await expect(unlinkStaleSocket(oneByte)).rejects.toBeInstanceOf(
+      DaemonSocketPathOccupiedError,
+    );
+    expect(readFileSync(oneByte, "utf8")).toBe("x");
+  });
+
   it("fails closed on an inconclusive probe", async () => {
     // An unanswered probe is not evidence that the path is free.
     const path = testSocketPath("inconclusive");
@@ -209,6 +231,107 @@ describe("#529 daemon socket path handling", () => {
     // The successor's live socket is still at the well-known path.
     expect(statSync(path).isSocket()).toBe(true);
   });
+});
+
+describe("#536 follow-up: placeholder removal is identity-checked", () => {
+  it("removes its OWN placeholder on clean shutdown", async () => {
+    // The #529 root cause: the shutdown placeholder was left behind, and the
+    // next daemon could not reap it. A clean shutdown must leave the path free.
+    const path = testSocketPath("placeholder-cleanup");
+    rmSync(path, { force: true });
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    cleanups.push(() => rmSync(path, { force: true }));
+
+    await daemon.start();
+    expect(statSync(path).isSocket()).toBe(true);
+    await daemon.shutdown();
+    expect(existsSync(path)).toBe(false);
+  }, 10_000);
+
+  it("leaves a successor's live socket alone", async () => {
+    // Macroscope Critical / Codex P1 asked for identity revalidation between
+    // the lstat and the unlink. The narrow interleaving itself is not
+    // deterministically reproducible without an injected filesystem seam — see
+    // the PR body — so this asserts the observable contract: a SOCKET at the
+    // path is never removed by the placeholder cleanup.
+    const path = testSocketPath("successor-survives");
+    rmSync(path, { force: true });
+
+    const daemon = new CmuxLayerDaemon({
+      socketPath: path,
+      exec: listSurfacesExec(),
+      skipAgentLifecycle: true,
+    });
+    await daemon.start();
+    await daemon.shutdown();
+
+    const successor = net.createServer(() => {});
+    await new Promise<void>((resolve) =>
+      successor.listen(path, () => resolve()),
+    );
+    cleanups.push(
+      () =>
+        new Promise<void>((resolve) => {
+          successor.close(() => resolve());
+          rmSync(path, { force: true });
+        }),
+    );
+
+    await (
+      daemon as unknown as {
+        removeOwnedSocketPlaceholder(): Promise<void>;
+      }
+    ).removeOwnedSocketPlaceholder();
+
+    expect(statSync(path).isSocket()).toBe(true);
+  }, 10_000);
+});
+
+describe("#536 follow-up: readiness honours always-settles", () => {
+  it("rejects at the deadline even when the probe NEVER settles", async () => {
+    // Codex P2: the loop awaited probeDaemon directly, so a probe that never
+    // settled blocked before the deadline check and the whole helper hung —
+    // the deadlock it exists to bound, reproduced inside it.
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/never-settles.sock",
+      probeDaemon: () => new Promise<boolean>(() => {}),
+      sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      timeoutMs: 40,
+      pollMs: 5,
+    });
+    await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+  }, 3_000);
+
+  it("rejects at the deadline even when the SLEEP never settles", async () => {
+    const readiness = awaitDaemonReadiness({
+      socketPath: "/tmp/cmux529/sleep-hangs.sock",
+      probeDaemon: async () => false,
+      sleep: () => new Promise<void>(() => {}),
+      timeoutMs: 40,
+      pollMs: 5,
+    });
+    await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+  }, 3_000);
+
+  it("does not overshoot the deadline when pollMs exceeds timeoutMs", async () => {
+    const startedAt = Date.now();
+    await expect(
+      awaitDaemonReadiness({
+        socketPath: "/tmp/cmux529/overshoot.sock",
+        probeDaemon: async () => false,
+        sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+        timeoutMs: 50,
+        // Far larger than the deadline: an uncapped sleep would block ~5s.
+        pollMs: 5_000,
+      }),
+    ).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  }, 5_000);
 });
 
 describe("#529 daemon readiness propagation", () => {

--- a/tests/daemon-deadlock-529.test.ts
+++ b/tests/daemon-deadlock-529.test.ts
@@ -324,6 +324,7 @@ describe("#536 follow-up: readiness honours always-settles", () => {
     // Codex P2: the loop awaited probeDaemon directly, so a probe that never
     // settled blocked before the deadline check and the whole helper hung —
     // the deadlock it exists to bound, reproduced inside it.
+    const startedAt = Date.now();
     const readiness = awaitDaemonReadiness({
       socketPath: "/tmp/cmux529/never-settles.sock",
       probeDaemon: () => new Promise<boolean>(() => {}),
@@ -332,12 +333,16 @@ describe("#536 follow-up: readiness honours always-settles", () => {
       pollMs: 5,
     });
     await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+    // Near the deadline, not merely before the test timeout: a regression that
+    // rejects after seconds would otherwise still pass (CodeRabbit, #537).
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   }, 3_000);
 
   it("rejects immediately at timeoutMs=0 when the probe never settles", async () => {
     // #537 review (Macroscope): the zero-timeout path bypassed the deadline
     // race entirely, so a hung probe hung forever on the configuration that
     // asks for no waiting at all.
+    const startedAt = Date.now();
     const readiness = awaitDaemonReadiness({
       socketPath: "/tmp/cmux529/zero-timeout.sock",
       probeDaemon: () => new Promise<boolean>(() => {}),
@@ -346,9 +351,11 @@ describe("#536 follow-up: readiness honours always-settles", () => {
       pollMs: 5,
     });
     await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   }, 3_000);
 
   it("rejects at the deadline even when the SLEEP never settles", async () => {
+    const startedAt = Date.now();
     const readiness = awaitDaemonReadiness({
       socketPath: "/tmp/cmux529/sleep-hangs.sock",
       probeDaemon: async () => false,
@@ -357,6 +364,7 @@ describe("#536 follow-up: readiness honours always-settles", () => {
       pollMs: 5,
     });
     await expect(readiness).rejects.toBeInstanceOf(DaemonReadinessTimeoutError);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   }, 3_000);
 
   it("does not overshoot the deadline when pollMs exceeds timeoutMs", async () => {

--- a/tests/daemon-lifecycle-state.test.ts
+++ b/tests/daemon-lifecycle-state.test.ts
@@ -7,6 +7,9 @@
  * that actually matters.
  */
 import { beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   DaemonReadinessTimeoutError,
   DaemonSocketInUseError,
@@ -110,6 +113,48 @@ describe("daemon lifecycle state", () => {
       "dead-owner-leftover",
     );
   });
+
+  it("captures the stderr of a FAST-FAILING child, not an empty excerpt", async () => {
+    // #536 review (Macroscope): the record was written from `exit`, which
+    // snapshots the buffer BEFORE the stderr pipe has drained. The real daemon
+    // does exactly this shape — print the fatal, then `process.exit(1)` — so a
+    // lost excerpt loses the evidence #529 needed.
+    //
+    // HONEST NOTE: on the pre-fix code this is a RACE, not a guaranteed
+    // failure — a short write often lands before `exit` fires, which is why it
+    // did not bite when run against main. What the fix changes is that the
+    // capture is now deterministic (recorded on `close`, after stdio
+    // completes) rather than dependent on that timing. This test asserts the
+    // contract; it cannot prove the removal of a race in one run.
+    const { spawnDaemonProcess } = await import("../src/daemon-spawn.js");
+    const dir = mkdtempSync(join(tmpdir(), "cmux536-stderr-"));
+    const script = join(dir, "fast-fail.js");
+    writeFileSync(
+      script,
+      'process.stderr.write("[cmuxlayer-daemon] fatal Error: boom\\n");\n' +
+        "process.exit(1);\n",
+    );
+
+    const child = await spawnDaemonProcess({
+      socketPath: join(dir, "unused.sock"),
+      env: {},
+      daemonScriptPath: script,
+      logger: { error: () => {} },
+      // Keep the test's own stderr clean; capture still happens.
+      stderrSink: () => {},
+    });
+
+    await new Promise<void>((resolve) => {
+      child.once("close", () => setTimeout(resolve, 50));
+    });
+
+    const snapshot = daemonLifecycleSnapshot();
+    expect(snapshot.last_exit).not.toBeNull();
+    expect(snapshot.last_exit?.code).toBe(1);
+    expect(snapshot.last_exit?.stderr_excerpt).toContain("fatal Error: boom");
+
+    rmSync(dir, { recursive: true, force: true });
+  }, 10_000);
 
   it("bounds the stderr excerpt from the tail", () => {
     const excerpt = daemonStderrExcerpt(`${"x".repeat(5_000)}TAIL`);


### PR DESCRIPTION
Forward-fix for the four review findings that landed on #536 between my thread check and my merge. **Merging over them was my error** — the timeline and triage are on #536. Main keeps `81825fe` by lead ruling: reverting would reinstate an infinite hang to avoid a narrow TOCTOU.

Merge authority for this PR is the lead's. **Do not merge.**

## What changed

**1. Critical (Macroscope) / P1 (Codex) — `removeOwnedSocketPlaceholder` unlinked by pathname**

It did `lstat`, then `unlink` on the path. A successor that removed the placeholder and bound its own socket between those two calls lost its live endpoint; an operator file that replaced the placeholder was deleted too. Identity is now captured at the `lstat` and revalidated immediately before the unlink, skipping a changed object.

This restores the ≤30-line P2-2 narrowing the split allowlist permitted — **I dropped it while minimising, so this regression was mine, not inherited.** Audited the other pathname unlinks: `unlinkStaleSocket` already revalidates, and the only other one targets the pid-unique sheltered path, which cannot race.

**2. P2 (Codex) — `awaitDaemonReadiness` did not honour always-settles**

The loop awaited `probeDaemon()` directly, so a probe that never settles blocked *before* the deadline check and the whole `Promise.race` stayed pending forever. The helper reproduced the deadlock it exists to bound. Every await in the loop is now raced against a standalone deadline timer, cleared in `finally`.

**3. Medium (Macroscope) — stderr excerpt could be empty for a fast-failing daemon**

The exit record was written from `exit`, which snapshots the buffer before the pipe drains — losing exactly the evidence #529 needed. It is recorded on `close` (fires only after stdio completes), de-duplicated by a flag, with a bounded exit-path fallback for the inherited-stderr case.

**4. High minor (Macroscope) — poll sleep uncapped**

Capped to the remaining time, so `pollMs > timeoutMs` no longer overshoots the hard deadline.

## Refused, with reasoning (both answered in-thread on #536)

- **Hold guard releases the tail while its operation runs** (Macroscope High). Deliberate liveness trade: the alternative is the permanent hang this work exists to fix. Real cancellation needs a token threaded through `agent-discovery` / `agent-registry` / `cmux-client` — tracked in **#535**. Bounded meanwhile at 120s, after the 45s acquire bound, and every firing is counted in `control_health`.
- **Reaping an empty file at the socket path** (Codex P1). Lead ruling: a 0-byte regular file at the socket path *is* the reboot leftover #529 exists to clear, and carries no operator data to destroy. Non-empty files are already untouchable via the size check. New test pins both sides of that boundary.

## Test evidence

Three new tests **bite on `main`** (= merged `81825fe`) — all three hang and time out:

```
× rejects at the deadline even when the probe NEVER settles   3009ms → Test timed out in 3000ms
× rejects at the deadline even when the SLEEP never settles    3003ms → Test timed out in 3000ms
× does not overshoot the deadline when pollMs exceeds timeoutMs 5001ms → Test timed out in 5000ms
Tests  3 failed | 21 passed (24)
```

Also added: the 0-byte/1-byte reap boundary, placeholder cleanup after clean shutdown, and a successor's socket surviving placeholder cleanup.

## Two honest limits on the test coverage

- **The Critical's interleaving is not deterministically reproducible.** The window between `lstat` and `unlink` needs an injected filesystem seam to hit reliably. The committed test asserts the observable contract — a socket at the path is never removed by placeholder cleanup — and the code comment records the race. I did not claim a bite I cannot demonstrate.
- **The stderr test is a race on the pre-fix code, not a guaranteed failure.** A short write often lands before `exit` fires, which is why it did not bite when I ran it against main. What the fix changes is that capture becomes *deterministic* rather than timing-dependent. The test comment says exactly this rather than implying otherwise.

## Gates

- `tsc --noEmit` clean.
- `bash scripts/run_tests.sh` env-stripped via `.githooks/pre-push` (not bypassed): **145 files, 3326 passed, 1 skipped**.
- `npx vitest run` plain env: **145 files, 3326 passed, 1 skipped**.

No packaged-bottle verification — that remains the lead's post-merge step.

— cmuxlayer-worker (worker) · claude-code/unknown
<!-- golem-id v1 {"seat":"cmuxlayer-worker","role":"worker","harness":"claude-code","model":"unknown","model_source":"unavailable","session":"9aca6d01","ts":"2026-08-24T17:55:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon socket-path unlink and readiness timeout paths that can drop live endpoints or hang autostart. Logic is fail-closed with tests, but remaining TOCTOU windows and skipped cleanup if identity capture fails are still operationally sensitive.
> 
> **Overview**
> Hardens three #536 follow-ups so daemon shutdown and autostart cannot delete a successor’s socket, hang forever, or drop a fast-fail stderr excerpt.
> 
> Placeholder cleanup now records the empty file created via exclusive `open("wx")`/`fstat`, then unlinks only if that same empty regular file is still at the path. Successor sockets and non-empty operator files are left alone.
> 
> `awaitDaemonReadiness` races every probe and sleep against a referenced deadline timer (including `timeoutMs=0`) and caps poll sleep to remaining time, so a hung probe/sleep cannot deadlock the helper.
> 
> Spawned-daemon exit records are written on `'close'` after stderr drains. A 300ms provisional record on `'exit'` covers inherited stderr and is upgraded when `'close'` arrives with the full excerpt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63aa04ee9084b23fc174f6491c7be3f30316ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix placeholder removal identity checks and enforce readiness deadline in daemon
> - `CmuxLayerDaemon` now records the exact file identity (`ownedPlaceholderIdentity`) when creating a socket placeholder via `writeOwnedSocketPlaceholder`, and `removeOwnedSocketPlaceholder` only unlinks the matching empty regular file — it never removes a successor's live socket or a non-empty operator file.
> - `awaitDaemonReadiness` wraps every `probeDaemon` and `sleep` call in a `withDeadline` race so the function always settles by `timeoutMs`, even when the probe or sleep never resolve; sleep duration is capped to remaining time to avoid overshooting.
> - `spawnDaemonProcess` now records the daemon exit record on stdio `'close'` (after stderr drains) instead of `'exit'`, ensuring `stderr_excerpt` captures the complete tail; a provisional record with a 300 ms timeout bridges the gap when stderr is piped.
> - Behavioral Change: `removeOwnedSocketPlaceholder` will leave a placeholder file in place if its identity no longer matches what this daemon created — previously it would `unlink` any empty file at the path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f63aa04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daemon shutdown reporting, including more reliable exit details and captured error output.
  - Prevented cleanup from deleting active socket endpoints or unrelated files.
  - Improved removal of stale daemon placeholders while preserving valid files.
  - Added firm readiness deadlines so hung checks and polling attempts fail predictably instead of waiting indefinitely.

- **Tests**
  - Added coverage for daemon cleanup, readiness timeouts, lifecycle handling, exit codes, and captured error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->