### PR TITLE
fix: trim list_agents output

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14891,6 +14891,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       surface_id: string;
       send_via: "send_to";
       closure: ClosureState;
+      parsed_cli_mismatch?: true;
       health?: AgentHealth;
     };
     type ListAgentsCacheEntry = {
@@ -15005,6 +15006,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           detail: args.detail,
         });
         const renderListAgentsResponse = (entry: ListAgentsCacheEntry) => {
+          const actionableDeliveries =
+            args.detail === "full"
+              ? engine
+                  .listDeliveryReceipts()
+                  .filter(
+                    (receipt) =>
+                      !receipt.terminal || receipt.needs_attention === true,
+                  )
+                  .sort((left, right) =>
+                    left.created_at.localeCompare(right.created_at),
+                  )
+              : [];
           const agents =
             args.detail === "full"
               ? entry.agents
@@ -15023,6 +15036,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   blocked_on_prompt: agent.blocked_on_prompt.value,
                   send_via: agent.send_via,
                   closure: agent.closure,
+                  ...(agent.parsed_cli_mismatch === true
+                    ? { parsed_cli_mismatch: true }
+                    : {}),
                 }));
           const data = {
             derived_at: entry.derived_at,
@@ -15033,12 +15049,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               : {}),
             ...(args.detail === "full"
               ? {
-                  deliveries: engine
-                    .listDeliveryReceipts()
-                    .filter(
-                      (receipt) =>
-                        !receipt.terminal || receipt.needs_attention === true,
-                    )
+                  deliveries: actionableDeliveries
                     .slice(-listAgentsDeliveryLimit)
                     .map((receipt) => ({
                       delivery_id: receipt.delivery_id,
@@ -15055,6 +15066,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           }
                         : {}),
                     })),
+                  deliveries_total: actionableDeliveries.length,
+                  deliveries_truncated:
+                    actionableDeliveries.length > listAgentsDeliveryLimit,
                 }
               : {}),
           };
@@ -15185,7 +15199,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                               paused: true,
                               pausedSource: agent.paused_source ?? "inferred",
                             }
-                        : {}),
+                          : {}),
                     }),
                     cli: agent.cli,
                     role: inferRecordRoleOrNull(agent),

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,7 @@ import {
   issueCoordinationContract,
   coordinationFooterBytes,
   writeBootContractFile,
+  type ClosureState,
   type CoordinationContract,
 } from "./coordination-paths.js";
 import {
@@ -14883,16 +14884,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
 
     // 15. list_agents
+    const listAgentsDeliveryLimit = 20;
+    type ListAgentsObservedRow = ObservedPublicAgent & {
+      cli: CliType;
+      role: AgentRole | null;
+      surface_id: string;
+      send_via: "send_to";
+      closure: ClosureState;
+      health?: AgentHealth;
+    };
     type ListAgentsCacheEntry = {
       topology_signature: string;
       derived_at: number;
-      agents: Array<
-        ObservedPublicAgent & {
-          surface_id: string;
-          send_via: "send_to";
-          health?: AgentHealth;
-        }
-      >;
+      agents: ListAgentsObservedRow[];
       skipped_agents: Array<{ agent_id: string; error: string }>;
     };
     const listAgentsCache = new Map<string, ListAgentsCacheEntry>();
@@ -14914,7 +14918,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "list_agents",
-      "List live-derived agents, including registry-persisted prompt blockage and pause state; filter to blocked agents or children with mine/parent_agent_id. Default summary is lean (id, state, surface_id, send_via, paused). Pass detail=full for health diagnostics and the full registry record.",
+      "List live-derived agents, including registry-persisted prompt blockage and pause state; filter to blocked agents or children with mine/parent_agent_id. Default summary returns flat addressable scalars only. Pass detail=full for provenance, health diagnostics, the full registry record, and up to 20 unresolved or attention delivery receipts.",
       {
         state: z
           .enum([
@@ -14954,7 +14958,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           .optional()
           .default("summary")
           .describe(
-            "summary (default): lean addressable rows. full: health diagnostics plus the full registry record.",
+            "summary (default): flat addressable scalar rows. full: provenance, health diagnostics, the full registry record, and up to 20 unresolved or attention delivery receipts.",
           ),
         max_age_ms: z
           .number()
@@ -15001,30 +15005,56 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           detail: args.detail,
         });
         const renderListAgentsResponse = (entry: ListAgentsCacheEntry) => {
+          const agents =
+            args.detail === "full"
+              ? entry.agents
+              : entry.agents.map((agent) => ({
+                  agent_id: agent.agent_id,
+                  repo: agent.repo,
+                  cli: agent.cli,
+                  role: agent.role,
+                  state: agent.state.value,
+                  surface_id: agent.surface_id,
+                  model: agent.model.value,
+                  session_id: agent.session_id.value,
+                  resumable: agent.resumable.value,
+                  resume_command: agent.resume_command ?? null,
+                  paused: agent.paused.value,
+                  blocked_on_prompt: agent.blocked_on_prompt.value,
+                  send_via: agent.send_via,
+                  closure: agent.closure,
+                }));
           const data = {
             derived_at: entry.derived_at,
-            agents: entry.agents as unknown as Record<string, unknown>[],
-            count: entry.agents.length,
+            agents: agents as unknown as Record<string, unknown>[],
+            count: agents.length,
             ...(entry.skipped_agents.length > 0
               ? { skipped_agents: entry.skipped_agents }
               : {}),
             ...(args.detail === "full"
               ? {
-                  deliveries: engine.listDeliveryReceipts().map((receipt) => ({
-                    delivery_id: receipt.delivery_id,
-                    agent_id: receipt.agent_id,
-                    delivery_state: receipt.delivery_state,
-                    terminal: receipt.terminal,
-                    created_at: receipt.created_at,
-                    resolved_at: receipt.resolved_at,
-                    retry_count: receipt.retry_count,
-                    ...(receipt.needs_attention === true
-                      ? {
-                          needs_attention: true,
-                          attention_reason: receipt.attention_reason,
-                        }
-                      : {}),
-                  })),
+                  deliveries: engine
+                    .listDeliveryReceipts()
+                    .filter(
+                      (receipt) =>
+                        !receipt.terminal || receipt.needs_attention === true,
+                    )
+                    .slice(-listAgentsDeliveryLimit)
+                    .map((receipt) => ({
+                      delivery_id: receipt.delivery_id,
+                      agent_id: receipt.agent_id,
+                      delivery_state: receipt.delivery_state,
+                      terminal: receipt.terminal,
+                      created_at: receipt.created_at,
+                      resolved_at: receipt.resolved_at,
+                      retry_count: receipt.retry_count,
+                      ...(receipt.needs_attention === true
+                        ? {
+                            needs_attention: true,
+                            attention_reason: receipt.attention_reason,
+                          }
+                        : {}),
+                    })),
                 }
               : {}),
           };
@@ -15155,8 +15185,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                               paused: true,
                               pausedSource: agent.paused_source ?? "inferred",
                             }
-                          : {}),
+                        : {}),
                     }),
+                    cli: agent.cli,
+                    role: inferRecordRoleOrNull(agent),
                     surface_id: agent.surface_id,
                     send_via: "send_to" as const,
                     // #481: computed on every listMerged, read only by the

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -510,8 +510,7 @@ describe("F1 — live state, not the stale registry record", () => {
     );
 
     expect(row, JSON.stringify(parsed)).toBeTruthy();
-    expect(row.state.value).toBe("working");
-    expect(row.state.source).toBe("screen");
+    expect(row.state).toBe("working");
     expect(row.closure).toBe("pending");
   });
 

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -581,14 +581,14 @@ describe("Phase 10 painpoint e2e replay", () => {
       const listed = parseToolResult<{
         agents: Array<{
           agent_id: string;
-          state: { value: AgentState };
+          state: AgentState;
         }>;
       }>(await getTool(server, "list_agents").handler({}, {}));
 
       expect(listed.agents).toEqual([
         expect.objectContaining({
           agent_id: "terminal-worker-empty-scan",
-          state: expect.objectContaining({ value: "done" }),
+          state: "done",
         }),
       ]);
     } finally {

--- a/tests/paused-visibility.test.ts
+++ b/tests/paused-visibility.test.ts
@@ -205,7 +205,7 @@ describe("paused pane visibility", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it("list_agents summary rows include paused with source", async () => {
+  it("list_agents summary rows include flat paused state", async () => {
     registerAgent(
       server,
       makeAgent({
@@ -220,16 +220,11 @@ describe("paused pane visibility", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agents[0]).toMatchObject({
       agent_id: "agent-paused",
-      paused: {
-        value: true,
-        source: "inferred",
-        coverage: "harness_only",
-        note: "cmux-UI pause not detectable; see #447",
-      },
+      paused: true,
     });
   });
 
-  it("list_agents summary rows keep boolean false and name harness-only coverage on a clean agent", async () => {
+  it("list_agents summary rows keep boolean false on a clean agent", async () => {
     registerAgent(
       server,
       makeAgent({
@@ -242,14 +237,9 @@ describe("paused pane visibility", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.agents[0]).toMatchObject({
       agent_id: "agent-idle",
-      paused: {
-        value: false,
-        source: "inferred",
-        coverage: "harness_only",
-        note: "cmux-UI pause not detectable; see #447",
-      },
+      paused: false,
     });
-    expect(typeof parsed.agents[0].paused.value).toBe("boolean");
+    expect(typeof parsed.agents[0].paused).toBe("boolean");
   });
 
   it("read_screen parsed output includes paused with inferred source", async () => {

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -1015,7 +1015,7 @@ describe("send_to v2 background verify", () => {
     });
   });
 
-  it("exposes deliveries on list_agents detail=full", async () => {
+  it("bounds list_agents detail=full deliveries to the last 20 unresolved or attention receipts", async () => {
     const client = new FakeAgentSurfaceClient();
     server = createVerifyServer(client);
     registerAgent(server);
@@ -1028,17 +1028,44 @@ describe("send_to v2 background verify", () => {
       }),
     );
 
+    const engine = server._registeredTools.interact._engine;
+    const terminal = engine.queueDelivery({
+      delivery_id: "terminal-history",
+      agent_id: "agent-1",
+      text: "old terminal receipt",
+      press_enter: true,
+      source_event: "send_to",
+    });
+    engine.resolveDelivery({
+      ...terminal,
+      delivery_state: "submitted",
+      terminal: true,
+      submit_verified: true,
+    });
+    for (let index = 0; index < 25; index += 1) {
+      engine.queueDelivery({
+        delivery_id: `queued-${index}`,
+        agent_id: "agent-1",
+        text: `queued ${index}`,
+        press_enter: true,
+        source_event: "send_to",
+      });
+    }
+
     const listed = parseResult(
       await callTool(server, "list_agents", { detail: "full" }),
     );
+    expect(listed.deliveries).toHaveLength(20);
     expect(listed.deliveries).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          delivery_id: sent.delivery_id,
-          agent_id: "agent-1",
-          delivery_state: "pending_verify",
-          terminal: false,
-        }),
+        expect.objectContaining({ delivery_id: "queued-24" }),
+      ]),
+    );
+    expect(listed.deliveries).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ delivery_id: sent.delivery_id }),
+        expect.objectContaining({ delivery_id: "terminal-history" }),
+        expect.objectContaining({ delivery_id: "queued-0" }),
       ]),
     );
   });

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -1020,13 +1020,11 @@ describe("send_to v2 background verify", () => {
     server = createVerifyServer(client);
     registerAgent(server);
 
-    const sent = parseResult(
-      await callTool(server, "send_to", {
-        agent_id: "agent-1",
-        text: "list me",
-        press_enter: true,
-      }),
-    );
+    await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "list me",
+      press_enter: true,
+    });
 
     const engine = server._registeredTools.interact._engine;
     const terminal = engine.queueDelivery({
@@ -1056,18 +1054,15 @@ describe("send_to v2 background verify", () => {
       await callTool(server, "list_agents", { detail: "full" }),
     );
     expect(listed.deliveries).toHaveLength(20);
-    expect(listed.deliveries).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ delivery_id: "queued-24" }),
-      ]),
+    expect(
+      listed.deliveries.map(
+        (delivery: { delivery_id: string }) => delivery.delivery_id,
+      ),
+    ).toEqual(
+      Array.from({ length: 20 }, (_, index) => `queued-${index + 5}`),
     );
-    expect(listed.deliveries).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ delivery_id: sent.delivery_id }),
-        expect.objectContaining({ delivery_id: "terminal-history" }),
-        expect.objectContaining({ delivery_id: "queued-0" }),
-      ]),
-    );
+    expect(listed.deliveries_total).toBe(26);
+    expect(listed.deliveries_truncated).toBe(true);
   });
 
   it("does not fail queued_followup after the verify deadline or file a ticket", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5600,10 +5600,10 @@ describe("agent lifecycle tool handlers", () => {
     const listedAgent = (
       listed.agents as Array<{
         agent_id?: string;
-        state?: { value?: string };
+        state?: string;
       }>
     ).find((agent) => agent.agent_id === parsed.agent_id);
-    expect(listedAgent?.state?.value).toBe("error");
+    expect(listedAgent?.state).toBe("error");
   }, 10_000);
 
   it("spawn_agent does not ctrl-u a healthy booting pane with echoed launcher output", async () => {
@@ -7122,31 +7122,37 @@ describe("agent lifecycle tool handlers", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.derived_at).toEqual(expect.any(Number));
     expect(parsed.count).toBe(1);
-    expect(parsed.agents[0].repo).toBe("brainlayer");
-    expect(parsed.agents[0].state).toMatchObject({
-      value: "working",
-      source: expect.stringMatching(/^(screen|registry|process)$/),
-      observed_at_ms: expect.any(Number),
+    expect(Object.keys(parsed.agents[0]).sort()).toEqual(
+      [
+        "agent_id",
+        "blocked_on_prompt",
+        "cli",
+        "closure",
+        "model",
+        "paused",
+        "repo",
+        "resumable",
+        "resume_command",
+        "role",
+        "send_via",
+        "session_id",
+        "state",
+        "surface_id",
+      ].sort(),
+    );
+    expect(parsed.agents[0]).toMatchObject({
+      repo: "brainlayer",
+      cli: "claude",
+      role: "worker",
+      state: "working",
+      model: "sonnet",
+      session_id: null,
+      resumable: false,
+      resume_command: null,
+      paused: false,
+      blocked_on_prompt: false,
+      send_via: "send_to",
     });
-    expect(parsed.agents[0].model).toMatchObject({
-      value: "sonnet",
-      source: "registry",
-      observed_at_ms: expect.any(Number),
-    });
-    expect(parsed.agents[0].session_id).toMatchObject({
-      value: null,
-      source: "registry",
-      observed_at_ms: expect.any(Number),
-    });
-    expect(parsed.agents[0].resumable).toMatchObject({
-      value: false,
-      source: "registry",
-      observed_at_ms: expect.any(Number),
-    });
-    expect(parsed.agents[0].resume_command).toBeUndefined();
-    expect(parsed.agents[0].surface_id).toBeDefined();
-    expect(parsed.agents[0].send_via).toBe("send_to");
-    expect(parsed.agents[0].health).toBeUndefined();
   });
 
   it("list_agents detail=full includes health diagnostics", async () => {
@@ -7216,7 +7222,10 @@ describe("agent lifecycle tool handlers", () => {
     const before = Date.now();
 
     const parsed = parseToolResult(
-      await registeredTestTool(server, "list_agents").handler({}, {}),
+      await registeredTestTool(server, "list_agents").handler(
+        { detail: "full" },
+        {},
+      ),
     );
     const agent = parsed.agents.find(
       (candidate: { agent_id: string }) =>
@@ -7428,11 +7437,11 @@ describe("agent lifecycle tool handlers", () => {
     const list = registeredTestTool(server, "list_agents");
 
     const first = parseToolResult(
-      await list.handler({ max_age_ms: 5_000 }, {}),
+      await list.handler({ max_age_ms: 5_000, detail: "full" }, {}),
     );
     routeClient.client.readScreen.mockClear();
     const cached = parseToolResult(
-      await list.handler({ max_age_ms: 5_000 }, {}),
+      await list.handler({ max_age_ms: 5_000, detail: "full" }, {}),
     );
 
     expect(cached.derived_at).toBe(first.derived_at);
@@ -7446,7 +7455,7 @@ describe("agent lifecycle tool handlers", () => {
       },
     ]);
     const refreshed = parseToolResult(
-      await list.handler({ max_age_ms: 5_000 }, {}),
+      await list.handler({ max_age_ms: 5_000, detail: "full" }, {}),
     );
 
     expect(routeClient.client.readScreen).toHaveBeenCalled();
@@ -7524,7 +7533,7 @@ describe("agent lifecycle tool handlers", () => {
       expect.objectContaining({ agent_id: "healthy-agent" }),
       expect.objectContaining({
         agent_id: "corrupt-agent",
-        resumable: expect.objectContaining({ value: true }),
+        resumable: true,
         resume_command: "codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust resume 019d9aa5-93c0-7a52-9c47-9be1f7625f4f",
       }),
     ]);
@@ -7572,9 +7581,9 @@ describe("agent lifecycle tool handlers", () => {
 
     expect(parsed.agents[0]).toMatchObject({
       agent_id: "corrupt-claude-agent",
-      resumable: expect.objectContaining({ value: false }),
+      resumable: false,
     });
-    expect(parsed.agents[0]).not.toHaveProperty("resume_command");
+    expect(parsed.agents[0]).toHaveProperty("resume_command", null);
   });
 
   it("send_to keeps repaired registry repo ownership when a title contains a surface suffix", async () => {
@@ -9069,11 +9078,7 @@ describe("agent lifecycle tool handlers", () => {
       result.structuredContent ?? JSON.parse(result.content[0].text);
 
     expect(parsed.agents[0]).toMatchObject({
-      session_id: {
-        value: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
-        source: "registry",
-        observed_at_ms: expect.any(Number),
-      },
+      session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
       resume_command:
         "brainlayerClaude -s --resume 019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
     });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -12640,7 +12640,7 @@ describe("tool handler integration", () => {
     const tool = (server as any)._registeredTools["list_agents"];
 
     try {
-      const result = await tool.handler({}, {} as any);
+      const result = await tool.handler({ detail: "full" }, {} as any);
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
 
@@ -12711,7 +12711,7 @@ describe("tool handler integration", () => {
 
     try {
       await context.lifecycleStartPromise;
-      const result = await tool.handler({}, {} as any);
+      const result = await tool.handler({ detail: "full" }, {} as any);
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
 
@@ -12815,10 +12815,7 @@ describe("tool handler integration", () => {
       expect(parsed.count).toBe(1);
       expect(parsed.agents[0]).toMatchObject({
         agent_id: "prompt-blocked-agent",
-        blocked_on_prompt: {
-          value: true,
-          source: "registry",
-        },
+        blocked_on_prompt: true,
       });
       expect(parsed.agents[0].detail).toBeUndefined();
     } finally {

--- a/tests/t1-registry-truth.test.ts
+++ b/tests/t1-registry-truth.test.ts
@@ -582,7 +582,7 @@ describe("T1 #481 — parsed_cli_mismatch reaches a reader again", () => {
     engine.getRegistry().set(record.agent_id, record);
 
     const result = await server._registeredTools["list_agents"].handler(
-      { detail: "full" },
+      {},
       {} as any,
     );
     const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);

--- a/tests/t1-registry-truth.test.ts
+++ b/tests/t1-registry-truth.test.ts
@@ -582,7 +582,7 @@ describe("T1 #481 — parsed_cli_mismatch reaches a reader again", () => {
     engine.getRegistry().set(record.agent_id, record);
 
     const result = await server._registeredTools["list_agents"].handler(
-      {},
+      { detail: "full" },
       {} as any,
     );
     const parsed = result.structuredContent ?? JSON.parse(result.content[0].text);

--- a/tests/t1b-closure-probe-divergence.test.ts
+++ b/tests/t1b-closure-probe-divergence.test.ts
@@ -239,8 +239,7 @@ describe("T1b (#488) — closure and state resolve from ONE observation", () => 
     const parsed = parseResult(await callTool(server, "list_agents", {}));
     const row = rowFor(parsed, "cmuxlayerCodex-t1b-busy");
     expect(row, JSON.stringify(parsed)).toBeTruthy();
-    expect(row.state.value).toBe("working");
-    expect(row.state.source).toBe("screen");
+    expect(row.state).toBe("working");
     expect(row.closure).toBe("pending");
   });
 


### PR DESCRIPTION
## Summary
- make default `list_agents` return the 14 flat D15 scalar fields, plus sparse `parsed_cli_mismatch: true` only when live and recorded CLIs disagree
- retain provenance and diagnostics under `detail: "full"`
- bound full-mode delivery diagnostics to the latest 20 unresolved or attention-needed receipts
- expose `deliveries_total` and `deliveries_truncated`, with receipts ordered by `created_at`
- update direct consumers and regression coverage for both response modes

## Round-two review dispositions
- P2-1: restored the default-detail #481 guard and sparse mismatch signal
- P2-2: measured full mode on the same eight-agent fleet; see Runtime measurements
- P3-1: replaced the weak negative matcher with the exact returned delivery ID sequence
- P3-2: added total/truncation scalars and explicit chronological ordering
- Nit: repaired the nested ternary indentation

## Verification
- `bun run typecheck`
- `bun run test -- --reporter=dot` — 145 files passed; 3,328 passed, 1 skipped
- `CMUXLAYER_FORCE_INPROCESS=1 bun run typecheck`
- forced-inprocess suite excluding the daemon-only topology restart case — 144 files passed; 3,326 passed, 1 skipped
- default daemon-only topology restart case — 2 tests passed
- pre-push hook — 145 files passed; 3,328 passed, 1 skipped

## Runtime measurements
Same eight live agent IDs in both samples:

- Summary: installed baseline 7,940 bytes → exact worktree build 3,174 bytes; 4,766 bytes / 60.0% smaller.
- Full: installed baseline 173,934 bytes with 584 historical receipts → exact worktree build 39,103 bytes with 1 actionable receipt; 134,831 bytes / 77.5% smaller.

The before measurements used the currently installed MCP implementation. The after measurements launched this exact worktree build with `CMUXLAYER_FORCE_INPROCESS=1` against the same live fleet; they do not claim the installed runtime has already changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flatten `list_agents` summary output and cap actionable deliveries to 20
> - Summary (default) `list_agents` responses now use flattened primitive fields (`state`, `model`, `session_id`, `resumable`, `paused`, `blocked_on_prompt`) instead of nested objects, and include `cli`, `role`, `send_via`, and `closure`.
> - Full-detail responses return agents unmodified but now export only the last 20 actionable deliveries (non-terminal or `needs_attention===true`), sorted by `created_at`, with `deliveries_total` and `deliveries_truncated` metadata.
> - Risk: Behavioral change — callers expecting nested `state`/`paused` objects in summary output will break; in-tree tests are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbe2810.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

— cmuxlayerCodex-458d2f6e (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-458d2f6e","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0347c","ts":"2026-08-24T16:46:12Z"} -->
