### PR TITLE
fix: harden degraded lifecycle sweeps

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -624,6 +624,8 @@ async function validateCodexModel(
 }
 
 export interface AgentEngineOptions {
+  /** Debug-only sweep phase timings. Defaults to stderr so MCP stdout stays framed. */
+  sweepDebugLog?: (message: string) => void;
   spawnPreflight?: (
     params: SpawnAgentParams,
   ) => Promise<SpawnPreflightResult | void>;
@@ -900,6 +902,26 @@ interface SweepAgentContext {
 
 interface SweepMutationSkipAccounting {
   counted: boolean;
+}
+
+type SweepDeferredOperation = () => unknown | Promise<unknown>;
+
+interface SweepPlan {
+  surfaceTopology: SurfaceTopologySnapshot | null;
+  initialVersions: Map<string, number>;
+  persistence: SweepDeferredOperation[];
+  publications: SweepDeferredOperation[];
+  notifications: SweepDeferredOperation[];
+  planner: AgentEngine;
+  registryMaps: {
+    agents: Map<string, AgentRecord>;
+    aliases: Map<string, string>;
+    surfacelessObservations: Map<string, unknown>;
+    unclaimedAbsenceObservations: Map<string, unknown>;
+  };
+  originalSidebarSnapshot: Map<string, SidebarStatusSnapshot>;
+  timings: Record<string, number>;
+  readOnly: boolean;
 }
 
 class PlacementSurfaceBindingError extends Error {}
@@ -1575,6 +1597,10 @@ export class AgentEngine {
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
   private currentSweepScreenSignatures = new Map<string, string>();
+  /** Tick-wide screen memo: every agent is read at most once while planning. */
+  private currentSweepAgentContexts = new Map<string, SweepAgentContext>();
+  /** Non-null only on the isolated planner clone used outside the lifecycle lock. */
+  private activeSweepPlan: SweepPlan | null = null;
   /** agentId → last material (de-chromed) screen output change. */
   private fleetScreenProgress = new Map<string, FleetScreenProgressSnapshot>();
   /** agentId → last-pushed status target/value */
@@ -1652,6 +1678,7 @@ export class AgentEngine {
   private haltWedgedDwellMs: number;
   private haltWedgedSweeps: number;
   private autoResolvePrompts: boolean;
+  private sweepDebugLog: (message: string) => void;
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
@@ -1659,6 +1686,9 @@ export class AgentEngine {
     opts?: AgentEngineOptions,
   ) {
     this.stateMgr = stateMgr;
+    this.sweepDebugLog =
+      opts?.sweepDebugLog ??
+      ((message) => process.stderr.write(`${message}\n`));
     this.deliveryReceiptsPath = join(
       stateMgr.getBaseDir(),
       "delivery-receipts.json",
@@ -3522,6 +3552,14 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<CmuxReadScreenResult> {
+    if (this.activeSweepPlan) {
+      const sharedCtx =
+        this.currentSweepAgentContexts.get(agent.agent_id) ?? ctx;
+      if (!this.currentSweepAgentContexts.has(agent.agent_id)) {
+        this.currentSweepAgentContexts.set(agent.agent_id, sharedCtx);
+      }
+      ctx = sharedCtx;
+    }
     ctx.route ??= this.resolveAgentIoRoute(
       agent.agent_id,
       this.client.supportsStableSurfaceReads ? ctx.surfaceTopology : undefined,
@@ -4653,22 +4691,28 @@ export class AgentEngine {
     );
     const unblockAction = this.haltUnblockAction(episode, haltType);
     try {
-      dispatchOnce(
-        ancestor.agent_id,
-        {
-          id: `agent-halt:${episode.agent_id}:${episode.halt_episode_started_at}`,
-          from: "cmuxlayer:lifecycle",
-          to: ancestor.agent_id,
-          tag: `agent_halt_${haltType}`,
-          task:
-            `Agent ${episode.agent_id} in surface ${episode.surface_id} has remained ` +
-            `${haltType} for ${durationSeconds}s. Last observable action: ` +
-            `${episode.halt_last_observable_action ?? "unknown"}. ` +
-            `Exact unblock action: ${unblockAction}. ` +
-            `Session resume fallback: ${resumeCommand}`,
-        },
-        this.inboxOpts,
-      );
+      const haltDispatch = () =>
+        dispatchOnce(
+          ancestor.agent_id,
+          {
+            id: `agent-halt:${episode.agent_id}:${episode.halt_episode_started_at}`,
+            from: "cmuxlayer:lifecycle",
+            to: ancestor.agent_id,
+            tag: `agent_halt_${haltType}`,
+            task:
+              `Agent ${episode.agent_id} in surface ${episode.surface_id} has remained ` +
+              `${haltType} for ${durationSeconds}s. Last observable action: ` +
+              `${episode.halt_last_observable_action ?? "unknown"}. ` +
+              `Exact unblock action: ${unblockAction}. ` +
+              `Session resume fallback: ${resumeCommand}`,
+          },
+          this.inboxOpts,
+        );
+      if (this.activeSweepPlan) {
+        this.activeSweepPlan.notifications.push(haltDispatch);
+      } else {
+        haltDispatch();
+      }
       const notified = this.stateMgr.updateRecord(episode.agent_id, {
         halt_notification_sent_at: nowIso,
         halt_notified_ancestor_id: ancestor.agent_id,
@@ -4751,20 +4795,27 @@ export class AgentEngine {
 
     let inboxDispatched = false;
     if (agent.parent_agent_id) {
+      const parentAgentId = agent.parent_agent_id;
       try {
-        dispatchOnce(
-          agent.parent_agent_id,
-          {
-            id: `agent-cli-exit:${agent.agent_id}:${exited.updated_at}`,
-            from: "cmuxlayer:lifecycle",
-            to: agent.parent_agent_id,
-            tag: "agent_cli_exit",
-            task:
-              `Agent ${agent.agent_id} CLI exited to a bare shell without done evidence. ` +
-              `Registry state is error; surface ${agent.surface_id}.`,
-          },
-          this.inboxOpts,
-        );
+        const exitDispatch = () =>
+          dispatchOnce(
+            parentAgentId,
+            {
+              id: `agent-cli-exit:${agent.agent_id}:${exited.updated_at}`,
+              from: "cmuxlayer:lifecycle",
+              to: parentAgentId,
+              tag: "agent_cli_exit",
+              task:
+                `Agent ${agent.agent_id} CLI exited to a bare shell without done evidence. ` +
+                `Registry state is error; surface ${agent.surface_id}.`,
+            },
+            this.inboxOpts,
+          );
+        if (this.activeSweepPlan) {
+          this.activeSweepPlan.notifications.push(exitDispatch);
+        } else {
+          exitDispatch();
+        }
         inboxDispatched = true;
       } catch {
         // The durable event below records the failed dispatch for lead recovery.
@@ -6434,9 +6485,24 @@ export class AgentEngine {
   }
 
   async runSweep(): Promise<void> {
-    await this.runLifecycleMutation(() => this.runSweepOnce(), {
+    this.currentSweepScreenSignatures = new Map();
+    this.currentSweepAgentContexts = new Map();
+    const buildStartedAt = Date.now();
+    await this.sweepMonitorRegistryBestEffort();
+    const plan = await this.buildSweepPlan();
+    plan.timings.build_total_ms = Date.now() - buildStartedAt;
+    const applyStartedAt = Date.now();
+    await this.runLifecycleMutation(() => this.applySweepPlan(plan), {
       label: "sweep",
     });
+    plan.timings.apply_ms = Date.now() - applyStartedAt;
+    await this.sweepWatchesBestEffort();
+    await this.drainOutboxBestEffort();
+    this.sweepDebugLog(
+      `[cmuxlayer] sweep timing ${Object.entries(plan.timings)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(" ")}`,
+    );
     await this.drainDeliveryQueue();
     await this.verifyPendingDeliveries();
   }
@@ -7245,24 +7311,388 @@ export class AgentEngine {
     timer.unref?.();
   }
 
-  private async runSweepOnce(): Promise<void> {
+  private createSweepPlan(
+    surfaceTopology: SurfaceTopologySnapshot | null,
+  ): SweepPlan {
+    const realStateMgr = this.stateMgr;
+    const records = new Map(
+      realStateMgr.listStates().map((record) => [record.agent_id, record]),
+    );
+    const persistence: SweepDeferredOperation[] = [];
+    const publications: SweepDeferredOperation[] = [];
+    const notifications: SweepDeferredOperation[] = [];
+    const originalSidebarSnapshot = new Map(this.sidebarSnapshot);
+    const eventLog = realStateMgr.getEventLog() as unknown as Record<
+      string,
+      (...args: unknown[]) => unknown
+    >;
+    const eventLogProxy = new Proxy(eventLog, {
+      get: (target, property) => {
+        const value = target[property as string];
+        if (typeof value !== "function") return value;
+        return (...args: unknown[]) => {
+          persistence.push(() => value.apply(target, args));
+        };
+      },
+    });
+    const surfaceIndex =
+      realStateMgr.getSurfaceSessionIndex() as unknown as Record<
+        string,
+        (...args: unknown[]) => unknown
+      >;
+    const surfaceIndexProxy = new Proxy(surfaceIndex, {
+      get: (target, property) => {
+        const value = target[property as string];
+        if (typeof value !== "function") return value;
+        return (...args: unknown[]) => {
+          persistence.push(() => value.apply(target, args));
+        };
+      },
+    });
+    const requireRecord = (agentId: string): AgentRecord => {
+      const current = records.get(agentId);
+      if (!current) throw new Error(`Agent not found: ${agentId}`);
+      return current;
+    };
+    const stateProxy = new Proxy(realStateMgr, {
+      get: (target, property) => {
+        if (property === "readState") {
+          return (agentId: string) => records.get(agentId) ?? null;
+        }
+        if (property === "listStates") {
+          return () => [...records.values()];
+        }
+        if (property === "hasStateFile") {
+          return (agentId: string) => records.has(agentId);
+        }
+        if (property === "getEventLog") return () => eventLogProxy;
+        if (property === "getSurfaceSessionIndex") {
+          return () => surfaceIndexProxy;
+        }
+        if (property === "updateRecord") {
+          return (agentId: string, fields: Partial<AgentRecord>) => {
+            const current = requireRecord(agentId);
+            const updated: AgentRecord = {
+              ...current,
+              ...fields,
+              version: current.version + 1,
+              updated_at: new Date().toISOString(),
+            };
+            records.set(agentId, updated);
+            persistence.push(() => {
+              realStateMgr.updateRecord(agentId, fields);
+            });
+            return updated;
+          };
+        }
+        if (property === "transition") {
+          return (
+            agentId: string,
+            toState: AgentState,
+            extra?: Partial<AgentRecord>,
+          ) => {
+            const current = requireRecord(agentId);
+            if (!isValidTransition(current.state, toState)) {
+              throw new Error(
+                `Invalid state transition: ${current.state} → ${toState}`,
+              );
+            }
+            const updated: AgentRecord = {
+              ...current,
+              state: toState,
+              version: current.version + 1,
+              updated_at: new Date().toISOString(),
+              ...(extra?.error !== undefined ? { error: extra.error } : {}),
+              ...(extra?.pid !== undefined ? { pid: extra.pid } : {}),
+              ...(extra?.cli_session_id !== undefined
+                ? { cli_session_id: extra.cli_session_id }
+                : {}),
+              ...(extra?.cli_session_path !== undefined
+                ? { cli_session_path: extra.cli_session_path }
+                : {}),
+            };
+            records.set(agentId, updated);
+            persistence.push(() => {
+              realStateMgr.transition(agentId, toState, extra);
+            });
+            return updated;
+          };
+        }
+        if (property === "setTranscriptSessionCaptureDeferred") {
+          return (agentId: string, deferred: boolean, attempts = 0) => {
+            const current = requireRecord(agentId);
+            const normalizedAttempts = Number.isFinite(attempts)
+              ? Math.max(0, Math.trunc(attempts))
+              : 0;
+            if (
+              current.transcript_session_capture_deferred === deferred &&
+              (current.transcript_session_capture_attempts ?? 0) ===
+                normalizedAttempts
+            ) {
+              return current;
+            }
+            const updated = {
+              ...current,
+              transcript_session_capture_deferred: deferred,
+              transcript_session_capture_attempts: normalizedAttempts,
+            };
+            records.set(agentId, updated);
+            persistence.push(() => {
+              realStateMgr.setTranscriptSessionCaptureDeferred(
+                agentId,
+                deferred,
+                normalizedAttempts,
+              );
+            });
+            return updated;
+          };
+        }
+        if (property === "removeState") {
+          return (agentId: string) => {
+            records.delete(agentId);
+            persistence.push(() => realStateMgr.removeState(agentId));
+          };
+        }
+        if (property === "renameState") {
+          return (agentId: string, newAgentId: string) => {
+            const current = requireRecord(agentId);
+            if (records.has(newAgentId)) {
+              throw new Error(`Agent already exists: ${newAgentId}`);
+            }
+            const updated: AgentRecord = {
+              ...current,
+              agent_id: newAgentId,
+              version: current.version + 1,
+              updated_at: new Date().toISOString(),
+            };
+            records.delete(agentId);
+            records.set(newAgentId, updated);
+            for (const [childId, child] of records) {
+              if (child.parent_agent_id === agentId) {
+                records.set(childId, {
+                  ...child,
+                  parent_agent_id: newAgentId,
+                  version: child.version + 1,
+                  updated_at: new Date().toISOString(),
+                });
+              }
+            }
+            persistence.push(() => {
+              realStateMgr.renameState(agentId, newAgentId);
+            });
+            return updated;
+          };
+        }
+        if (property === "writeState") {
+          return (record: AgentRecord) => {
+            records.set(record.agent_id, record);
+            persistence.push(() => realStateMgr.writeState(record));
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as StateManager;
+
+    const registryInternals = this.registry as unknown as {
+      agents: Map<string, AgentRecord>;
+      aliases: Map<string, string>;
+      surfacelessObservations: Map<string, unknown>;
+      unclaimedAbsenceObservations: Map<string, unknown>;
+    };
+    const registryMaps = {
+      agents: new Map(registryInternals.agents),
+      aliases: new Map(registryInternals.aliases),
+      surfacelessObservations: new Map(
+        registryInternals.surfacelessObservations,
+      ),
+      unclaimedAbsenceObservations: new Map(
+        registryInternals.unclaimedAbsenceObservations,
+      ),
+    };
+    const registryProxy = new Proxy(this.registry, {
+      get: (target, property, receiver) => {
+        if (property === "stateMgr") return stateProxy;
+        if (property in registryMaps) {
+          return registryMaps[property as keyof typeof registryMaps];
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const planner = Object.assign(
+      Object.create(Object.getPrototypeOf(this)),
+      this,
+    ) as AgentEngine;
+    const plan: SweepPlan = {
+      surfaceTopology,
+      initialVersions: new Map(
+        [...records].map(([agentId, record]) => [agentId, record.version]),
+      ),
+      persistence,
+      publications,
+      notifications,
+      planner,
+      registryMaps,
+      originalSidebarSnapshot,
+      timings: {},
+      readOnly: false,
+    };
+
+    const realClient = this.client as unknown as Record<string, unknown>;
+    const publicationMethods = new Set([
+      "setStatus",
+      "setStatuses",
+      "clearStatus",
+      "setProgress",
+      "clearProgress",
+      "log",
+    ]);
+    const notificationMethods = new Set([
+      "notify",
+      "notifyLifecycleEvent",
+      "send",
+    ]);
+    const topologyMutationMethods = new Set([
+      "newSplit",
+      "newSurface",
+      "moveSurface",
+      "closeSurface",
+      "renameTab",
+    ]);
+    const clientProxy = new Proxy(realClient, {
+      get: (target, property) => {
+        const name = String(property);
+        const value = target[name];
+        if (typeof value !== "function") return value;
+        if (publicationMethods.has(name)) {
+          return (...args: unknown[]) => {
+            publications.push(async () => {
+              const result = await value.apply(target, args);
+              if (name === "setStatuses" && result === false) {
+                const updates = (args[0] ?? []) as CmuxStatusUpdate[];
+                for (const update of updates) {
+                  const previous = originalSidebarSnapshot.get(update.key);
+                  if (previous) this.sidebarSnapshot.set(update.key, previous);
+                  else this.sidebarSnapshot.delete(update.key);
+                }
+              }
+            });
+            return Promise.resolve(name === "setStatuses" ? true : undefined);
+          };
+        }
+        if (notificationMethods.has(name)) {
+          return (...args: unknown[]) => {
+            notifications.push(async () => {
+              try {
+                await value.apply(target, args);
+              } catch {
+                if (name === "notifyLifecycleEvent") {
+                  const [event, agent, signature] = args as [
+                    AgentLifecycleEvent,
+                    AgentRecord,
+                    string | undefined,
+                  ];
+                  const suffix = signature === undefined ? "" : `:${signature}`;
+                  this.notifiedEvents.delete(
+                    `${agent.agent_id}:${event}${suffix}`,
+                  );
+                  const previous = originalSidebarSnapshot.get(agent.agent_id);
+                  if (previous) {
+                    this.sidebarSnapshot.set(agent.agent_id, previous);
+                  } else {
+                    this.sidebarSnapshot.delete(agent.agent_id);
+                  }
+                } else if (name === "notify") {
+                  const notification = args[0] as { surface?: string };
+                  const agent = this.registry
+                    .list()
+                    .find(
+                      (candidate) =>
+                        candidate.surface_id === notification.surface,
+                    );
+                  if (agent) {
+                    this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
+                  }
+                }
+              }
+            });
+            return Promise.resolve(undefined);
+          };
+        }
+        if (topologyMutationMethods.has(name)) {
+          return (...args: unknown[]) => {
+            persistence.push(() => value.apply(target, args));
+            if (name === "newSplit") {
+              const opts = (args[1] ?? {}) as {
+                workspace?: string;
+                pane?: string;
+              };
+              return Promise.resolve({
+                workspace: opts.workspace ?? "",
+                surface: "sweep-plan-placeholder",
+                pane: opts.pane ?? "",
+                title: "",
+                type: "terminal",
+              });
+            }
+            return Promise.resolve(undefined);
+          };
+        }
+        return value.bind(target);
+      },
+    }) as unknown as AgentEngineClient;
+    const realPublisher = this.fleetSidebarPublisher;
+    const publisherProxy = new Proxy(realPublisher, {
+      get: (target, property) => {
+        if (property === "publish") {
+          return (...args: unknown[]) => {
+            publications.push(() =>
+              (target.publish as (...values: unknown[]) => void)(...args),
+            );
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    planner.stateMgr = stateProxy;
+    planner.registry = registryProxy;
+    planner.client = clientProxy;
+    planner.fleetSidebarPublisher = publisherProxy;
+    planner.sidebarSnapshot = new Map(this.sidebarSnapshot);
+    planner.fleetScreenProgress = new Map(this.fleetScreenProgress);
+    planner.loggedEvents = new Set(this.loggedEvents);
+    planner.notifiedEvents = new Set(this.notifiedEvents);
+    planner.deliveredLeadMonitorDeathAlerts = new Set(
+      this.deliveredLeadMonitorDeathAlerts,
+    );
+    planner.readyPatternMatches = new Map(this.readyPatternMatches);
+    planner.cliExitShellMatches = new Map(this.cliExitShellMatches);
+    planner.promptResolutionFailures = new Map(this.promptResolutionFailures);
+    planner.promptMotionObservedAtMs = new Map(this.promptMotionObservedAtMs);
+    planner.promptMotionScreenSignatures = new Map(
+      this.promptMotionScreenSignatures,
+    );
+    planner.currentSweepScreenSignatures = new Map();
+    planner.currentSweepAgentContexts = new Map();
+    planner.activeSweepPlan = plan;
+    return plan;
+  }
+
+  private async buildSweepPlanContents(
+    surfaceTopology: SurfaceTopologySnapshot,
+    timings: Record<string, number>,
+  ): Promise<void> {
     const skipAccounting: SweepMutationSkipAccounting = { counted: false };
-    this.currentSweepScreenSignatures = new Map();
-    await this.runCloseForensicsBestEffort();
-    const surfaceTopology = await this.collectObservedSurfaceTopology();
-    const transportHealth = getTransportHealth(this.client);
-    const topologyIsAuthoritative =
-      surfaceTopology?.complete === true && surfaceTopology.surfaces.length > 0;
-    const mutationsAreSafe =
-      topologyIsAuthoritative &&
-      transportHealth?.mode === "socket" &&
-      transportHealth.degraded === false;
-    if (mutationsAreSafe) {
-      this.sweepSkippedMutations = 0;
-    }
-    const observedSurfaces = topologyIsAuthoritative
-      ? surfaceTopology.surfaces
-      : undefined;
+    const time = async (name: string, operation: () => Promise<void>) => {
+      const startedAt = Date.now();
+      await operation();
+      timings[name] = Date.now() - startedAt;
+    };
+    const observedSurfaces = surfaceTopology.surfaces;
+    await time("close_forensics_ms", () => this.runCloseForensicsBestEffort());
     // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
     // but require one confirmation window after the surface is first observed
     // absent. The same gate also applies to terminal worker cleanup below.
@@ -7272,11 +7702,10 @@ export class AgentEngine {
       confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
       now: Date.now(),
     };
-    await this.reapChannelMarkersBestEffort();
-    if (mutationsAreSafe) {
+    await time("registry_ms", async () => {
       const observed = {
         ...surfacelessConfirmation,
-        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+        surfaces: observedSurfaces,
       };
       if (
         this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
@@ -7293,17 +7722,13 @@ export class AgentEngine {
       ) {
         await this.purgeStartupTerminalAgents();
       }
-    } else {
-      this.countSkippedSweepTick(skipAccounting);
-    }
+    });
 
     // Deferred transcript identity does not require a live surface binding.
     // Retry after the one-shot startup purge has retained marked rows, but
     // before normal terminal cleanup can act on a closed pane.
-    await this.retryDeferredTranscriptCaptures();
-    await this.sweepWatchesBestEffort();
+    await time("transcript_ms", () => this.retryDeferredTranscriptCaptures());
     if (
-      mutationsAreSafe &&
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
       await this.registry.purgeTerminal({
@@ -7311,23 +7736,153 @@ export class AgentEngine {
         ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       });
     }
-    await this.sweepMonitorRegistryBestEffort();
     if (
-      mutationsAreSafe &&
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
-      await this.reconcileRolePlacements("idle", { surfaceTopology });
+      await time("role_ms", async () => {
+        await this.reconcileRolePlacements("idle", { surfaceTopology });
+      });
     }
-    if (!mutationsAreSafe) {
-      await this.syncSidebar({}, null);
-    } else if (
+    if (
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
-      await this.syncSidebar({}, surfaceTopology, () =>
-        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting),
+      await time("sidebar_ms", async () => {
+        await this.syncSidebar({}, surfaceTopology, () =>
+          this.canRunSnapshotBackedSweepMutation(
+            surfaceTopology,
+            skipAccounting,
+          ),
+        );
+      });
+    }
+  }
+
+  private async buildSweepPlan(): Promise<SweepPlan> {
+    const topologyStartedAt = Date.now();
+    const surfaceTopology = await this.collectObservedSurfaceTopology();
+    const plan = this.createSweepPlan(surfaceTopology);
+    plan.timings.topology_ms = Date.now() - topologyStartedAt;
+    const markerStartedAt = Date.now();
+    await this.reapChannelMarkersBestEffort();
+    plan.timings.channel_markers_ms = Date.now() - markerStartedAt;
+    const transportHealth = getTransportHealth(this.client);
+    const canBuildMutatingPlan =
+      surfaceTopology?.complete === true &&
+      surfaceTopology.surfaces.length > 0 &&
+      transportHealth?.mode === "socket" &&
+      transportHealth.degraded === false;
+    if (!canBuildMutatingPlan || !surfaceTopology) {
+      plan.readOnly = true;
+      const sidebarStartedAt = Date.now();
+      await plan.planner.syncSidebar({}, null);
+      plan.timings.sidebar_ms = Date.now() - sidebarStartedAt;
+      return plan;
+    }
+    const buildStartedAt = Date.now();
+    await plan.planner.buildSweepPlanContents(surfaceTopology, plan.timings);
+    plan.timings.build_total_ms = Date.now() - buildStartedAt;
+    return plan;
+  }
+
+  private sweepPlanInputIsCurrent(plan: SweepPlan): boolean {
+    if (!this.isSweepTopologyObserverCurrent(plan.surfaceTopology))
+      return false;
+    const transportHealth = getTransportHealth(this.client);
+    if (
+      transportHealth?.mode !== "socket" ||
+      transportHealth.degraded !== false
+    ) {
+      return false;
+    }
+    const currentRecords = new Map(
+      this.stateMgr
+        .listStates()
+        .map((record) => [record.agent_id, record.version]),
+    );
+    if (currentRecords.size !== plan.initialVersions.size) return false;
+    for (const [agentId, version] of plan.initialVersions) {
+      if (currentRecords.get(agentId) !== version) return false;
+    }
+    return true;
+  }
+
+  private applyPlannedRegistry(plan: SweepPlan): void {
+    const target = this.registry as unknown as {
+      agents: Map<string, AgentRecord>;
+      aliases: Map<string, string>;
+      surfacelessObservations: Map<string, unknown>;
+      unclaimedAbsenceObservations: Map<string, unknown>;
+    };
+    target.agents.clear();
+    for (const [agentId, preview] of plan.registryMaps.agents) {
+      target.agents.set(agentId, this.stateMgr.readState(agentId) ?? preview);
+    }
+    target.aliases = new Map(plan.registryMaps.aliases);
+    target.surfacelessObservations = new Map(
+      plan.registryMaps.surfacelessObservations,
+    );
+    target.unclaimedAbsenceObservations = new Map(
+      plan.registryMaps.unclaimedAbsenceObservations,
+    );
+  }
+
+  private applyPlannedMemory(plan: SweepPlan): void {
+    const planner = plan.planner;
+    this.sidebarSnapshot = planner.sidebarSnapshot;
+    this.fleetScreenProgress = planner.fleetScreenProgress;
+    this.loggedEvents = planner.loggedEvents;
+    this.notifiedEvents = planner.notifiedEvents;
+    this.deliveredLeadMonitorDeathAlerts =
+      planner.deliveredLeadMonitorDeathAlerts;
+    this.readyPatternMatches = planner.readyPatternMatches;
+    this.cliExitShellMatches = planner.cliExitShellMatches;
+    this.promptResolutionFailures = planner.promptResolutionFailures;
+    this.promptMotionObservedAtMs = planner.promptMotionObservedAtMs;
+    this.promptMotionScreenSignatures = planner.promptMotionScreenSignatures;
+    this.currentSweepScreenSignatures = planner.currentSweepScreenSignatures;
+  }
+
+  private async applySweepPlan(plan: SweepPlan): Promise<boolean> {
+    // This is the single post-pass authorization check. Nothing in the plan
+    // has touched authoritative state, cmux status, or notification channels.
+    if (plan.readOnly) {
+      this.applyPlannedMemory(plan);
+      for (const operation of plan.publications) await operation();
+      this.sweepSkippedMutations += 1;
+      return false;
+    }
+    if (!this.sweepPlanInputIsCurrent(plan)) {
+      this.sweepSkippedMutations += 1;
+      console.warn(
+        "[cmuxlayer] sweep plan dropped: topology observer, transport, or registry version changed",
       );
+      return false;
     }
-    await this.drainOutboxBestEffort();
+
+    try {
+      for (const operation of plan.persistence) await operation();
+    } catch (error) {
+      this.sweepSkippedMutations += 1;
+      console.warn(
+        `[cmuxlayer] sweep plan persistence failed before publication: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return false;
+    }
+    this.applyPlannedRegistry(plan);
+    this.applyPlannedMemory(plan);
+    for (const operation of plan.publications) {
+      try {
+        await operation();
+      } catch {
+        // Status/log publication is best-effort. A failed row remains dirty in
+        // the in-memory snapshot and is retried by the next planned sweep.
+      }
+    }
+    for (const operation of plan.notifications) await operation();
+    this.sweepSkippedMutations = 0;
+    return true;
   }
 
   private async reapChannelMarkersBestEffort(): Promise<void> {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -624,6 +624,8 @@ async function validateCodexModel(
 }
 
 export interface AgentEngineOptions {
+  /** Debug-only sweep phase timings. Defaults to stderr-safe console.debug. */
+  sweepDebugLog?: (message: string) => void;
   spawnPreflight?: (
     params: SpawnAgentParams,
   ) => Promise<SpawnPreflightResult | void>;
@@ -892,10 +894,13 @@ export interface SweepTimingOptions {
 type SweepTimingInput = number | Partial<SweepTimingOptions>;
 
 interface SweepAgentContext {
+  sweep?: boolean;
   screen?: Promise<CmuxReadScreenResult>;
   route?: Promise<AgentRoute>;
   surfaceTopology?: SurfaceTopologySnapshot | null;
   observedSurfaceRef?: string | null;
+  topologyGeneration?: number;
+  skipAccounting?: SweepMutationSkipAccounting;
 }
 
 interface SweepMutationSkipAccounting {
@@ -993,6 +998,9 @@ export interface LifecycleLockState {
   forced_releases: number;
   /** Sweep ticks that preserved state because topology could not authorize deletion. */
   sweep_skipped_mutations: number;
+  sweep_skipped_reason: string | null;
+  /** Sweep ticks that stopped early to let a queued lifecycle mutation run. */
+  sweep_yielded: number;
   timeouts: number;
   last_timeout: LifecycleLockTimeoutRecord | null;
 }
@@ -1575,6 +1583,7 @@ export class AgentEngine {
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
   private currentSweepScreenSignatures = new Map<string, string>();
+  private sweepDebugLog: (message: string) => void;
   /** agentId → last material (de-chromed) screen output change. */
   private fleetScreenProgress = new Map<string, FleetScreenProgressSnapshot>();
   /** agentId → last-pushed status target/value */
@@ -1631,6 +1640,9 @@ export class AgentEngine {
   private lifecycleLockQueueDepth = 0;
   private lifecycleLockForcedReleases = 0;
   private sweepSkippedMutations = 0;
+  private sweepSkippedReason: string | null = null;
+  private sweepYielded = 0;
+  private sweepTopologyGeneration = 0;
   private lifecycleLockTimeouts = 0;
   private lifecycleLockLastTimeout: LifecycleLockTimeoutRecord | null = null;
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
@@ -1737,6 +1749,9 @@ export class AgentEngine {
     this.loadDeliveryReceipts();
     this.registry = registry;
     this.client = client;
+    this.sweepDebugLog =
+      opts?.sweepDebugLog ??
+      ((message) => process.stderr.write(`${message}\n`));
     this.roleSurfaceIdsProvider = opts?.roleSurfaceIdsProvider;
     this.launchCommandSender = opts?.launchCommandSender;
     this.inboxOpts = opts?.inboxOpts;
@@ -3482,7 +3497,7 @@ export class AgentEngine {
       index.persistRecord(canonicalFinal);
       this.registry.rename(updated.agent_id, finalAgentId, canonicalFinal);
       this.transferAgentRenameMemory(updated.agent_id, finalAgentId);
-      this.stateMgr.removeState(updated.agent_id);
+      this.removeStateForSweep({}, updated.agent_id);
       removePendingChannelMarkerAfterRegistration(
         updated.agent_id,
         finalAgentId,
@@ -3603,6 +3618,7 @@ export class AgentEngine {
     ctx: SweepAgentContext,
     opts: { resolveTranscript?: boolean } = {},
   ): Promise<AgentRecord> {
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
     if (agent.cli_session_id) {
       const canResolveSelfRegistration =
         this.canUseSelfRegistrationProcessEvidence(agent);
@@ -3741,6 +3757,7 @@ export class AgentEngine {
 
     try {
       const screen = await this.readSweepScreen(captureAgent, ctx);
+      if (!this.assertSweepInputCurrent(ctx)) return captureAgent;
       const sessionId = extractSessionId(screen.text);
       if (!sessionId) {
         return captureAgent;
@@ -3800,6 +3817,7 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<AgentRecord> {
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
     if (agent.state !== "booting") {
       this.readyPatternMatches.delete(agent.agent_id);
       return agent;
@@ -3810,6 +3828,7 @@ export class AgentEngine {
 
     try {
       const screen = await this.readSweepScreen(agent, ctx);
+      if (!this.assertSweepInputCurrent(ctx)) return agent;
       const parsed = parseScreen(screen.text);
       const parsedEffort =
         agent.cli === "codex" ? parseCodexEffort(parsed.model) : null;
@@ -3938,9 +3957,11 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<{ agent: AgentRecord; screenText?: string }> {
+    if (!this.assertSweepInputCurrent(ctx)) return { agent };
     if (TERMINAL_STATES.has(agent.state)) return { agent };
 
     if (await this.hasGroundTruthDone(agent, ctx)) {
+      if (!this.assertSweepInputCurrent(ctx)) return { agent };
       try {
         const marked = this.stateMgr.updateRecord(agent.agent_id, {
           task_done_candidate_at: null,
@@ -3958,6 +3979,7 @@ export class AgentEngine {
 
     try {
       const screen = await this.readSweepScreen(agent, ctx);
+      if (!this.assertSweepInputCurrent(ctx)) return { agent };
       if (!this.hasOutputDoneEvidence(agent.cli, screen.text)) {
         if (agent.task_done_candidate_at) {
           const updated = this.stateMgr.updateRecord(agent.agent_id, {
@@ -4335,7 +4357,9 @@ export class AgentEngine {
     screenText: string,
     disposition: Extract<PromptDisposition, { kind: "resolve" }>,
     nowIso: string,
+    ctx: SweepAgentContext = {},
   ): Promise<{ agent: AgentRecord; recovered: boolean }> {
+    if (!this.assertSweepInputCurrent(ctx)) return { agent, recovered: false };
     const signature = screenTextSignature(screenText);
     if (this.promptResolutionFailures.get(agent.agent_id) === signature) {
       return { agent, recovered: false };
@@ -4353,6 +4377,8 @@ export class AgentEngine {
     let error: string | null = null;
     try {
       const route = await this.resolveAgentIoRoute(agent.agent_id);
+      if (!this.assertSweepInputCurrent(ctx))
+        return { agent, recovered: false };
       const assertSurfaceBindingCurrent = async (): Promise<void> => {
         await this.resolveUnchangedAgentIoRoute(
           agent.agent_id,
@@ -4360,6 +4386,9 @@ export class AgentEngine {
           "prompt resolution",
         );
       };
+      if (!this.assertSweepInputCurrent(ctx)) {
+        return { agent, recovered: false };
+      }
       await this.client.sendKey(route.surface_id, disposition.key, {
         workspace: route.workspace_id ?? undefined,
         ...this.stableSurfaceWriteOptions(route.surface_uuid),
@@ -4371,6 +4400,9 @@ export class AgentEngine {
         workspace: route.workspace_id ?? undefined,
       });
       await assertSurfaceBindingCurrent();
+      if (!this.assertSweepInputCurrent(ctx)) {
+        return { agent, recovered: false };
+      }
       const after = parseScreen(afterScreen.text);
       afterControlState = after.control_state;
       const recovered =
@@ -4400,6 +4432,9 @@ export class AgentEngine {
       agent = this.persistPromptBlockedState(agent, false, nowIso);
       return { agent: this.clearHaltEpisode(agent), recovered: true };
     } catch (cause) {
+      if (!this.assertSweepInputCurrent(ctx)) {
+        return { agent, recovered: false };
+      }
       error = cause instanceof Error ? cause.message : String(cause);
       this.promptResolutionFailures.set(agent.agent_id, signature);
       this.appendResolvedPromptEvent({
@@ -4419,7 +4454,9 @@ export class AgentEngine {
   private async maybeEscalateLiveHalt(
     agent: AgentRecord,
     screenText: string,
+    ctx: SweepAgentContext = {},
   ): Promise<AgentRecord> {
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
     const nowMs = this.haltNow();
     const nowIso = new Date(nowMs).toISOString();
     const parsed = parseScreen(screenText);
@@ -4430,7 +4467,9 @@ export class AgentEngine {
         screenText,
         disposition,
         nowIso,
+        ctx,
       );
+      if (!this.assertSweepInputCurrent(ctx)) return agent;
       agent = resolution.agent;
       if (resolution.recovered) return agent;
       disposition = {
@@ -4617,6 +4656,7 @@ export class AgentEngine {
       return episode;
     }
     const resolution = await this.nearestLiveHaltAncestor(episode, nowMs);
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
     if (resolution.fallback) {
       episode = this.stateMgr.updateRecord(episode.agent_id, {
         halt_missing_ancestor_count:
@@ -4709,6 +4749,7 @@ export class AgentEngine {
     ctx: SweepAgentContext,
     knownScreenText?: string,
   ): Promise<AgentRecord> {
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
     if (
       TERMINAL_STATES.has(agent.state) ||
       !(["ready", "working", "idle"] as AgentState[]).includes(agent.state)
@@ -4725,6 +4766,8 @@ export class AgentEngine {
       this.cliExitShellMatches.delete(agent.agent_id);
       return agent;
     }
+
+    if (!this.assertSweepInputCurrent(ctx)) return agent;
 
     if (parseScreen(screenText).control_state !== "shell") {
       this.cliExitShellMatches.delete(agent.agent_id);
@@ -5076,7 +5119,9 @@ export class AgentEngine {
   private async logLifecycleEvent(
     agent: AgentRecord,
     event: AgentLifecycleEvent,
+    ctx: SweepAgentContext = {},
   ): Promise<void> {
+    if (!this.assertSweepInputCurrent(ctx)) return;
     const eventKey = `${agent.agent_id}:${event}`;
     if (this.loggedEvents.has(eventKey)) {
       return;
@@ -5124,6 +5169,16 @@ export class AgentEngine {
     }
   }
 
+  private async notifyLifecycleEventForSweep(
+    ctx: SweepAgentContext,
+    agent: AgentRecord,
+    event: AgentLifecycleEvent,
+    signature?: string,
+  ): Promise<boolean> {
+    if (!this.assertSweepInputCurrent(ctx)) return false;
+    return this.notifyLifecycleEvent(agent, event, signature);
+  }
+
   private clearHealthNotificationMemory(agentId: string): void {
     const healthPrefix = `${agentId}:health:`;
     for (const key of this.notifiedEvents) {
@@ -5131,6 +5186,28 @@ export class AgentEngine {
         this.notifiedEvents.delete(key);
       }
     }
+  }
+
+  private async publishSweepStatus(
+    ctx: SweepAgentContext,
+    statusUpdates: CmuxStatusUpdate[],
+  ): Promise<boolean> {
+    if (!this.assertSweepInputCurrent(ctx)) return false;
+    if (statusUpdates.length === 1) {
+      const [update] = statusUpdates;
+      await this.client.setStatus(update.key, update.value, update);
+      return true;
+    }
+    if (statusUpdates.length > 1) {
+      if (this.client.setStatuses) {
+        return (await this.client.setStatuses(statusUpdates)) !== false;
+      }
+      for (const update of statusUpdates) {
+        if (!this.assertSweepInputCurrent(ctx)) return false;
+        await this.client.setStatus(update.key, update.value, update);
+      }
+    }
+    return true;
   }
 
   private shouldNotifyDone(harvestability: WorkerHarvestability): boolean {
@@ -5210,12 +5287,51 @@ export class AgentEngine {
     return false;
   }
 
+  /**
+   * The single bounded authorization check for a sweep side effect. Non-sweep
+   * callers do not carry `sweep`, so normal interactive lifecycle operations
+   * retain their existing behavior.
+   */
+  private assertSweepInputCurrent(ctx: SweepAgentContext): boolean {
+    if (ctx.sweep !== true) return true;
+    const topology = ctx.surfaceTopology ?? null;
+    const transport = getTransportHealth(this.client);
+    const reason =
+      topology?.complete !== true || topology.surfaces.length === 0
+        ? "topology_incomplete"
+        : !this.isSweepTopologyObserverCurrent(topology)
+          ? "epoch_changed"
+          : transport?.mode !== "socket" || transport.degraded !== false
+            ? "transport_degraded"
+            : ctx.topologyGeneration !== this.sweepTopologyGeneration ||
+                topology.generation !== ctx.topologyGeneration
+              ? "topology_generation_changed"
+              : null;
+    const current = reason === null;
+    if (!current && ctx.skipAccounting) {
+      this.countSkippedSweepTick(ctx.skipAccounting, reason);
+    }
+    return current;
+  }
+
+  private shouldYieldSweep(): boolean {
+    if (this.lifecycleLockQueueDepth === 0) return false;
+    this.sweepYielded += 1;
+    return true;
+  }
+
+  private invalidateSweepTopologyGeneration(): void {
+    this.sweepTopologyGeneration += 1;
+  }
+
   private countSkippedSweepTick(
     skipAccounting: SweepMutationSkipAccounting,
+    reason = "epoch_changed",
   ): void {
     if (skipAccounting.counted) return;
     skipAccounting.counted = true;
     this.sweepSkippedMutations += 1;
+    this.sweepSkippedReason = reason;
   }
 
   private assertSurfaceObserverEpochCurrent(
@@ -5257,6 +5373,7 @@ export class AgentEngine {
     opts: { firstConnect?: boolean } = {},
     surfaceTopologyOverride?: SurfaceTopologySnapshot | null,
     snapshotMutationAllowed?: () => boolean,
+    sweepContext: SweepAgentContext = {},
   ): Promise<void> {
     const agents = this.registry.list();
     const total = agents.length;
@@ -5323,6 +5440,7 @@ export class AgentEngine {
             // Best-effort cleanup for a no-longer-resolvable binding.
           }
         }
+        if (!this.assertSweepInputCurrent(sweepContext)) return;
         this.sidebarSnapshot.delete(registryAgent.agent_id);
         // The registry row still exists. Keep once-only lifecycle delivery
         // memory so a recovered binding cannot re-emit "spawned" or terminal
@@ -5376,7 +5494,10 @@ export class AgentEngine {
         );
         this.registry.set(originalAgent.agent_id, originalAgent);
       }
-      const sweepCtx: SweepAgentContext = { surfaceTopology };
+      const sweepCtx: SweepAgentContext = {
+        ...sweepContext,
+        surfaceTopology,
+      };
       // MCP readiness must not depend on a synchronous scan of the host's
       // transcript tree. Normal sweeps retry transcript capture after startup.
       const capturedAgent = await this.maybeCaptureBootSessionId(
@@ -5406,6 +5527,7 @@ export class AgentEngine {
             // Best-effort cleanup; closed panes must not emit fresh health signals.
           }
         }
+        if (!this.assertSweepInputCurrent(sweepCtx)) return;
         this.sidebarSnapshot.delete(initialAgentId);
         this.clearAgentLifecycleMemory(initialAgentId);
         continue;
@@ -5444,7 +5566,7 @@ export class AgentEngine {
         if (targetAgent.agent_id === agent.agent_id) return sweepCtx;
         const existing = healthScreenContexts.get(targetAgent.agent_id);
         if (existing) return existing;
-        const next: SweepAgentContext = { surfaceTopology };
+        const next: SweepAgentContext = { ...sweepContext, surfaceTopology };
         healthScreenContexts.set(targetAgent.agent_id, next);
         return next;
       };
@@ -5537,6 +5659,7 @@ export class AgentEngine {
             // Best-effort cleanup; the next coherent sweep republishes it.
           }
         }
+        if (!this.assertSweepInputCurrent(sweepCtx)) return;
         this.sidebarSnapshot.delete(initialAgentId);
         this.clearAgentLifecycleMemory(initialAgentId);
         continue;
@@ -5550,7 +5673,11 @@ export class AgentEngine {
         }
       }
       if (haltScreenText !== undefined) {
-        agent = await this.maybeEscalateLiveHalt(agent, haltScreenText);
+        agent = await this.maybeEscalateLiveHalt(
+          agent,
+          haltScreenText,
+          sweepCtx,
+        );
       }
       if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
         continue;
@@ -5561,6 +5688,7 @@ export class AgentEngine {
         surfaceBinding.workspaceId ?? agent.workspace_id ?? null;
       const health = evaluateAgentHealth(agent, healthInput);
       await this.maybeNotifyLeadMonitorDeath(agent, healthInput);
+      if (!this.assertSweepInputCurrent(sweepCtx)) return;
       if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
         continue;
       }
@@ -5580,27 +5708,28 @@ export class AgentEngine {
 
       // Lifecycle log: spawned (first encounter)
       if (!prev) {
-        await this.logLifecycleEvent(agent, "spawned");
+        await this.logLifecycleEvent(agent, "spawned", sweepCtx);
       }
 
       // Lifecycle log: done
       if (state === "done") {
-        await this.logLifecycleEvent(agent, "done");
+        await this.logLifecycleEvent(agent, "done", sweepCtx);
         if (this.shouldNotifyDone(harvestability)) {
-          await this.notifyLifecycleEvent(agent, "done");
+          await this.notifyLifecycleEventForSweep(sweepCtx, agent, "done");
         }
       }
 
       // Lifecycle log: error
       if (state === "error") {
-        await this.logLifecycleEvent(agent, "errored");
-        await this.notifyLifecycleEvent(agent, "errored");
+        await this.logLifecycleEvent(agent, "errored", sweepCtx);
+        await this.notifyLifecycleEventForSweep(sweepCtx, agent, "errored");
       }
 
       const shouldNotifyHealth = this.shouldNotifyHealthChange(prev, health);
       let healthNotificationDelivered = true;
       if (shouldNotifyHealth) {
-        healthNotificationDelivered = await this.notifyLifecycleEvent(
+        healthNotificationDelivered = await this.notifyLifecycleEventForSweep(
+          sweepCtx,
           agent,
           "health",
           healthSignature,
@@ -5695,6 +5824,7 @@ export class AgentEngine {
       if (statusChanged) {
         pendingStatusSnapshots.push({ agentId, snapshot: nextSnapshot });
       } else {
+        if (!this.assertSweepInputCurrent(sweepCtx)) return;
         this.sidebarSnapshot.set(agentId, nextSnapshot);
       }
 
@@ -5713,6 +5843,7 @@ export class AgentEngine {
             contextPct >= 80 &&
             agent.quality !== "degraded"
           ) {
+            if (!this.assertSweepInputCurrent(sweepCtx)) return;
             // Mark degraded
             const updated = this.stateMgr.updateRecord(agentId, {
               quality: "degraded",
@@ -5759,6 +5890,7 @@ export class AgentEngine {
           surfaces: surfaceTopology?.surfaces,
         }))
       ) {
+        if (!this.assertSweepInputCurrent(sweepCtx)) return;
         const heartbeat = this.stateMgr.updateRecord(agentId, {});
         this.registry.set(agentId, heartbeat);
       }
@@ -5768,19 +5900,15 @@ export class AgentEngine {
       return;
     }
 
-    let statusBatchApplied = true;
-    if (statusUpdates.length === 1) {
-      const [update] = statusUpdates;
-      await this.client.setStatus(update.key, update.value, update);
-    } else if (statusUpdates.length > 1) {
-      if (this.client.setStatuses) {
-        statusBatchApplied =
-          (await this.client.setStatuses(statusUpdates)) !== false;
-      } else {
-        for (const update of statusUpdates) {
-          await this.client.setStatus(update.key, update.value, update);
-        }
-      }
+    const statusBatchApplied = await this.publishSweepStatus(
+      sweepContext,
+      statusUpdates,
+    );
+    if (
+      statusUpdates.length > 0 &&
+      !this.assertSweepInputCurrent(sweepContext)
+    ) {
+      return;
     }
     if (statusBatchApplied) {
       for (const pending of pendingStatusSnapshots) {
@@ -5809,6 +5937,7 @@ export class AgentEngine {
         } catch {
           // Best-effort sidebar cleanup
         }
+        if (!this.assertSweepInputCurrent(sweepContext)) return;
         this.sidebarSnapshot.delete(agentId);
         this.clearAgentLifecycleMemory(agentId);
       }
@@ -5876,8 +6005,12 @@ export class AgentEngine {
     opts: {
       agentIds?: ReadonlySet<string>;
       surfaceTopology?: SurfaceTopologySnapshot | null;
+      sweepContext?: SweepAgentContext;
     } = {},
   ): Promise<RolePlacementReconcileSummary> {
+    if (!this.assertSweepInputCurrent(opts.sweepContext ?? {})) {
+      return { moved: [], skipped: [] };
+    }
     const summary: RolePlacementReconcileSummary = { moved: [], skipped: [] };
     const eligibleForTrigger = (agent: AgentRecord): boolean => {
       if (agent.surface_provenance !== "cmuxlayer_spawn") return false;
@@ -5935,6 +6068,9 @@ export class AgentEngine {
           expectedSurfaceRef: string,
           operation: string,
         ): Promise<void> => {
+          if (!this.assertSweepInputCurrent(opts.sweepContext ?? {})) {
+            throw new Error("sweep input changed before role placement");
+          }
           this.assertSurfaceObserverEpochCurrent(observerEpoch, operation);
           const current =
             this.registry.get(agent.agent_id) ??
@@ -5979,6 +6115,9 @@ export class AgentEngine {
             this.stateMgr.readState(agent.agent_id);
           if (!latest || !eligibleForTrigger(latest)) {
             throw new Error("agent became busy before role placement mutation");
+          }
+          if (!this.assertSweepInputCurrent(opts.sweepContext ?? {})) {
+            throw new Error("sweep input changed before role placement");
           }
         };
 
@@ -6056,6 +6195,7 @@ export class AgentEngine {
             beforeMutation: () =>
               assertFreshAgentBinding(sourceRef, "worker-column seed"),
           });
+          this.invalidateSweepTopologyGeneration();
           this.assertSurfaceObserverEpochCurrent(
             observerEpoch,
             "role placement",
@@ -6089,6 +6229,7 @@ export class AgentEngine {
             beforeMutation: () =>
               assertFreshAgentBinding(sourceRef, "role placement move"),
           });
+          this.invalidateSweepTopologyGeneration();
           summary.moved.push({
             agent_id: agent.agent_id,
             surface_id: sourceRef,
@@ -6253,7 +6394,10 @@ export class AgentEngine {
     }
   }
 
-  private async purgeStartupTerminalAgents(): Promise<void> {
+  private async purgeStartupTerminalAgents(
+    ctx: SweepAgentContext = {},
+  ): Promise<void> {
+    if (!this.assertSweepInputCurrent(ctx)) return;
     if (!this.startupPurgePending) return;
     this.startupPurgePending = false;
     const retainedAgentIds = new Set(this.startupPurgeRetainedAgentIds);
@@ -6280,6 +6424,31 @@ export class AgentEngine {
         healthSignature: "__purged__",
       });
     }
+  }
+
+  private async evictSurfacelessForSweep(
+    ctx: SweepAgentContext,
+    observed: Parameters<AgentRegistry["evictSurfaceless"]>[0],
+  ): Promise<void> {
+    if (!this.assertSweepInputCurrent(ctx)) return;
+    await this.registry.evictSurfaceless(observed);
+  }
+
+  private async purgeTerminalForSweep(
+    ctx: SweepAgentContext,
+    observed: Parameters<AgentRegistry["purgeTerminal"]>[0],
+  ): Promise<void> {
+    if (!this.assertSweepInputCurrent(ctx)) return;
+    await this.registry.purgeTerminal(observed);
+  }
+
+  private removeStateForSweep(
+    ctx: SweepAgentContext,
+    agentId: string,
+  ): boolean {
+    if (!this.assertSweepInputCurrent(ctx)) return false;
+    this.stateMgr.removeState(agentId);
+    return true;
   }
 
   /**
@@ -6428,6 +6597,8 @@ export class AgentEngine {
       hold_timeout_ms: this.lifecycleLockHoldTimeoutMs,
       forced_releases: this.lifecycleLockForcedReleases,
       sweep_skipped_mutations: this.sweepSkippedMutations,
+      sweep_skipped_reason: this.sweepSkippedReason,
+      sweep_yielded: this.sweepYielded,
       timeouts: this.lifecycleLockTimeouts,
       last_timeout: this.lifecycleLockLastTimeout,
     };
@@ -7246,88 +7417,141 @@ export class AgentEngine {
   }
 
   private async runSweepOnce(): Promise<void> {
-    const skipAccounting: SweepMutationSkipAccounting = { counted: false };
-    this.currentSweepScreenSignatures = new Map();
-    await this.runCloseForensicsBestEffort();
-    const surfaceTopology = await this.collectObservedSurfaceTopology();
-    const transportHealth = getTransportHealth(this.client);
-    const topologyIsAuthoritative =
-      surfaceTopology?.complete === true && surfaceTopology.surfaces.length > 0;
-    const mutationsAreSafe =
-      topologyIsAuthoritative &&
-      transportHealth?.mode === "socket" &&
-      transportHealth.degraded === false;
-    if (mutationsAreSafe) {
-      this.sweepSkippedMutations = 0;
-    }
-    const observedSurfaces = topologyIsAuthoritative
-      ? surfaceTopology.surfaces
-      : undefined;
-    // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
-    // but require one confirmation window after the surface is first observed
-    // absent. The same gate also applies to terminal worker cleanup below.
-    // This absorbs cmux's short post-create topology lag without retaining old
-    // ghosts indefinitely. Empty or failed enumeration remains inconclusive.
-    const surfacelessConfirmation = {
-      confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
-      now: Date.now(),
+    const timings: Record<string, number> = {};
+    const sweepStartedAt = Date.now();
+    const time = async <T>(name: string, operation: () => Promise<T>) => {
+      const startedAt = Date.now();
+      try {
+        return await operation();
+      } finally {
+        timings[name] = Date.now() - startedAt;
+      }
     };
-    await this.reapChannelMarkersBestEffort();
-    if (mutationsAreSafe) {
-      const observed = {
-        ...surfacelessConfirmation,
-        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+    try {
+      const skipAccounting: SweepMutationSkipAccounting = { counted: false };
+      this.currentSweepScreenSignatures = new Map();
+      const surfaceTopology = await time("topology_ms", () =>
+        this.collectObservedSurfaceTopology(),
+      );
+      this.sweepTopologyGeneration += 1;
+      if (surfaceTopology) {
+        surfaceTopology.generation = this.sweepTopologyGeneration;
+      }
+      const sweepCtx: SweepAgentContext = {
+        sweep: true,
+        surfaceTopology,
+        topologyGeneration: surfaceTopology?.generation,
+        skipAccounting,
       };
-      if (
-        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-      ) {
-        await this.registry.reconcile(observed);
+      const transportHealth = getTransportHealth(this.client);
+      const topologyIsAuthoritative =
+        surfaceTopology?.complete === true &&
+        surfaceTopology.surfaces.length > 0;
+      const mutationsAreSafe =
+        topologyIsAuthoritative &&
+        transportHealth?.mode === "socket" &&
+        transportHealth.degraded === false;
+      if (mutationsAreSafe) {
+        this.sweepSkippedMutations = 0;
+        this.sweepSkippedReason = null;
       }
-      if (
-        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-      ) {
-        await this.registry.evictSurfaceless(observed);
+      const observedSurfaces = topologyIsAuthoritative
+        ? surfaceTopology.surfaces
+        : undefined;
+      // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
+      // but require one confirmation window after the surface is first observed
+      // absent. The same gate also applies to terminal worker cleanup below.
+      // This absorbs cmux's short post-create topology lag without retaining old
+      // ghosts indefinitely. Empty or failed enumeration remains inconclusive.
+      const surfacelessConfirmation = {
+        confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
+        now: Date.now(),
+      };
+      await time("close_forensics_ms", () =>
+        this.runCloseForensicsBestEffort(sweepCtx),
+      );
+      if (this.shouldYieldSweep()) return;
+      await time("channel_markers_ms", () =>
+        this.reapChannelMarkersBestEffort(),
+      );
+      if (this.shouldYieldSweep()) return;
+      if (mutationsAreSafe) {
+        const observed = {
+          ...surfacelessConfirmation,
+          ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+        };
+        if (this.assertSweepInputCurrent(sweepCtx)) {
+          await time("registry_reconcile_ms", () =>
+            this.registry.reconcile(observed),
+          );
+        }
+        if (this.shouldYieldSweep()) return;
+        if (this.assertSweepInputCurrent(sweepCtx)) {
+          await time("evict_ms", () =>
+            this.evictSurfacelessForSweep(sweepCtx, observed),
+          );
+        }
+        if (this.shouldYieldSweep()) return;
+        if (this.assertSweepInputCurrent(sweepCtx)) {
+          await time("startup_purge_ms", () =>
+            this.purgeStartupTerminalAgents(sweepCtx),
+          );
+        }
+      } else {
+        this.countSkippedSweepTick(skipAccounting, "transport_degraded");
       }
-      if (
-        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-      ) {
-        await this.purgeStartupTerminalAgents();
-      }
-    } else {
-      this.countSkippedSweepTick(skipAccounting);
-    }
 
-    // Deferred transcript identity does not require a live surface binding.
-    // Retry after the one-shot startup purge has retained marked rows, but
-    // before normal terminal cleanup can act on a closed pane.
-    await this.retryDeferredTranscriptCaptures();
-    await this.sweepWatchesBestEffort();
-    if (
-      mutationsAreSafe &&
-      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-    ) {
-      await this.registry.purgeTerminal({
-        ...surfacelessConfirmation,
-        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
-      });
-    }
-    await this.sweepMonitorRegistryBestEffort();
-    if (
-      mutationsAreSafe &&
-      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-    ) {
-      await this.reconcileRolePlacements("idle", { surfaceTopology });
-    }
-    if (!mutationsAreSafe) {
-      await this.syncSidebar({}, null);
-    } else if (
-      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
-    ) {
-      await this.syncSidebar({}, surfaceTopology, () =>
-        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting),
+      // Deferred transcript identity does not require a live surface binding.
+      // Retry after the one-shot startup purge has retained marked rows, but
+      // before normal terminal cleanup can act on a closed pane.
+      await time("transcript_ms", () => this.retryDeferredTranscriptCaptures());
+      if (this.shouldYieldSweep()) return;
+      await time("watches_ms", () => this.sweepWatchesBestEffort());
+      if (this.shouldYieldSweep()) return;
+      if (mutationsAreSafe && this.assertSweepInputCurrent(sweepCtx)) {
+        await time("terminal_purge_ms", () =>
+          this.purgeTerminalForSweep(sweepCtx, {
+            ...surfacelessConfirmation,
+            ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+          }),
+        );
+      }
+      if (this.shouldYieldSweep()) return;
+      await time("monitors_ms", () => this.sweepMonitorRegistryBestEffort());
+      if (this.shouldYieldSweep()) return;
+      if (mutationsAreSafe && this.assertSweepInputCurrent(sweepCtx)) {
+        await time("placements_ms", () =>
+          this.reconcileRolePlacements("idle", {
+            surfaceTopology,
+            sweepContext: sweepCtx,
+          }),
+        );
+      }
+      if (this.shouldYieldSweep()) return;
+      if (!mutationsAreSafe) {
+        await time("sidebar_ms", () =>
+          this.syncSidebar({}, null, undefined, sweepCtx),
+        );
+      } else if (this.assertSweepInputCurrent(sweepCtx)) {
+        await time("sidebar_ms", () =>
+          this.syncSidebar(
+            {},
+            surfaceTopology,
+            () => this.assertSweepInputCurrent(sweepCtx),
+            sweepCtx,
+          ),
+        );
+      }
+      if (this.shouldYieldSweep()) return;
+      await time("outbox_ms", () => this.drainOutboxBestEffort());
+    } finally {
+      timings.total_ms = Date.now() - sweepStartedAt;
+      this.sweepDebugLog(
+        `[cmuxlayer] sweep timing ${Object.entries(timings)
+          .map(([name, value]) => `${name}=${value}`)
+          .join(" ")}`,
       );
     }
-    await this.drainOutboxBestEffort();
   }
 
   private async reapChannelMarkersBestEffort(): Promise<void> {
@@ -7383,13 +7607,15 @@ export class AgentEngine {
    * can become a recoverable crash. Forensics remains best-effort and never
    * breaks the sweep.
    */
-  private async runCloseForensicsBestEffort(): Promise<void> {
+  private async runCloseForensicsBestEffort(
+    ctx: SweepAgentContext,
+  ): Promise<void> {
     if (!this.closeForensicsRunner) return;
     if (this.closeForensicsSweepInFlight) return;
     this.closeForensicsSweepInFlight = true;
     try {
       const result = await this.closeForensicsRunner();
-      this.markIntentionalSurfaceCloses(result.events);
+      this.markIntentionalSurfaceCloses(result.events, ctx);
     } catch {
       // Never break the sweep on a forensics failure; it retries next sweep.
     } finally {
@@ -7397,7 +7623,11 @@ export class AgentEngine {
     }
   }
 
-  private markIntentionalSurfaceCloses(events: CloseForensicsEvent[]): void {
+  private markIntentionalSurfaceCloses(
+    events: CloseForensicsEvent[],
+    ctx: SweepAgentContext,
+  ): void {
+    if (!this.assertSweepInputCurrent(ctx)) return;
     const closedSurfaceUuids = new Set(
       events
         .filter(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5157,14 +5157,21 @@ export class AgentEngine {
     return !surfaceTopology.workspaceBySurface.has(agent.surface_id);
   }
 
-  private surfaceObserverIdProvider(): SurfaceObserverIdProvider | undefined {
+  private surfaceObserverEpochProvider():
+    SurfaceObserverIdProvider | undefined {
     return this.registry.isObserverOwnershipEnforced()
       ? () => this.registry.getObserverEpoch()
       : undefined;
   }
 
+  private surfaceObserverIdProvider(): SurfaceObserverIdProvider | undefined {
+    return this.registry.isObserverOwnershipEnforced()
+      ? () => this.registry.getObserverId()
+      : undefined;
+  }
+
   private captureSurfaceObserverEpoch(): SurfaceObserverEpoch {
-    return captureObserverEpoch(this.surfaceObserverIdProvider());
+    return captureObserverEpoch(this.surfaceObserverEpochProvider());
   }
 
   private isSurfaceObserverEpochCurrent(
@@ -5172,8 +5179,30 @@ export class AgentEngine {
   ): boolean {
     return isSurfaceObserverEpochCurrent(
       observerEpoch,
-      this.surfaceObserverIdProvider(),
+      this.surfaceObserverEpochProvider(),
     );
+  }
+
+  private isSweepTopologyObserverCurrent(
+    surfaceTopology: SurfaceTopologySnapshot | null,
+  ): boolean {
+    if (!this.registry.isObserverOwnershipEnforced()) return true;
+    return Boolean(
+      surfaceTopology?.observerId &&
+      surfaceTopology.observerEpoch &&
+      this.registry.getObserverId() === surfaceTopology.observerId &&
+      this.registry.getObserverEpoch() === surfaceTopology.observerEpoch,
+    );
+  }
+
+  private canRunSnapshotBackedSweepMutation(
+    surfaceTopology: SurfaceTopologySnapshot | null,
+  ): boolean {
+    if (this.isSweepTopologyObserverCurrent(surfaceTopology)) return true;
+    // The topology belongs to a replaced route. Count each preserved mutation
+    // as reason=epoch_changed and never re-collect partway through this sweep.
+    this.sweepSkippedMutations += 1;
+    return false;
   }
 
   private assertSurfaceObserverEpochCurrent(
@@ -5193,6 +5222,7 @@ export class AgentEngine {
     return collectSurfaceTopology(
       this.client,
       undefined,
+      this.surfaceObserverEpochProvider(),
       this.surfaceObserverIdProvider(),
     );
   }
@@ -5201,6 +5231,7 @@ export class AgentEngine {
     return collectSurfaceTopology(
       this.client,
       undefined,
+      this.surfaceObserverEpochProvider(),
       this.surfaceObserverIdProvider(),
     );
   }
@@ -7196,9 +7227,15 @@ export class AgentEngine {
         ...surfacelessConfirmation,
         ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       };
-      await this.registry.reconcile(observed);
-      await this.registry.evictSurfaceless(observed);
-      await this.purgeStartupTerminalAgents();
+      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+        await this.registry.reconcile(observed);
+      }
+      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+        await this.registry.evictSurfaceless(observed);
+      }
+      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+        await this.purgeStartupTerminalAgents();
+      }
     } else {
       this.sweepSkippedMutations += 1;
     }
@@ -7208,18 +7245,27 @@ export class AgentEngine {
     // before normal terminal cleanup can act on a closed pane.
     await this.retryDeferredTranscriptCaptures();
     await this.sweepWatchesBestEffort();
-    if (mutationsAreSafe) {
+    if (
+      mutationsAreSafe &&
+      this.canRunSnapshotBackedSweepMutation(surfaceTopology)
+    ) {
       await this.registry.purgeTerminal({
         ...surfacelessConfirmation,
         ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       });
     }
     await this.sweepMonitorRegistryBestEffort();
-    if (mutationsAreSafe) {
+    if (
+      mutationsAreSafe &&
+      this.canRunSnapshotBackedSweepMutation(surfaceTopology)
+    ) {
       await this.reconcileRolePlacements("idle", { surfaceTopology });
     }
-    const sidebarTopology = mutationsAreSafe ? surfaceTopology : null;
-    await this.syncSidebar({}, sidebarTopology);
+    if (!mutationsAreSafe) {
+      await this.syncSidebar({}, null);
+    } else if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+      await this.syncSidebar({}, surfaceTopology);
+    }
     await this.drainOutboxBestEffort();
   }
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -898,6 +898,10 @@ interface SweepAgentContext {
   observedSurfaceRef?: string | null;
 }
 
+interface SweepMutationSkipAccounting {
+  counted: boolean;
+}
+
 class PlacementSurfaceBindingError extends Error {}
 
 interface StopPostConditionResult {
@@ -5197,12 +5201,21 @@ export class AgentEngine {
 
   private canRunSnapshotBackedSweepMutation(
     surfaceTopology: SurfaceTopologySnapshot | null,
+    skipAccounting: SweepMutationSkipAccounting,
   ): boolean {
     if (this.isSweepTopologyObserverCurrent(surfaceTopology)) return true;
-    // The topology belongs to a replaced route. Count each preserved mutation
-    // as reason=epoch_changed and never re-collect partway through this sweep.
-    this.sweepSkippedMutations += 1;
+    // The topology belongs to a replaced route. Count this preserved sweep tick
+    // once as reason=epoch_changed and never re-collect partway through it.
+    this.countSkippedSweepTick(skipAccounting);
     return false;
+  }
+
+  private countSkippedSweepTick(
+    skipAccounting: SweepMutationSkipAccounting,
+  ): void {
+    if (skipAccounting.counted) return;
+    skipAccounting.counted = true;
+    this.sweepSkippedMutations += 1;
   }
 
   private assertSurfaceObserverEpochCurrent(
@@ -5243,6 +5256,7 @@ export class AgentEngine {
   private async syncSidebar(
     opts: { firstConnect?: boolean } = {},
     surfaceTopologyOverride?: SurfaceTopologySnapshot | null,
+    snapshotMutationAllowed?: () => boolean,
   ): Promise<void> {
     const agents = this.registry.list();
     const total = agents.length;
@@ -5277,6 +5291,9 @@ export class AgentEngine {
     const fleetCandidates: FleetSidebarCandidate[] = [];
 
     for (const registryAgent of agents) {
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
       if (opts.firstConnect && TERMINAL_STATES.has(registryAgent.state)) {
         this.cliExitShellMatches.delete(registryAgent.agent_id);
         continue;
@@ -5350,6 +5367,9 @@ export class AgentEngine {
         bindingPatch.surface_observer_id = observerId;
       }
       if (Object.keys(bindingPatch).length > 0) {
+        if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+          continue;
+        }
         originalAgent = this.stateMgr.updateRecord(
           originalAgent.agent_id,
           bindingPatch,
@@ -5371,6 +5391,9 @@ export class AgentEngine {
         sweepCtx,
         taskDoneResult.screenText,
       );
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
       const initialAgentId = agent.agent_id;
       if (this.isKnownClosedSurface(agent, surfaceTopology)) {
         const prev = this.sidebarSnapshot.get(initialAgentId);
@@ -5489,12 +5512,17 @@ export class AgentEngine {
           harvestability,
         },
       );
-      if (
-        !(await this.sweepReadMatchesBinding(
-          sweepCtx,
-          surfaceBinding.surfaceRef,
-        ))
-      ) {
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
+      const sweepReadMatchesBinding = await this.sweepReadMatchesBinding(
+        sweepCtx,
+        surfaceBinding.surfaceRef,
+      );
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
+      if (!sweepReadMatchesBinding) {
         // The fresh I/O resolver observed this stable UUID at a different ref
         // than the topology snapshot that began the sweep. The screen belongs
         // to the fresh route, while title/topology still belong to the outer
@@ -5524,12 +5552,18 @@ export class AgentEngine {
       if (haltScreenText !== undefined) {
         agent = await this.maybeEscalateLiveHalt(agent, haltScreenText);
       }
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
       const { agent_id: agentId, state } = agent;
       const boundSurfaceRef = surfaceBinding.surfaceRef;
       const boundWorkspaceId =
         surfaceBinding.workspaceId ?? agent.workspace_id ?? null;
       const health = evaluateAgentHealth(agent, healthInput);
       await this.maybeNotifyLeadMonitorDeath(agent, healthInput);
+      if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+        continue;
+      }
       const healthSignature = this.healthSignature(health);
       const statusValue = this.buildSidebarStatusValue(
         agent,
@@ -5580,6 +5614,9 @@ export class AgentEngine {
       }
 
       if (!(opts.firstConnect && TERMINAL_STATES.has(state))) {
+        if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+          continue;
+        }
         fleetCandidates.push({
           agentId: agent.agent_id,
           agentType: agent.cli,
@@ -5634,6 +5671,9 @@ export class AgentEngine {
           } catch {
             // Best-effort cleanup of stale workspace-scoped status.
           }
+        }
+        if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+          continue;
         }
         const sidebar = STATE_SIDEBAR[state];
         statusUpdates.push({
@@ -5724,6 +5764,10 @@ export class AgentEngine {
       }
     }
 
+    if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+      return;
+    }
+
     let statusBatchApplied = true;
     if (statusUpdates.length === 1) {
       const [update] = statusUpdates;
@@ -5755,6 +5799,9 @@ export class AgentEngine {
     }
     for (const [agentId, snapshot] of this.sidebarSnapshot) {
       if (!currentAgentIds.has(agentId)) {
+        if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+          return;
+        }
         try {
           await this.client.clearStatus(agentId, {
             workspace: snapshot.workspaceId ?? undefined,
@@ -5789,6 +5836,9 @@ export class AgentEngine {
           : opts.firstConnect
             ? "unknown"
             : "empty";
+    if (snapshotMutationAllowed && !snapshotMutationAllowed()) {
+      return;
+    }
     try {
       this.fleetSidebarPublisher.publish({
         state: publicationState,
@@ -7196,6 +7246,7 @@ export class AgentEngine {
   }
 
   private async runSweepOnce(): Promise<void> {
+    const skipAccounting: SweepMutationSkipAccounting = { counted: false };
     this.currentSweepScreenSignatures = new Map();
     await this.runCloseForensicsBestEffort();
     const surfaceTopology = await this.collectObservedSurfaceTopology();
@@ -7227,17 +7278,23 @@ export class AgentEngine {
         ...surfacelessConfirmation,
         ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       };
-      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+      if (
+        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
+      ) {
         await this.registry.reconcile(observed);
       }
-      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+      if (
+        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
+      ) {
         await this.registry.evictSurfaceless(observed);
       }
-      if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
+      if (
+        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
+      ) {
         await this.purgeStartupTerminalAgents();
       }
     } else {
-      this.sweepSkippedMutations += 1;
+      this.countSkippedSweepTick(skipAccounting);
     }
 
     // Deferred transcript identity does not require a live surface binding.
@@ -7247,7 +7304,7 @@ export class AgentEngine {
     await this.sweepWatchesBestEffort();
     if (
       mutationsAreSafe &&
-      this.canRunSnapshotBackedSweepMutation(surfaceTopology)
+      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
       await this.registry.purgeTerminal({
         ...surfacelessConfirmation,
@@ -7257,14 +7314,18 @@ export class AgentEngine {
     await this.sweepMonitorRegistryBestEffort();
     if (
       mutationsAreSafe &&
-      this.canRunSnapshotBackedSweepMutation(surfaceTopology)
+      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
       await this.reconcileRolePlacements("idle", { surfaceTopology });
     }
     if (!mutationsAreSafe) {
       await this.syncSidebar({}, null);
-    } else if (this.canRunSnapshotBackedSweepMutation(surfaceTopology)) {
-      await this.syncSidebar({}, surfaceTopology);
+    } else if (
+      this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
+    ) {
+      await this.syncSidebar({}, surfaceTopology, () =>
+        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting),
+      );
     }
     await this.drainOutboxBestEffort();
   }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -7175,6 +7175,9 @@ export class AgentEngine {
       topologyIsAuthoritative &&
       transportHealth?.mode === "socket" &&
       transportHealth.degraded === false;
+    if (mutationsAreSafe) {
+      this.sweepSkippedMutations = 0;
+    }
     const observedSurfaces = topologyIsAuthoritative
       ? surfaceTopology.surfaces
       : undefined;
@@ -8667,6 +8670,12 @@ export class AgentEngine {
         topologyOverride === undefined
           ? await this.collectObservedSurfaceTopology()
           : topologyOverride;
+      if (topologyOverride !== undefined) {
+        this.assertSurfaceObserverEpochCurrent(
+          topology?.observerEpoch,
+          "sweep route resolution",
+        );
+      }
       const binding = resolveAgentSurfaceBinding(agent, topology);
       if (
         topology?.complete !== true ||
@@ -8700,6 +8709,12 @@ export class AgentEngine {
       topologyOverride === undefined
         ? await this.collectObservedSurfaceTopology()
         : topologyOverride;
+    if (topologyOverride !== undefined) {
+      this.assertSurfaceObserverEpochCurrent(
+        topology?.observerEpoch,
+        "sweep route resolution",
+      );
+    }
     const binding = resolveAgentSurfaceBinding(agent, topology);
     if (!binding || binding.provenance !== "uuid") {
       if (agentProcessMayBeAlive(agent)) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -231,6 +231,10 @@ import {
   type SurfaceTopologySnapshot,
 } from "./surface-topology.js";
 import {
+  getTransportHealth,
+  type TransportHealthSignal,
+} from "./cmux-transport-self-heal.js";
+import {
   DEFAULT_CHANNEL_MARKER_RETENTION_MS,
   dispatchOnce,
   readInbox,
@@ -890,6 +894,7 @@ type SweepTimingInput = number | Partial<SweepTimingOptions>;
 interface SweepAgentContext {
   screen?: Promise<CmuxReadScreenResult>;
   route?: Promise<AgentRoute>;
+  observedRouteMismatch?: boolean;
 }
 
 class PlacementSurfaceBindingError extends Error {}
@@ -981,6 +986,8 @@ export interface LifecycleLockState {
   acquire_timeout_ms: number;
   hold_timeout_ms: number;
   forced_releases: number;
+  /** Sweep ticks that preserved state because topology could not authorize deletion. */
+  sweep_skipped_mutations: number;
   timeouts: number;
   last_timeout: LifecycleLockTimeoutRecord | null;
 }
@@ -1062,6 +1069,9 @@ export function resolveSweepTiming(
 }
 
 interface AgentEngineClient {
+  getTransportHealth?(): TransportHealthSignal | null;
+  /** Native and CLI clients accept a stable UUID as the read-screen target. */
+  supportsStableSurfaceReads?: boolean;
   listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }>;
   log(
     message: string,
@@ -1615,6 +1625,12 @@ export class AgentEngine {
   private lifecycleLockAcquiredAtMs: number | null = null;
   private lifecycleLockQueueDepth = 0;
   private lifecycleLockForcedReleases = 0;
+  private sweepSkippedMutations = 0;
+  /** Authoritative snapshot reused only while one sweep publishes its sidebar. */
+  private currentSweepTopologyOverride:
+    | SurfaceTopologySnapshot
+    | null
+    | undefined;
   private lifecycleLockTimeouts = 0;
   private lifecycleLockLastTimeout: LifecycleLockTimeoutRecord | null = null;
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
@@ -3492,7 +3508,11 @@ export class AgentEngine {
     opts: { lines?: number; scrollback?: boolean } = {},
   ): Promise<CmuxReadScreenResult> {
     const route = await this.resolveAgentIoRoute(agent.agent_id);
-    return this.client.readScreen(route.surface_id, {
+    const readTarget =
+      this.client.supportsStableSurfaceReads && route.surface_uuid
+        ? route.surface_uuid
+        : route.surface_id;
+    return this.client.readScreen(readTarget, {
       ...opts,
       workspace: route.workspace_id ?? undefined,
     });
@@ -3504,10 +3524,24 @@ export class AgentEngine {
   ): Promise<CmuxReadScreenResult> {
     ctx.route ??= this.resolveAgentIoRoute(agent.agent_id);
     ctx.screen ??= ctx.route.then(async (route) => {
-      const screen = await this.client.readScreen(route.surface_id, {
+      const readTarget =
+        this.client.supportsStableSurfaceReads && route.surface_uuid
+          ? route.surface_uuid
+          : route.surface_id;
+      const screen = await this.client.readScreen(readTarget, {
         lines: BOOT_SESSION_CAPTURE_LINES,
         workspace: route.workspace_id ?? undefined,
       });
+      const observedSurface = screen.surface?.trim();
+      if (
+        this.client.supportsStableSurfaceReads &&
+        route.surface_uuid &&
+        observedSurface &&
+        observedSurface !== route.surface_id &&
+        observedSurface.toLowerCase() !== route.surface_uuid.toLowerCase()
+      ) {
+        ctx.observedRouteMismatch = true;
+      }
       await this.resolveUnchangedAgentIoRoute(
         agent.agent_id,
         route,
@@ -3544,6 +3578,7 @@ export class AgentEngine {
     ctx: SweepAgentContext,
     surfaceRef: string,
   ): Promise<boolean> {
+    if (ctx.observedRouteMismatch) return false;
     if (!ctx.route) return true;
     try {
       const readRoute = await ctx.route;
@@ -5167,6 +5202,17 @@ export class AgentEngine {
   }
 
   private collectObservedSurfaceTopology(): Promise<SurfaceTopologySnapshot | null> {
+    if (this.currentSweepTopologyOverride !== undefined) {
+      return Promise.resolve(this.currentSweepTopologyOverride);
+    }
+    return collectSurfaceTopology(
+      this.client,
+      undefined,
+      this.surfaceObserverIdProvider(),
+    );
+  }
+
+  private collectFreshObservedSurfaceTopology(): Promise<SurfaceTopologySnapshot | null> {
     return collectSurfaceTopology(
       this.client,
       undefined,
@@ -5179,12 +5225,16 @@ export class AgentEngine {
    * Logs lifecycle events (spawned, done, error) once each.
    */
   private async syncSidebar(
-    opts: { firstConnect?: boolean } = {},
+    opts: { firstConnect?: boolean; allowRecordRemoval?: boolean } = {},
+    surfaceTopologyOverride?: SurfaceTopologySnapshot | null,
   ): Promise<void> {
     const agents = this.registry.list();
     const total = agents.length;
     const done = agents.filter((a) => a.state === "done").length;
-    const surfaceTopology = await this.collectObservedSurfaceTopology();
+    const surfaceTopology =
+      surfaceTopologyOverride === undefined
+        ? await this.collectObservedSurfaceTopology()
+        : surfaceTopologyOverride;
     const observedLiveSurfaceRefs =
       surfaceTopology?.complete === true
         ? [...surfaceTopology.workspaceBySurface.keys()].sort()
@@ -5513,8 +5563,14 @@ export class AgentEngine {
         this.clearHealthNotificationMemory(agentId);
       }
 
-      const archived = await this.maybeArchiveDoneAgent(agent);
-      const reaped = archived ? false : await this.maybeReapIdleWorker(agent);
+      const allowRecordRemoval = opts.allowRecordRemoval !== false;
+      const archived = allowRecordRemoval
+        ? await this.maybeArchiveDoneAgent(agent)
+        : false;
+      const reaped =
+        allowRecordRemoval && !archived
+          ? await this.maybeReapIdleWorker(agent)
+          : false;
       if (archived || reaped) {
         try {
           await this.client.clearStatus(agentId, {
@@ -5670,7 +5726,9 @@ export class AgentEngine {
       if (
         state !== "booting" &&
         !TERMINAL_STATES.has(state) &&
-        (await this.registry.isSurfaceAlive(agent))
+        (await this.registry.isSurfaceAlive(agent, {
+          surfaces: surfaceTopology?.surfaces,
+        }))
       ) {
         const heartbeat = this.stateMgr.updateRecord(agentId, {});
         this.registry.set(agentId, heartbeat);
@@ -5776,7 +5834,10 @@ export class AgentEngine {
    */
   async reconcileRolePlacements(
     trigger: RolePlacementReconcileTrigger,
-    opts: { agentIds?: ReadonlySet<string> } = {},
+    opts: {
+      agentIds?: ReadonlySet<string>;
+      surfaceTopology?: SurfaceTopologySnapshot | null;
+    } = {},
   ): Promise<RolePlacementReconcileSummary> {
     const summary: RolePlacementReconcileSummary = { moved: [], skipped: [] };
     const eligibleForTrigger = (agent: AgentRecord): boolean => {
@@ -5813,6 +5874,22 @@ export class AgentEngine {
         continue;
       }
 
+      // The sweep already owns one complete topology observation. If it proves
+      // this seat is in the canonical column, avoid enumerating the workspace
+      // again. A misplaced or inconclusive seat still takes the existing fresh
+      // mutation-guard path below.
+      const sweepBinding = resolveAgentSurfaceBinding(
+        agent,
+        opts.surfaceTopology ?? null,
+      );
+      if (
+        sweepBinding?.provenance === "uuid" &&
+        opts.surfaceTopology?.topologyBySurface.get(sweepBinding.surfaceRef)
+          ?.column === targetColumn
+      ) {
+        continue;
+      }
+
       const observerEpoch = this.captureSurfaceObserverEpoch();
       try {
         const assertFreshAgentBinding = async (
@@ -5834,7 +5911,7 @@ export class AgentEngine {
               "agent provenance, state, or stable binding changed before mutation",
             );
           }
-          const topology = await this.collectObservedSurfaceTopology();
+          const topology = await this.collectFreshObservedSurfaceTopology();
           this.assertSurfaceObserverEpochCurrent(observerEpoch, operation);
           if (!topology?.complete) {
             throw new Error("fresh stable UUID topology is incomplete");
@@ -5991,7 +6068,8 @@ export class AgentEngine {
                 "worker-column seed has no stable UUID; refusing cleanup by mutable ref",
               );
             }
-            const seedTopology = await this.collectObservedSurfaceTopology();
+            const seedTopology =
+              await this.collectFreshObservedSurfaceTopology();
             const seedBinding = seedTopology?.complete
               ? resolveAgentSurfaceBinding(
                   {
@@ -6015,7 +6093,7 @@ export class AgentEngine {
                   "role placement seed cleanup",
                 );
                 const freshSeedTopology =
-                  await this.collectObservedSurfaceTopology();
+                  await this.collectFreshObservedSurfaceTopology();
                 this.assertSurfaceObserverEpochCurrent(
                   observerEpoch,
                   "role placement seed cleanup",
@@ -6310,6 +6388,7 @@ export class AgentEngine {
       acquire_timeout_ms: this.lifecycleLockAcquireTimeoutMs,
       hold_timeout_ms: this.lifecycleLockHoldTimeoutMs,
       forced_releases: this.lifecycleLockForcedReleases,
+      sweep_skipped_mutations: this.sweepSkippedMutations,
       timeouts: this.lifecycleLockTimeouts,
       last_timeout: this.lifecycleLockLastTimeout,
     };
@@ -7130,6 +7209,24 @@ export class AgentEngine {
   private async runSweepOnce(): Promise<void> {
     this.currentSweepScreenSignatures = new Map();
     await this.runCloseForensicsBestEffort();
+    const surfaceTopology = await this.collectObservedSurfaceTopology();
+    const reuseSweepTopology = this.client.supportsStableSurfaceReads === true;
+    if (reuseSweepTopology) {
+      this.currentSweepTopologyOverride = surfaceTopology;
+    }
+    try {
+    const transportHealth = getTransportHealth(this.client);
+    const topologyIsAuthoritative =
+      surfaceTopology?.complete === true &&
+      surfaceTopology.surfaces.length > 0;
+    const mutationsAreSafe =
+      transportHealth === null ||
+      (topologyIsAuthoritative &&
+        transportHealth.mode === "socket" &&
+        transportHealth.degraded !== true);
+    const observedSurfaces = topologyIsAuthoritative
+      ? surfaceTopology.surfaces
+      : undefined;
     // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
     // but require one confirmation window after the surface is first observed
     // absent. The same gate also applies to terminal worker cleanup below.
@@ -7139,22 +7236,45 @@ export class AgentEngine {
       confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
       now: Date.now(),
     };
-    await this.registry.reconcile(surfacelessConfirmation);
     await this.reapChannelMarkersBestEffort();
-    await this.registry.evictSurfaceless(surfacelessConfirmation);
-
-    await this.purgeStartupTerminalAgents();
+    if (mutationsAreSafe) {
+      const observed = {
+        ...surfacelessConfirmation,
+        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+      };
+      await this.registry.reconcile(observed);
+      await this.registry.evictSurfaceless(observed);
+      await this.purgeStartupTerminalAgents();
+    } else {
+      this.sweepSkippedMutations += 1;
+    }
 
     // Deferred transcript identity does not require a live surface binding.
     // Retry after the one-shot startup purge has retained marked rows, but
     // before normal terminal cleanup can act on a closed pane.
     await this.retryDeferredTranscriptCaptures();
     await this.sweepWatchesBestEffort();
-    await this.registry.purgeTerminal(surfacelessConfirmation);
+    if (mutationsAreSafe) {
+      await this.registry.purgeTerminal({
+        ...surfacelessConfirmation,
+        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
+      });
+    }
     await this.sweepMonitorRegistryBestEffort();
-    await this.reconcileRolePlacements("idle");
-    await this.syncSidebar();
+    if (mutationsAreSafe) {
+      await this.reconcileRolePlacements("idle", { surfaceTopology });
+    }
+    const sidebarTopology = mutationsAreSafe ? surfaceTopology : null;
+    await this.syncSidebar(
+      { allowRecordRemoval: mutationsAreSafe },
+      sidebarTopology,
+    );
     await this.drainOutboxBestEffort();
+    } finally {
+      if (reuseSweepTopology) {
+      this.currentSweepTopologyOverride = undefined;
+      }
+    }
   }
 
   private async reapChannelMarkersBestEffort(): Promise<void> {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -894,7 +894,8 @@ type SweepTimingInput = number | Partial<SweepTimingOptions>;
 interface SweepAgentContext {
   screen?: Promise<CmuxReadScreenResult>;
   route?: Promise<AgentRoute>;
-  observedRouteMismatch?: boolean;
+  surfaceTopology?: SurfaceTopologySnapshot | null;
+  observedSurfaceRef?: string | null;
 }
 
 class PlacementSurfaceBindingError extends Error {}
@@ -1626,11 +1627,6 @@ export class AgentEngine {
   private lifecycleLockQueueDepth = 0;
   private lifecycleLockForcedReleases = 0;
   private sweepSkippedMutations = 0;
-  /** Authoritative snapshot reused only while one sweep publishes its sidebar. */
-  private currentSweepTopologyOverride:
-    | SurfaceTopologySnapshot
-    | null
-    | undefined;
   private lifecycleLockTimeouts = 0;
   private lifecycleLockLastTimeout: LifecycleLockTimeoutRecord | null = null;
   private deliveryReceipts = new Map<string, AgentDeliveryReceipt>();
@@ -3522,7 +3518,10 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<CmuxReadScreenResult> {
-    ctx.route ??= this.resolveAgentIoRoute(agent.agent_id);
+    ctx.route ??= this.resolveAgentIoRoute(
+      agent.agent_id,
+      this.client.supportsStableSurfaceReads ? ctx.surfaceTopology : undefined,
+    );
     ctx.screen ??= ctx.route.then(async (route) => {
       const readTarget =
         this.client.supportsStableSurfaceReads && route.surface_uuid
@@ -3533,20 +3532,14 @@ export class AgentEngine {
         workspace: route.workspace_id ?? undefined,
       });
       const observedSurface = screen.surface?.trim();
-      if (
-        this.client.supportsStableSurfaceReads &&
-        route.surface_uuid &&
-        observedSurface &&
-        observedSurface !== route.surface_id &&
-        observedSurface.toLowerCase() !== route.surface_uuid.toLowerCase()
-      ) {
-        ctx.observedRouteMismatch = true;
+      ctx.observedSurfaceRef = observedSurface || null;
+      if (!this.client.supportsStableSurfaceReads) {
+        await this.resolveUnchangedAgentIoRoute(
+          agent.agent_id,
+          route,
+          "sweep screen read",
+        );
       }
-      await this.resolveUnchangedAgentIoRoute(
-        agent.agent_id,
-        route,
-        "sweep screen read",
-      );
       this.currentSweepScreenSignatures.set(
         agent.agent_id,
         `${route.surface_id}:${screenTextSignature(screen.text)}`,
@@ -3578,10 +3571,19 @@ export class AgentEngine {
     ctx: SweepAgentContext,
     surfaceRef: string,
   ): Promise<boolean> {
-    if (ctx.observedRouteMismatch) return false;
     if (!ctx.route) return true;
     try {
       const readRoute = await ctx.route;
+      if (this.client.supportsStableSurfaceReads) {
+        const observedSurface = ctx.observedSurfaceRef;
+        return (
+          readRoute.surface_id === surfaceRef &&
+          (!observedSurface ||
+            observedSurface === readRoute.surface_id ||
+            observedSurface.toLowerCase() ===
+              readRoute.surface_uuid?.toLowerCase())
+        );
+      }
       const currentRoute = await this.resolveAgentIoRoute(readRoute.agent_id);
       return (
         this.sameSurfaceRoute(readRoute, currentRoute) &&
@@ -4780,20 +4782,6 @@ export class AgentEngine {
     return exited;
   }
 
-  private async maybeArchiveDoneAgent(agent: AgentRecord): Promise<boolean> {
-    void agent;
-    // Sweeps must never close user panes. TASK_DONE marks state only; explicit
-    // close_surface/stop_agent remain available when an orchestrator chooses it.
-    return false;
-  }
-
-  private async maybeReapIdleWorker(agent: AgentRecord): Promise<boolean> {
-    void agent;
-    // The old idle-worker reaper was too destructive for unattended workspaces.
-    // Keep panes visible until an explicit close command is issued.
-    return false;
-  }
-
   private async cleanupUnboundCreatedSurface(
     surface: CreatedAgentSurface,
     operation: "agent-placement" | "crash-recovery",
@@ -5202,9 +5190,6 @@ export class AgentEngine {
   }
 
   private collectObservedSurfaceTopology(): Promise<SurfaceTopologySnapshot | null> {
-    if (this.currentSweepTopologyOverride !== undefined) {
-      return Promise.resolve(this.currentSweepTopologyOverride);
-    }
     return collectSurfaceTopology(
       this.client,
       undefined,
@@ -5225,7 +5210,7 @@ export class AgentEngine {
    * Logs lifecycle events (spawned, done, error) once each.
    */
   private async syncSidebar(
-    opts: { firstConnect?: boolean; allowRecordRemoval?: boolean } = {},
+    opts: { firstConnect?: boolean } = {},
     surfaceTopologyOverride?: SurfaceTopologySnapshot | null,
   ): Promise<void> {
     const agents = this.registry.list();
@@ -5340,7 +5325,7 @@ export class AgentEngine {
         );
         this.registry.set(originalAgent.agent_id, originalAgent);
       }
-      const sweepCtx: SweepAgentContext = {};
+      const sweepCtx: SweepAgentContext = { surfaceTopology };
       // MCP readiness must not depend on a synchronous scan of the host's
       // transcript tree. Normal sweeps retry transcript capture after startup.
       const capturedAgent = await this.maybeCaptureBootSessionId(
@@ -5405,7 +5390,7 @@ export class AgentEngine {
         if (targetAgent.agent_id === agent.agent_id) return sweepCtx;
         const existing = healthScreenContexts.get(targetAgent.agent_id);
         if (existing) return existing;
-        const next: SweepAgentContext = {};
+        const next: SweepAgentContext = { surfaceTopology };
         healthScreenContexts.set(targetAgent.agent_id, next);
         return next;
       };
@@ -5563,29 +5548,6 @@ export class AgentEngine {
         this.clearHealthNotificationMemory(agentId);
       }
 
-      const allowRecordRemoval = opts.allowRecordRemoval !== false;
-      const archived = allowRecordRemoval
-        ? await this.maybeArchiveDoneAgent(agent)
-        : false;
-      const reaped =
-        allowRecordRemoval && !archived
-          ? await this.maybeReapIdleWorker(agent)
-          : false;
-      if (archived || reaped) {
-        try {
-          await this.client.clearStatus(agentId, {
-            workspace: agent.workspace_id ?? undefined,
-          });
-        } catch {
-          // Best-effort sidebar cleanup; the surface has already been closed.
-        }
-        this.registry.remove(agentId);
-        this.stateMgr.removeState(agentId);
-        this.sidebarSnapshot.delete(agentId);
-        this.clearAgentLifecycleMemory(agentId);
-        continue;
-      }
-
       if (!(opts.firstConnect && TERMINAL_STATES.has(state))) {
         fleetCandidates.push({
           agentId: agent.agent_id,
@@ -5672,11 +5634,7 @@ export class AgentEngine {
         try {
           const screenText =
             taskDoneResult.screenText ??
-            (
-              await this.readAgentScreen(agent, {
-                lines: 5,
-              })
-            ).text;
+            (await this.readSweepScreen(agent, sweepCtx)).text;
           const parsed = parseScreen(tailScreenLines(screenText, 5));
           const contextPct = parsed.context_pct;
           if (
@@ -7210,20 +7168,13 @@ export class AgentEngine {
     this.currentSweepScreenSignatures = new Map();
     await this.runCloseForensicsBestEffort();
     const surfaceTopology = await this.collectObservedSurfaceTopology();
-    const reuseSweepTopology = this.client.supportsStableSurfaceReads === true;
-    if (reuseSweepTopology) {
-      this.currentSweepTopologyOverride = surfaceTopology;
-    }
-    try {
     const transportHealth = getTransportHealth(this.client);
     const topologyIsAuthoritative =
-      surfaceTopology?.complete === true &&
-      surfaceTopology.surfaces.length > 0;
+      surfaceTopology?.complete === true && surfaceTopology.surfaces.length > 0;
     const mutationsAreSafe =
-      transportHealth === null ||
-      (topologyIsAuthoritative &&
-        transportHealth.mode === "socket" &&
-        transportHealth.degraded !== true);
+      topologyIsAuthoritative &&
+      transportHealth?.mode === "socket" &&
+      transportHealth.degraded === false;
     const observedSurfaces = topologyIsAuthoritative
       ? surfaceTopology.surfaces
       : undefined;
@@ -7265,16 +7216,8 @@ export class AgentEngine {
       await this.reconcileRolePlacements("idle", { surfaceTopology });
     }
     const sidebarTopology = mutationsAreSafe ? surfaceTopology : null;
-    await this.syncSidebar(
-      { allowRecordRemoval: mutationsAreSafe },
-      sidebarTopology,
-    );
+    await this.syncSidebar({}, sidebarTopology);
     await this.drainOutboxBestEffort();
-    } finally {
-      if (reuseSweepTopology) {
-      this.currentSweepTopologyOverride = undefined;
-      }
-    }
   }
 
   private async reapChannelMarkersBestEffort(): Promise<void> {
@@ -8701,7 +8644,10 @@ export class AgentEngine {
    * UUID-less legacy records retain compatibility only when an owned ref is
    * proven by a complete fresh topology with no UUID identity coverage.
    */
-  async resolveAgentIoRoute(agentId: string): Promise<AgentRoute> {
+  async resolveAgentIoRoute(
+    agentId: string,
+    topologyOverride?: SurfaceTopologySnapshot | null,
+  ): Promise<AgentRoute> {
     let agent = this.registry.get(agentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
@@ -8717,7 +8663,10 @@ export class AgentEngine {
         );
       }
 
-      const topology = await this.collectObservedSurfaceTopology();
+      const topology =
+        topologyOverride === undefined
+          ? await this.collectObservedSurfaceTopology()
+          : topologyOverride;
       const binding = resolveAgentSurfaceBinding(agent, topology);
       if (
         topology?.complete !== true ||
@@ -8747,7 +8696,10 @@ export class AgentEngine {
       return this.resolveAgentRoute(agent.agent_id);
     }
 
-    const topology = await this.collectObservedSurfaceTopology();
+    const topology =
+      topologyOverride === undefined
+        ? await this.collectObservedSurfaceTopology()
+        : topologyOverride;
     const binding = resolveAgentSurfaceBinding(agent, topology);
     if (!binding || binding.provenance !== "uuid") {
       if (agentProcessMayBeAlive(agent)) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -624,8 +624,6 @@ async function validateCodexModel(
 }
 
 export interface AgentEngineOptions {
-  /** Debug-only sweep phase timings. Defaults to stderr so MCP stdout stays framed. */
-  sweepDebugLog?: (message: string) => void;
   spawnPreflight?: (
     params: SpawnAgentParams,
   ) => Promise<SpawnPreflightResult | void>;
@@ -902,26 +900,6 @@ interface SweepAgentContext {
 
 interface SweepMutationSkipAccounting {
   counted: boolean;
-}
-
-type SweepDeferredOperation = () => unknown | Promise<unknown>;
-
-interface SweepPlan {
-  surfaceTopology: SurfaceTopologySnapshot | null;
-  initialVersions: Map<string, number>;
-  persistence: SweepDeferredOperation[];
-  publications: SweepDeferredOperation[];
-  notifications: SweepDeferredOperation[];
-  planner: AgentEngine;
-  registryMaps: {
-    agents: Map<string, AgentRecord>;
-    aliases: Map<string, string>;
-    surfacelessObservations: Map<string, unknown>;
-    unclaimedAbsenceObservations: Map<string, unknown>;
-  };
-  originalSidebarSnapshot: Map<string, SidebarStatusSnapshot>;
-  timings: Record<string, number>;
-  readOnly: boolean;
 }
 
 class PlacementSurfaceBindingError extends Error {}
@@ -1597,10 +1575,6 @@ export class AgentEngine {
   private lastSweepSignature: string | null = null;
   private unchangedSweepCount = 0;
   private currentSweepScreenSignatures = new Map<string, string>();
-  /** Tick-wide screen memo: every agent is read at most once while planning. */
-  private currentSweepAgentContexts = new Map<string, SweepAgentContext>();
-  /** Non-null only on the isolated planner clone used outside the lifecycle lock. */
-  private activeSweepPlan: SweepPlan | null = null;
   /** agentId → last material (de-chromed) screen output change. */
   private fleetScreenProgress = new Map<string, FleetScreenProgressSnapshot>();
   /** agentId → last-pushed status target/value */
@@ -1678,7 +1652,6 @@ export class AgentEngine {
   private haltWedgedDwellMs: number;
   private haltWedgedSweeps: number;
   private autoResolvePrompts: boolean;
-  private sweepDebugLog: (message: string) => void;
   constructor(
     stateMgr: StateManager,
     registry: AgentRegistry,
@@ -1686,9 +1659,6 @@ export class AgentEngine {
     opts?: AgentEngineOptions,
   ) {
     this.stateMgr = stateMgr;
-    this.sweepDebugLog =
-      opts?.sweepDebugLog ??
-      ((message) => process.stderr.write(`${message}\n`));
     this.deliveryReceiptsPath = join(
       stateMgr.getBaseDir(),
       "delivery-receipts.json",
@@ -3552,14 +3522,6 @@ export class AgentEngine {
     agent: AgentRecord,
     ctx: SweepAgentContext,
   ): Promise<CmuxReadScreenResult> {
-    if (this.activeSweepPlan) {
-      const sharedCtx =
-        this.currentSweepAgentContexts.get(agent.agent_id) ?? ctx;
-      if (!this.currentSweepAgentContexts.has(agent.agent_id)) {
-        this.currentSweepAgentContexts.set(agent.agent_id, sharedCtx);
-      }
-      ctx = sharedCtx;
-    }
     ctx.route ??= this.resolveAgentIoRoute(
       agent.agent_id,
       this.client.supportsStableSurfaceReads ? ctx.surfaceTopology : undefined,
@@ -4691,28 +4653,22 @@ export class AgentEngine {
     );
     const unblockAction = this.haltUnblockAction(episode, haltType);
     try {
-      const haltDispatch = () =>
-        dispatchOnce(
-          ancestor.agent_id,
-          {
-            id: `agent-halt:${episode.agent_id}:${episode.halt_episode_started_at}`,
-            from: "cmuxlayer:lifecycle",
-            to: ancestor.agent_id,
-            tag: `agent_halt_${haltType}`,
-            task:
-              `Agent ${episode.agent_id} in surface ${episode.surface_id} has remained ` +
-              `${haltType} for ${durationSeconds}s. Last observable action: ` +
-              `${episode.halt_last_observable_action ?? "unknown"}. ` +
-              `Exact unblock action: ${unblockAction}. ` +
-              `Session resume fallback: ${resumeCommand}`,
-          },
-          this.inboxOpts,
-        );
-      if (this.activeSweepPlan) {
-        this.activeSweepPlan.notifications.push(haltDispatch);
-      } else {
-        haltDispatch();
-      }
+      dispatchOnce(
+        ancestor.agent_id,
+        {
+          id: `agent-halt:${episode.agent_id}:${episode.halt_episode_started_at}`,
+          from: "cmuxlayer:lifecycle",
+          to: ancestor.agent_id,
+          tag: `agent_halt_${haltType}`,
+          task:
+            `Agent ${episode.agent_id} in surface ${episode.surface_id} has remained ` +
+            `${haltType} for ${durationSeconds}s. Last observable action: ` +
+            `${episode.halt_last_observable_action ?? "unknown"}. ` +
+            `Exact unblock action: ${unblockAction}. ` +
+            `Session resume fallback: ${resumeCommand}`,
+        },
+        this.inboxOpts,
+      );
       const notified = this.stateMgr.updateRecord(episode.agent_id, {
         halt_notification_sent_at: nowIso,
         halt_notified_ancestor_id: ancestor.agent_id,
@@ -4795,27 +4751,20 @@ export class AgentEngine {
 
     let inboxDispatched = false;
     if (agent.parent_agent_id) {
-      const parentAgentId = agent.parent_agent_id;
       try {
-        const exitDispatch = () =>
-          dispatchOnce(
-            parentAgentId,
-            {
-              id: `agent-cli-exit:${agent.agent_id}:${exited.updated_at}`,
-              from: "cmuxlayer:lifecycle",
-              to: parentAgentId,
-              tag: "agent_cli_exit",
-              task:
-                `Agent ${agent.agent_id} CLI exited to a bare shell without done evidence. ` +
-                `Registry state is error; surface ${agent.surface_id}.`,
-            },
-            this.inboxOpts,
-          );
-        if (this.activeSweepPlan) {
-          this.activeSweepPlan.notifications.push(exitDispatch);
-        } else {
-          exitDispatch();
-        }
+        dispatchOnce(
+          agent.parent_agent_id,
+          {
+            id: `agent-cli-exit:${agent.agent_id}:${exited.updated_at}`,
+            from: "cmuxlayer:lifecycle",
+            to: agent.parent_agent_id,
+            tag: "agent_cli_exit",
+            task:
+              `Agent ${agent.agent_id} CLI exited to a bare shell without done evidence. ` +
+              `Registry state is error; surface ${agent.surface_id}.`,
+          },
+          this.inboxOpts,
+        );
         inboxDispatched = true;
       } catch {
         // The durable event below records the failed dispatch for lead recovery.
@@ -6485,24 +6434,9 @@ export class AgentEngine {
   }
 
   async runSweep(): Promise<void> {
-    this.currentSweepScreenSignatures = new Map();
-    this.currentSweepAgentContexts = new Map();
-    const buildStartedAt = Date.now();
-    await this.sweepMonitorRegistryBestEffort();
-    const plan = await this.buildSweepPlan();
-    plan.timings.build_total_ms = Date.now() - buildStartedAt;
-    const applyStartedAt = Date.now();
-    await this.runLifecycleMutation(() => this.applySweepPlan(plan), {
+    await this.runLifecycleMutation(() => this.runSweepOnce(), {
       label: "sweep",
     });
-    plan.timings.apply_ms = Date.now() - applyStartedAt;
-    await this.sweepWatchesBestEffort();
-    await this.drainOutboxBestEffort();
-    this.sweepDebugLog(
-      `[cmuxlayer] sweep timing ${Object.entries(plan.timings)
-        .map(([name, value]) => `${name}=${value}`)
-        .join(" ")}`,
-    );
     await this.drainDeliveryQueue();
     await this.verifyPendingDeliveries();
   }
@@ -7311,388 +7245,24 @@ export class AgentEngine {
     timer.unref?.();
   }
 
-  private createSweepPlan(
-    surfaceTopology: SurfaceTopologySnapshot | null,
-  ): SweepPlan {
-    const realStateMgr = this.stateMgr;
-    const records = new Map(
-      realStateMgr.listStates().map((record) => [record.agent_id, record]),
-    );
-    const persistence: SweepDeferredOperation[] = [];
-    const publications: SweepDeferredOperation[] = [];
-    const notifications: SweepDeferredOperation[] = [];
-    const originalSidebarSnapshot = new Map(this.sidebarSnapshot);
-    const eventLog = realStateMgr.getEventLog() as unknown as Record<
-      string,
-      (...args: unknown[]) => unknown
-    >;
-    const eventLogProxy = new Proxy(eventLog, {
-      get: (target, property) => {
-        const value = target[property as string];
-        if (typeof value !== "function") return value;
-        return (...args: unknown[]) => {
-          persistence.push(() => value.apply(target, args));
-        };
-      },
-    });
-    const surfaceIndex =
-      realStateMgr.getSurfaceSessionIndex() as unknown as Record<
-        string,
-        (...args: unknown[]) => unknown
-      >;
-    const surfaceIndexProxy = new Proxy(surfaceIndex, {
-      get: (target, property) => {
-        const value = target[property as string];
-        if (typeof value !== "function") return value;
-        return (...args: unknown[]) => {
-          persistence.push(() => value.apply(target, args));
-        };
-      },
-    });
-    const requireRecord = (agentId: string): AgentRecord => {
-      const current = records.get(agentId);
-      if (!current) throw new Error(`Agent not found: ${agentId}`);
-      return current;
-    };
-    const stateProxy = new Proxy(realStateMgr, {
-      get: (target, property) => {
-        if (property === "readState") {
-          return (agentId: string) => records.get(agentId) ?? null;
-        }
-        if (property === "listStates") {
-          return () => [...records.values()];
-        }
-        if (property === "hasStateFile") {
-          return (agentId: string) => records.has(agentId);
-        }
-        if (property === "getEventLog") return () => eventLogProxy;
-        if (property === "getSurfaceSessionIndex") {
-          return () => surfaceIndexProxy;
-        }
-        if (property === "updateRecord") {
-          return (agentId: string, fields: Partial<AgentRecord>) => {
-            const current = requireRecord(agentId);
-            const updated: AgentRecord = {
-              ...current,
-              ...fields,
-              version: current.version + 1,
-              updated_at: new Date().toISOString(),
-            };
-            records.set(agentId, updated);
-            persistence.push(() => {
-              realStateMgr.updateRecord(agentId, fields);
-            });
-            return updated;
-          };
-        }
-        if (property === "transition") {
-          return (
-            agentId: string,
-            toState: AgentState,
-            extra?: Partial<AgentRecord>,
-          ) => {
-            const current = requireRecord(agentId);
-            if (!isValidTransition(current.state, toState)) {
-              throw new Error(
-                `Invalid state transition: ${current.state} → ${toState}`,
-              );
-            }
-            const updated: AgentRecord = {
-              ...current,
-              state: toState,
-              version: current.version + 1,
-              updated_at: new Date().toISOString(),
-              ...(extra?.error !== undefined ? { error: extra.error } : {}),
-              ...(extra?.pid !== undefined ? { pid: extra.pid } : {}),
-              ...(extra?.cli_session_id !== undefined
-                ? { cli_session_id: extra.cli_session_id }
-                : {}),
-              ...(extra?.cli_session_path !== undefined
-                ? { cli_session_path: extra.cli_session_path }
-                : {}),
-            };
-            records.set(agentId, updated);
-            persistence.push(() => {
-              realStateMgr.transition(agentId, toState, extra);
-            });
-            return updated;
-          };
-        }
-        if (property === "setTranscriptSessionCaptureDeferred") {
-          return (agentId: string, deferred: boolean, attempts = 0) => {
-            const current = requireRecord(agentId);
-            const normalizedAttempts = Number.isFinite(attempts)
-              ? Math.max(0, Math.trunc(attempts))
-              : 0;
-            if (
-              current.transcript_session_capture_deferred === deferred &&
-              (current.transcript_session_capture_attempts ?? 0) ===
-                normalizedAttempts
-            ) {
-              return current;
-            }
-            const updated = {
-              ...current,
-              transcript_session_capture_deferred: deferred,
-              transcript_session_capture_attempts: normalizedAttempts,
-            };
-            records.set(agentId, updated);
-            persistence.push(() => {
-              realStateMgr.setTranscriptSessionCaptureDeferred(
-                agentId,
-                deferred,
-                normalizedAttempts,
-              );
-            });
-            return updated;
-          };
-        }
-        if (property === "removeState") {
-          return (agentId: string) => {
-            records.delete(agentId);
-            persistence.push(() => realStateMgr.removeState(agentId));
-          };
-        }
-        if (property === "renameState") {
-          return (agentId: string, newAgentId: string) => {
-            const current = requireRecord(agentId);
-            if (records.has(newAgentId)) {
-              throw new Error(`Agent already exists: ${newAgentId}`);
-            }
-            const updated: AgentRecord = {
-              ...current,
-              agent_id: newAgentId,
-              version: current.version + 1,
-              updated_at: new Date().toISOString(),
-            };
-            records.delete(agentId);
-            records.set(newAgentId, updated);
-            for (const [childId, child] of records) {
-              if (child.parent_agent_id === agentId) {
-                records.set(childId, {
-                  ...child,
-                  parent_agent_id: newAgentId,
-                  version: child.version + 1,
-                  updated_at: new Date().toISOString(),
-                });
-              }
-            }
-            persistence.push(() => {
-              realStateMgr.renameState(agentId, newAgentId);
-            });
-            return updated;
-          };
-        }
-        if (property === "writeState") {
-          return (record: AgentRecord) => {
-            records.set(record.agent_id, record);
-            persistence.push(() => realStateMgr.writeState(record));
-          };
-        }
-        const value = Reflect.get(target, property, target);
-        return typeof value === "function" ? value.bind(target) : value;
-      },
-    }) as StateManager;
-
-    const registryInternals = this.registry as unknown as {
-      agents: Map<string, AgentRecord>;
-      aliases: Map<string, string>;
-      surfacelessObservations: Map<string, unknown>;
-      unclaimedAbsenceObservations: Map<string, unknown>;
-    };
-    const registryMaps = {
-      agents: new Map(registryInternals.agents),
-      aliases: new Map(registryInternals.aliases),
-      surfacelessObservations: new Map(
-        registryInternals.surfacelessObservations,
-      ),
-      unclaimedAbsenceObservations: new Map(
-        registryInternals.unclaimedAbsenceObservations,
-      ),
-    };
-    const registryProxy = new Proxy(this.registry, {
-      get: (target, property, receiver) => {
-        if (property === "stateMgr") return stateProxy;
-        if (property in registryMaps) {
-          return registryMaps[property as keyof typeof registryMaps];
-        }
-        return Reflect.get(target, property, receiver);
-      },
-    });
-
-    const planner = Object.assign(
-      Object.create(Object.getPrototypeOf(this)),
-      this,
-    ) as AgentEngine;
-    const plan: SweepPlan = {
-      surfaceTopology,
-      initialVersions: new Map(
-        [...records].map(([agentId, record]) => [agentId, record.version]),
-      ),
-      persistence,
-      publications,
-      notifications,
-      planner,
-      registryMaps,
-      originalSidebarSnapshot,
-      timings: {},
-      readOnly: false,
-    };
-
-    const realClient = this.client as unknown as Record<string, unknown>;
-    const publicationMethods = new Set([
-      "setStatus",
-      "setStatuses",
-      "clearStatus",
-      "setProgress",
-      "clearProgress",
-      "log",
-    ]);
-    const notificationMethods = new Set([
-      "notify",
-      "notifyLifecycleEvent",
-      "send",
-    ]);
-    const topologyMutationMethods = new Set([
-      "newSplit",
-      "newSurface",
-      "moveSurface",
-      "closeSurface",
-      "renameTab",
-    ]);
-    const clientProxy = new Proxy(realClient, {
-      get: (target, property) => {
-        const name = String(property);
-        const value = target[name];
-        if (typeof value !== "function") return value;
-        if (publicationMethods.has(name)) {
-          return (...args: unknown[]) => {
-            publications.push(async () => {
-              const result = await value.apply(target, args);
-              if (name === "setStatuses" && result === false) {
-                const updates = (args[0] ?? []) as CmuxStatusUpdate[];
-                for (const update of updates) {
-                  const previous = originalSidebarSnapshot.get(update.key);
-                  if (previous) this.sidebarSnapshot.set(update.key, previous);
-                  else this.sidebarSnapshot.delete(update.key);
-                }
-              }
-            });
-            return Promise.resolve(name === "setStatuses" ? true : undefined);
-          };
-        }
-        if (notificationMethods.has(name)) {
-          return (...args: unknown[]) => {
-            notifications.push(async () => {
-              try {
-                await value.apply(target, args);
-              } catch {
-                if (name === "notifyLifecycleEvent") {
-                  const [event, agent, signature] = args as [
-                    AgentLifecycleEvent,
-                    AgentRecord,
-                    string | undefined,
-                  ];
-                  const suffix = signature === undefined ? "" : `:${signature}`;
-                  this.notifiedEvents.delete(
-                    `${agent.agent_id}:${event}${suffix}`,
-                  );
-                  const previous = originalSidebarSnapshot.get(agent.agent_id);
-                  if (previous) {
-                    this.sidebarSnapshot.set(agent.agent_id, previous);
-                  } else {
-                    this.sidebarSnapshot.delete(agent.agent_id);
-                  }
-                } else if (name === "notify") {
-                  const notification = args[0] as { surface?: string };
-                  const agent = this.registry
-                    .list()
-                    .find(
-                      (candidate) =>
-                        candidate.surface_id === notification.surface,
-                    );
-                  if (agent) {
-                    this.deliveredLeadMonitorDeathAlerts.delete(agent.agent_id);
-                  }
-                }
-              }
-            });
-            return Promise.resolve(undefined);
-          };
-        }
-        if (topologyMutationMethods.has(name)) {
-          return (...args: unknown[]) => {
-            persistence.push(() => value.apply(target, args));
-            if (name === "newSplit") {
-              const opts = (args[1] ?? {}) as {
-                workspace?: string;
-                pane?: string;
-              };
-              return Promise.resolve({
-                workspace: opts.workspace ?? "",
-                surface: "sweep-plan-placeholder",
-                pane: opts.pane ?? "",
-                title: "",
-                type: "terminal",
-              });
-            }
-            return Promise.resolve(undefined);
-          };
-        }
-        return value.bind(target);
-      },
-    }) as unknown as AgentEngineClient;
-    const realPublisher = this.fleetSidebarPublisher;
-    const publisherProxy = new Proxy(realPublisher, {
-      get: (target, property) => {
-        if (property === "publish") {
-          return (...args: unknown[]) => {
-            publications.push(() =>
-              (target.publish as (...values: unknown[]) => void)(...args),
-            );
-          };
-        }
-        const value = Reflect.get(target, property, target);
-        return typeof value === "function" ? value.bind(target) : value;
-      },
-    });
-
-    planner.stateMgr = stateProxy;
-    planner.registry = registryProxy;
-    planner.client = clientProxy;
-    planner.fleetSidebarPublisher = publisherProxy;
-    planner.sidebarSnapshot = new Map(this.sidebarSnapshot);
-    planner.fleetScreenProgress = new Map(this.fleetScreenProgress);
-    planner.loggedEvents = new Set(this.loggedEvents);
-    planner.notifiedEvents = new Set(this.notifiedEvents);
-    planner.deliveredLeadMonitorDeathAlerts = new Set(
-      this.deliveredLeadMonitorDeathAlerts,
-    );
-    planner.readyPatternMatches = new Map(this.readyPatternMatches);
-    planner.cliExitShellMatches = new Map(this.cliExitShellMatches);
-    planner.promptResolutionFailures = new Map(this.promptResolutionFailures);
-    planner.promptMotionObservedAtMs = new Map(this.promptMotionObservedAtMs);
-    planner.promptMotionScreenSignatures = new Map(
-      this.promptMotionScreenSignatures,
-    );
-    planner.currentSweepScreenSignatures = new Map();
-    planner.currentSweepAgentContexts = new Map();
-    planner.activeSweepPlan = plan;
-    return plan;
-  }
-
-  private async buildSweepPlanContents(
-    surfaceTopology: SurfaceTopologySnapshot,
-    timings: Record<string, number>,
-  ): Promise<void> {
+  private async runSweepOnce(): Promise<void> {
     const skipAccounting: SweepMutationSkipAccounting = { counted: false };
-    const time = async (name: string, operation: () => Promise<void>) => {
-      const startedAt = Date.now();
-      await operation();
-      timings[name] = Date.now() - startedAt;
-    };
-    const observedSurfaces = surfaceTopology.surfaces;
-    await time("close_forensics_ms", () => this.runCloseForensicsBestEffort());
+    this.currentSweepScreenSignatures = new Map();
+    await this.runCloseForensicsBestEffort();
+    const surfaceTopology = await this.collectObservedSurfaceTopology();
+    const transportHealth = getTransportHealth(this.client);
+    const topologyIsAuthoritative =
+      surfaceTopology?.complete === true && surfaceTopology.surfaces.length > 0;
+    const mutationsAreSafe =
+      topologyIsAuthoritative &&
+      transportHealth?.mode === "socket" &&
+      transportHealth.degraded === false;
+    if (mutationsAreSafe) {
+      this.sweepSkippedMutations = 0;
+    }
+    const observedSurfaces = topologyIsAuthoritative
+      ? surfaceTopology.surfaces
+      : undefined;
     // Reuse the resync path's authoritative-safe ghost eviction on every sweep,
     // but require one confirmation window after the surface is first observed
     // absent. The same gate also applies to terminal worker cleanup below.
@@ -7702,10 +7272,11 @@ export class AgentEngine {
       confirmationMs: SURFACE_EVICTION_CONFIRMATION_MS,
       now: Date.now(),
     };
-    await time("registry_ms", async () => {
+    await this.reapChannelMarkersBestEffort();
+    if (mutationsAreSafe) {
       const observed = {
         ...surfacelessConfirmation,
-        surfaces: observedSurfaces,
+        ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       };
       if (
         this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
@@ -7722,13 +7293,17 @@ export class AgentEngine {
       ) {
         await this.purgeStartupTerminalAgents();
       }
-    });
+    } else {
+      this.countSkippedSweepTick(skipAccounting);
+    }
 
     // Deferred transcript identity does not require a live surface binding.
     // Retry after the one-shot startup purge has retained marked rows, but
     // before normal terminal cleanup can act on a closed pane.
-    await time("transcript_ms", () => this.retryDeferredTranscriptCaptures());
+    await this.retryDeferredTranscriptCaptures();
+    await this.sweepWatchesBestEffort();
     if (
+      mutationsAreSafe &&
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
       await this.registry.purgeTerminal({
@@ -7736,153 +7311,23 @@ export class AgentEngine {
         ...(observedSurfaces ? { surfaces: observedSurfaces } : {}),
       });
     }
+    await this.sweepMonitorRegistryBestEffort();
     if (
+      mutationsAreSafe &&
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
-      await time("role_ms", async () => {
-        await this.reconcileRolePlacements("idle", { surfaceTopology });
-      });
+      await this.reconcileRolePlacements("idle", { surfaceTopology });
     }
-    if (
+    if (!mutationsAreSafe) {
+      await this.syncSidebar({}, null);
+    } else if (
       this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting)
     ) {
-      await time("sidebar_ms", async () => {
-        await this.syncSidebar({}, surfaceTopology, () =>
-          this.canRunSnapshotBackedSweepMutation(
-            surfaceTopology,
-            skipAccounting,
-          ),
-        );
-      });
-    }
-  }
-
-  private async buildSweepPlan(): Promise<SweepPlan> {
-    const topologyStartedAt = Date.now();
-    const surfaceTopology = await this.collectObservedSurfaceTopology();
-    const plan = this.createSweepPlan(surfaceTopology);
-    plan.timings.topology_ms = Date.now() - topologyStartedAt;
-    const markerStartedAt = Date.now();
-    await this.reapChannelMarkersBestEffort();
-    plan.timings.channel_markers_ms = Date.now() - markerStartedAt;
-    const transportHealth = getTransportHealth(this.client);
-    const canBuildMutatingPlan =
-      surfaceTopology?.complete === true &&
-      surfaceTopology.surfaces.length > 0 &&
-      transportHealth?.mode === "socket" &&
-      transportHealth.degraded === false;
-    if (!canBuildMutatingPlan || !surfaceTopology) {
-      plan.readOnly = true;
-      const sidebarStartedAt = Date.now();
-      await plan.planner.syncSidebar({}, null);
-      plan.timings.sidebar_ms = Date.now() - sidebarStartedAt;
-      return plan;
-    }
-    const buildStartedAt = Date.now();
-    await plan.planner.buildSweepPlanContents(surfaceTopology, plan.timings);
-    plan.timings.build_total_ms = Date.now() - buildStartedAt;
-    return plan;
-  }
-
-  private sweepPlanInputIsCurrent(plan: SweepPlan): boolean {
-    if (!this.isSweepTopologyObserverCurrent(plan.surfaceTopology))
-      return false;
-    const transportHealth = getTransportHealth(this.client);
-    if (
-      transportHealth?.mode !== "socket" ||
-      transportHealth.degraded !== false
-    ) {
-      return false;
-    }
-    const currentRecords = new Map(
-      this.stateMgr
-        .listStates()
-        .map((record) => [record.agent_id, record.version]),
-    );
-    if (currentRecords.size !== plan.initialVersions.size) return false;
-    for (const [agentId, version] of plan.initialVersions) {
-      if (currentRecords.get(agentId) !== version) return false;
-    }
-    return true;
-  }
-
-  private applyPlannedRegistry(plan: SweepPlan): void {
-    const target = this.registry as unknown as {
-      agents: Map<string, AgentRecord>;
-      aliases: Map<string, string>;
-      surfacelessObservations: Map<string, unknown>;
-      unclaimedAbsenceObservations: Map<string, unknown>;
-    };
-    target.agents.clear();
-    for (const [agentId, preview] of plan.registryMaps.agents) {
-      target.agents.set(agentId, this.stateMgr.readState(agentId) ?? preview);
-    }
-    target.aliases = new Map(plan.registryMaps.aliases);
-    target.surfacelessObservations = new Map(
-      plan.registryMaps.surfacelessObservations,
-    );
-    target.unclaimedAbsenceObservations = new Map(
-      plan.registryMaps.unclaimedAbsenceObservations,
-    );
-  }
-
-  private applyPlannedMemory(plan: SweepPlan): void {
-    const planner = plan.planner;
-    this.sidebarSnapshot = planner.sidebarSnapshot;
-    this.fleetScreenProgress = planner.fleetScreenProgress;
-    this.loggedEvents = planner.loggedEvents;
-    this.notifiedEvents = planner.notifiedEvents;
-    this.deliveredLeadMonitorDeathAlerts =
-      planner.deliveredLeadMonitorDeathAlerts;
-    this.readyPatternMatches = planner.readyPatternMatches;
-    this.cliExitShellMatches = planner.cliExitShellMatches;
-    this.promptResolutionFailures = planner.promptResolutionFailures;
-    this.promptMotionObservedAtMs = planner.promptMotionObservedAtMs;
-    this.promptMotionScreenSignatures = planner.promptMotionScreenSignatures;
-    this.currentSweepScreenSignatures = planner.currentSweepScreenSignatures;
-  }
-
-  private async applySweepPlan(plan: SweepPlan): Promise<boolean> {
-    // This is the single post-pass authorization check. Nothing in the plan
-    // has touched authoritative state, cmux status, or notification channels.
-    if (plan.readOnly) {
-      this.applyPlannedMemory(plan);
-      for (const operation of plan.publications) await operation();
-      this.sweepSkippedMutations += 1;
-      return false;
-    }
-    if (!this.sweepPlanInputIsCurrent(plan)) {
-      this.sweepSkippedMutations += 1;
-      console.warn(
-        "[cmuxlayer] sweep plan dropped: topology observer, transport, or registry version changed",
+      await this.syncSidebar({}, surfaceTopology, () =>
+        this.canRunSnapshotBackedSweepMutation(surfaceTopology, skipAccounting),
       );
-      return false;
     }
-
-    try {
-      for (const operation of plan.persistence) await operation();
-    } catch (error) {
-      this.sweepSkippedMutations += 1;
-      console.warn(
-        `[cmuxlayer] sweep plan persistence failed before publication: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return false;
-    }
-    this.applyPlannedRegistry(plan);
-    this.applyPlannedMemory(plan);
-    for (const operation of plan.publications) {
-      try {
-        await operation();
-      } catch {
-        // Status/log publication is best-effort. A failed row remains dirty in
-        // the in-memory snapshot and is retried by the next planned sweep.
-      }
-    }
-    for (const operation of plan.notifications) await operation();
-    this.sweepSkippedMutations = 0;
-    return true;
+    await this.drainOutboxBestEffort();
   }
 
   private async reapChannelMarkersBestEffort(): Promise<void> {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -43,6 +43,8 @@ export type SurfaceProvider = () => Promise<CmuxSurface[]>;
 interface SurfaceAbsenceOptions {
   confirmationMs?: number;
   now?: number;
+  /** Same-tick observation supplied by AgentEngine to avoid re-enumeration. */
+  surfaces?: readonly CmuxSurface[];
 }
 
 export interface LiveSeatDiscoveryProof {
@@ -633,6 +635,12 @@ export class AgentRegistry {
     return this.enforceObserverOwnership;
   }
 
+  private observedSurfaces(
+    override?: readonly CmuxSurface[],
+  ): Promise<readonly CmuxSurface[]> {
+    return override ? Promise.resolve(override) : this.surfaceProvider();
+  }
+
   /**
    * Decide whether a live observation is strong enough to bind an existing row.
    * Stable UUID equality can migrate ownership; mutable refs require the row to
@@ -775,9 +783,9 @@ export class AgentRegistry {
     opts: SurfaceAbsenceOptions = {},
   ): Promise<Set<string>> {
     const observerSnapshot = this.captureObserverSnapshot();
-    let surfaces: CmuxSurface[];
+    let surfaces: readonly CmuxSurface[];
     try {
-      surfaces = await this.surfaceProvider();
+      surfaces = await this.observedSurfaces(opts.surfaces);
     } catch {
       // Treat enumeration failures as "unknown", not "zero surfaces". A transient
       // socket/listing failure must not mark every active agent as disappeared.
@@ -1024,16 +1032,16 @@ export class AgentRegistry {
 
   async isSurfaceAlive(
     agent: Pick<AgentRecord, "surface_id" | "surface_uuid">,
-    opts: { ptyDead?: boolean } = {},
+    opts: { ptyDead?: boolean; surfaces?: readonly CmuxSurface[] } = {},
   ): Promise<boolean> {
     if (opts.ptyDead === true) {
       return false;
     }
 
     const observerSnapshot = this.captureObserverSnapshot();
-    let surfaces: CmuxSurface[];
+    let surfaces: readonly CmuxSurface[];
     try {
-      surfaces = await this.surfaceProvider();
+      surfaces = await this.observedSurfaces(opts.surfaces);
     } catch {
       // "Live" here means "not proven absent" for liveness guards.
       return true;
@@ -1768,9 +1776,9 @@ export class AgentRegistry {
     opts: SurfacelessEvictionOptions = {},
   ): Promise<string[]> {
     const observerSnapshot = this.captureObserverSnapshot();
-    let surfaces: CmuxSurface[];
+    let surfaces: readonly CmuxSurface[];
     try {
-      surfaces = await this.surfaceProvider();
+      surfaces = await this.observedSurfaces(opts.surfaces);
     } catch {
       return [];
     }
@@ -2643,12 +2651,12 @@ export class AgentRegistry {
    * Agents whose surface is still alive are kept (user may want to inspect output).
    */
   async purgeTerminal(
-    opts: { confirmationMs?: number; now?: number } = {},
+    opts: SurfaceAbsenceOptions = {},
   ): Promise<number> {
     const observerSnapshot = this.captureObserverSnapshot();
-    let surfaces: CmuxSurface[];
+    let surfaces: readonly CmuxSurface[];
     try {
-      surfaces = await this.surfaceProvider();
+      surfaces = await this.observedSurfaces(opts.surfaces);
     } catch {
       return 0;
     }

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -3,6 +3,7 @@ import { basename, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
+import { getTransportHealth } from "./cmux-transport-self-heal.js";
 import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
 import { makeSelfRegistrationSessionResolver } from "./self-registration.js";
 import type { AgentRoute } from "./agent-types.js";
@@ -277,6 +278,8 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       this.stateMgr,
       this.registry,
       {
+        getTransportHealth: () => getTransportHealth(this.client),
+        supportsStableSurfaceReads: true,
         log: async () => {},
         listWorkspaces: () => this.client.listWorkspaces(),
         setStatus: async () => {},

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -15,13 +15,14 @@ import { isCmuxSidebarStatusFrame } from "./cmux-status-frame.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const CONNECT_TIMEOUT_MS = 2_000;
-const BACKOFF_MAX_MS = 2_000;
+const BACKOFF_BASE_MS = 2_000;
+const BACKOFF_MAX_MS = 15_000;
 const MAX_IN_FLIGHT = 256;
 
 export interface BackoffOptions {
-  /** Base delay in milliseconds (default: 1000) */
+  /** Base delay in milliseconds (default: 2_000) */
   baseMs?: number;
-  /** Maximum delay in milliseconds (default: 2_000) */
+  /** Maximum delay in milliseconds (default: 15_000) */
   maxMs?: number;
   /** Apply random jitter to prevent thundering herd (default: true) */
   jitter?: boolean;
@@ -90,7 +91,7 @@ export class CmuxPersistentSocket {
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
     this.connectTimeoutMs = opts?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.maxInFlight = opts?.maxInFlight ?? MAX_IN_FLIGHT;
-    this.backoffBaseMs = opts?.backoff?.baseMs ?? 1000;
+    this.backoffBaseMs = opts?.backoff?.baseMs ?? BACKOFF_BASE_MS;
     this.backoffMaxMs = opts?.backoff?.maxMs ?? BACKOFF_MAX_MS;
     this.backoffJitter = opts?.backoff?.jitter ?? true;
     this.createConnection = opts?.createConnection ?? net.createConnection;
@@ -141,7 +142,6 @@ export class CmuxPersistentSocket {
           socket.destroy();
           return;
         }
-        socket.setTimeout(0);
         this.connectionGeneration++;
         this.connected = true;
         settled = true;
@@ -153,26 +153,33 @@ export class CmuxPersistentSocket {
       this.raiseSocketListenerLimit(socket);
 
       socket.setTimeout(this.connectTimeoutMs, () => {
-        if (settled) return;
-        settled = true;
+        const error = new CmuxSocketError(
+          `Connect timeout after ${this.connectTimeoutMs}ms`,
+          "connection_error",
+          { transportPhase: "connect" },
+        );
         this.connected = false;
         this.connectPromise = null;
         socket.destroy();
-        reject(
-          new CmuxSocketError(
-            `Connect timeout after ${this.connectTimeoutMs}ms`,
-            "connection_error",
-            { transportPhase: "connect" },
-          ),
-        );
+        this.rejectAllPending(error);
+        if (!settled) {
+          settled = true;
+          reject(error);
+        }
       });
 
       socket.on("data", (chunk: Buffer) => {
+        // A connected socket is not usable until cmux produces its first
+        // response bytes. Keep the connect-leg deadline armed across the OS
+        // connect event so an accepted-but-wedged daemon cannot inherit the
+        // much longer request timeout.
+        socket.setTimeout(0);
         this.buffer += chunk.toString("utf-8");
         this.processBuffer();
       });
 
       socket.on("error", (err: Error) => {
+        if (this.socket !== socket) return;
         this.connected = false;
         const socketError = this.toConnectionError(
           err,
@@ -477,7 +484,9 @@ export class CmuxPersistentSocket {
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        const index = this.pendingV1.findIndex((entry) => entry.timer === timer);
+        const index = this.pendingV1.findIndex(
+          (entry) => entry.timer === timer,
+        );
         const wasHead = index === 0;
         if (index !== -1) this.pendingV1.splice(index, 1);
         reject(

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -153,10 +153,11 @@ export class CmuxPersistentSocket {
       this.raiseSocketListenerLimit(socket);
 
       socket.setTimeout(this.connectTimeoutMs, () => {
+        const transportPhase = settled ? "response" : "connect";
         const error = new CmuxSocketError(
           `Connect timeout after ${this.connectTimeoutMs}ms`,
           "connection_error",
-          { transportPhase: "connect" },
+          { transportPhase },
         );
         this.connected = false;
         this.connectPromise = null;

--- a/src/cmux-persistent-socket.ts
+++ b/src/cmux-persistent-socket.ts
@@ -14,12 +14,14 @@ import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 import { isCmuxSidebarStatusFrame } from "./cmux-status-frame.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
+const CONNECT_TIMEOUT_MS = 2_000;
+const BACKOFF_MAX_MS = 2_000;
 const MAX_IN_FLIGHT = 256;
 
 export interface BackoffOptions {
   /** Base delay in milliseconds (default: 1000) */
   baseMs?: number;
-  /** Maximum delay in milliseconds (default: 30_000) */
+  /** Maximum delay in milliseconds (default: 2_000) */
   maxMs?: number;
   /** Apply random jitter to prevent thundering herd (default: true) */
   jitter?: boolean;
@@ -28,8 +30,11 @@ export interface BackoffOptions {
 export interface CmuxPersistentSocketOptions {
   socketPath?: string;
   timeoutMs?: number;
+  connectTimeoutMs?: number;
   maxInFlight?: number;
   backoff?: BackoffOptions;
+  /** Override connection creation for deterministic connect-leg tests. */
+  createConnection?: typeof net.createConnection;
 }
 
 interface V2Request {
@@ -65,10 +70,12 @@ export class CmuxPersistentSocket {
   }> = [];
   private connected = false;
   private timeoutMs: number;
+  private connectTimeoutMs: number;
   private maxInFlight: number;
   /** Guards against concurrent connect() calls */
   private connectPromise: Promise<void> | null = null;
   private connectionGeneration = 0;
+  private createConnection: typeof net.createConnection;
 
   // Backoff state
   private backoffBaseMs: number;
@@ -81,10 +88,12 @@ export class CmuxPersistentSocket {
     this.socketPath =
       opts?.socketPath ?? process.env.CMUX_SOCKET_PATH ?? DEFAULT_SOCKET_PATH;
     this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.connectTimeoutMs = opts?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.maxInFlight = opts?.maxInFlight ?? MAX_IN_FLIGHT;
     this.backoffBaseMs = opts?.backoff?.baseMs ?? 1000;
-    this.backoffMaxMs = opts?.backoff?.maxMs ?? 30_000;
+    this.backoffMaxMs = opts?.backoff?.maxMs ?? BACKOFF_MAX_MS;
     this.backoffJitter = opts?.backoff?.jitter ?? true;
+    this.createConnection = opts?.createConnection ?? net.createConnection;
   }
 
   /** Current backoff delay in ms (0 when connected or no failures). */
@@ -127,7 +136,12 @@ export class CmuxPersistentSocket {
     this.connectPromise = new Promise<void>((resolve, reject) => {
       let settled = false;
 
-      this.socket = net.createConnection({ path: this.socketPath }, () => {
+      const socket = this.createConnection({ path: this.socketPath }, () => {
+        if (settled) {
+          socket.destroy();
+          return;
+        }
+        socket.setTimeout(0);
         this.connectionGeneration++;
         this.connected = true;
         settled = true;
@@ -135,14 +149,30 @@ export class CmuxPersistentSocket {
         this.resetBackoff();
         resolve();
       });
-      this.raiseSocketListenerLimit(this.socket);
+      this.socket = socket;
+      this.raiseSocketListenerLimit(socket);
 
-      this.socket.on("data", (chunk: Buffer) => {
+      socket.setTimeout(this.connectTimeoutMs, () => {
+        if (settled) return;
+        settled = true;
+        this.connected = false;
+        this.connectPromise = null;
+        socket.destroy();
+        reject(
+          new CmuxSocketError(
+            `Connect timeout after ${this.connectTimeoutMs}ms`,
+            "connection_error",
+            { transportPhase: "connect" },
+          ),
+        );
+      });
+
+      socket.on("data", (chunk: Buffer) => {
         this.buffer += chunk.toString("utf-8");
         this.processBuffer();
       });
 
-      this.socket.on("error", (err: Error) => {
+      socket.on("error", (err: Error) => {
         this.connected = false;
         const socketError = this.toConnectionError(
           err,
@@ -156,7 +186,8 @@ export class CmuxPersistentSocket {
         }
       });
 
-      this.socket.on("close", () => {
+      socket.on("close", () => {
+        if (this.socket !== socket) return;
         this.connected = false;
         this.socket = null;
         // Reject all inflight requests — transport is gone

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -190,6 +190,8 @@ export class CmuxSelfHealingClient {
   private failedPayloadQueue: QueuedFailedPayload[] = [];
   private flushingFailedPayloadQueue: Promise<void> | null = null;
   private transportDenial: TransportDenialSignal | null = null;
+  /** Explicit cmux access-control denial is process-lifetime permanent. */
+  private hardAccessControlDenied = false;
   private completedRetryCount = 0;
   private upstreamProbeFailures = 0;
   private upstreamProbeStartedAt: number | null = null;
@@ -203,6 +205,9 @@ export class CmuxSelfHealingClient {
     this.socketClient = opts.socket ?? null;
     this.delegate = opts.socket ?? opts.cli;
     this.transportDenial = opts.initialDenial ?? null;
+    this.hardAccessControlDenied = Boolean(
+      opts.initialDenial && isCmuxAccessControlDenied(opts.initialDenial.error),
+    );
     if (opts.initialDenial) {
       this.upstreamProbeFailures = 1;
       this.upstreamProbeStartedAt = (opts.now ?? Date.now)();
@@ -216,7 +221,9 @@ export class CmuxSelfHealingClient {
     }
     if (!this.socketClient) {
       opts.logger?.error(
-        "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
+        this.hardAccessControlDenied
+          ? "[cmuxlayer] transport denied: access-control (hard state); daemon must be spawned from inside a cmux pane"
+          : "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
       );
     }
     this.startReprobe();
@@ -370,7 +377,7 @@ export class CmuxSelfHealingClient {
   }
 
   private startReprobe(): void {
-    if (this.reprobeTimer || this.stopped) {
+    if (this.reprobeTimer || this.stopped || this.hardAccessControlDenied) {
       return;
     }
     const delayMs = this.nextReprobeDelayMs();
@@ -613,9 +620,13 @@ export class CmuxSelfHealingClient {
     this.socketClient = null;
     this.delegate = this.opts.cli;
     this.observerRouteGeneration++;
-    this.transportDenial = null;
+    if (!this.hardAccessControlDenied) {
+      this.transportDenial = null;
+    }
     this.opts.logger?.error(
-      "[cmuxlayer] transport downgraded: socket -> cli (periodic socket re-probe active)",
+      this.hardAccessControlDenied
+        ? "[cmuxlayer] transport downgraded: socket -> cli (access-control hard state; daemon must be spawned from inside a cmux pane)"
+        : "[cmuxlayer] transport downgraded: socket -> cli (periodic socket re-probe active)",
     );
     this.startReprobe();
   }
@@ -678,6 +689,7 @@ export class CmuxSelfHealingClient {
       this.delegate = client;
       this.observerRouteGeneration++;
       this.transportDenial = null;
+      this.hardAccessControlDenied = false;
       this.clearReprobe();
       this.previousReprobeDelayMs = 0;
       this.opts.logger?.error("[cmuxlayer] transport upgraded: cli -> socket");
@@ -715,8 +727,14 @@ export class CmuxSelfHealingClient {
       socketPath: result.socketPath,
       error: result.error ?? "Access denied",
     };
+    this.hardAccessControlDenied =
+      result.denied_reason === "access-control" ||
+      isCmuxAccessControlDenied(result.error ?? "");
+    if (this.hardAccessControlDenied) {
+      this.clearReprobe();
+    }
     this.opts.logger?.error(
-      `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}`,
+      `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}; hard state, daemon must be spawned from inside a cmux pane`,
     );
   }
 

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -208,9 +208,8 @@ export class CmuxSelfHealingClient {
     this.socketClient = opts.socket ?? null;
     this.delegate = opts.socket ?? opts.cli;
     this.transportDenial = opts.initialDenial ?? null;
-    this.hardAccessControlDenied = Boolean(
-      opts.initialDenial && isCmuxAccessControlDenied(opts.initialDenial.error),
-    );
+    this.hardAccessControlDenied =
+      opts.initialDenial?.denied_reason === "access-control";
     if (opts.initialDenial) {
       this.upstreamProbeFailures = 1;
       this.upstreamProbeStartedAt = (opts.now ?? Date.now)();
@@ -328,14 +327,7 @@ export class CmuxSelfHealingClient {
       return await fn();
     } catch (error) {
       if (this.shouldDowngrade(error)) {
-        if (isCmuxAccessControlDenied(error) && this.socketClient) {
-          this.recordAccessControlDenial({
-            usable: false,
-            socketPath: this.socketClient.currentSocketPath(),
-            denied_reason: "access-control",
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
+        this.recordActiveAccessControlDenial(error);
         this.downgradeToCli();
       }
       throw error;
@@ -508,6 +500,7 @@ export class CmuxSelfHealingClient {
       this.socketClient &&
       this.isRecoverableSocketError(error)
     ) {
+      this.recordActiveAccessControlDenial(error);
       this.downgradeToCli();
     }
     if (!this.canRetryPayload(error, method)) {
@@ -741,6 +734,16 @@ export class CmuxSelfHealingClient {
     this.opts.logger?.error(
       `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}; hard state, daemon must be spawned from inside a cmux pane; slow recovery re-probe active`,
     );
+  }
+
+  private recordActiveAccessControlDenial(error: unknown): void {
+    if (!this.socketClient || !isCmuxAccessControlDenied(error)) return;
+    this.recordAccessControlDenial({
+      usable: false,
+      socketPath: this.socketClient.currentSocketPath(),
+      denied_reason: "access-control",
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   private isDenialClassError(error: unknown): boolean {

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -23,6 +23,7 @@ export const DEFAULT_PING_RETRY_ATTEMPTS = 3;
 export const DEFAULT_PING_RETRY_BACKOFF_MS = [100, 250, 500] as const;
 export const DEFAULT_TRANSPORT_REPROBE_MS = 5_000;
 export const DEFAULT_TRANSPORT_REPROBE_CAP_MS = 30_000;
+export const DEFAULT_HARD_DENIAL_REPROBE_MS = 300_000;
 export const DEFAULT_INTERACTIVE_RETRY_ATTEMPTS = 3;
 export const DEFAULT_INTERACTIVE_RETRY_BASE_MS = 100;
 export const DEFAULT_INTERACTIVE_RETRY_CAP_MS = 400;
@@ -61,6 +62,8 @@ export interface CmuxSelfHealingClientOptions {
   factoryOpts?: CreateCmuxClientOptions;
   reprobeIntervalMs?: number;
   reprobeCapMs?: number;
+  /** Slow recovery probe used after explicit cmux access-control denial. */
+  hardDenialReprobeMs?: number;
   random?: () => number;
   initialDenial?: TransportDenialSignal;
   logger?: Pick<Console, "error">;
@@ -190,7 +193,7 @@ export class CmuxSelfHealingClient {
   private failedPayloadQueue: QueuedFailedPayload[] = [];
   private flushingFailedPayloadQueue: Promise<void> | null = null;
   private transportDenial: TransportDenialSignal | null = null;
-  /** Explicit cmux access-control denial is process-lifetime permanent. */
+  /** Explicit cmux access-control denial suppresses the normal fast cadence. */
   private hardAccessControlDenied = false;
   private completedRetryCount = 0;
   private upstreamProbeFailures = 0;
@@ -222,7 +225,7 @@ export class CmuxSelfHealingClient {
     if (!this.socketClient) {
       opts.logger?.error(
         this.hardAccessControlDenied
-          ? "[cmuxlayer] transport denied: access-control (hard state); daemon must be spawned from inside a cmux pane"
+          ? "[cmuxlayer] transport denied: access-control (hard state); daemon must be spawned from inside a cmux pane; slow recovery re-probe active"
           : "[cmuxlayer] transport degraded: cli (periodic socket re-probe active)",
       );
     }
@@ -325,6 +328,14 @@ export class CmuxSelfHealingClient {
       return await fn();
     } catch (error) {
       if (this.shouldDowngrade(error)) {
+        if (isCmuxAccessControlDenied(error) && this.socketClient) {
+          this.recordAccessControlDenial({
+            usable: false,
+            socketPath: this.socketClient.currentSocketPath(),
+            denied_reason: "access-control",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
         this.downgradeToCli();
       }
       throw error;
@@ -377,7 +388,7 @@ export class CmuxSelfHealingClient {
   }
 
   private startReprobe(): void {
-    if (this.reprobeTimer || this.stopped || this.hardAccessControlDenied) {
+    if (this.reprobeTimer || this.stopped) {
       return;
     }
     const delayMs = this.nextReprobeDelayMs();
@@ -452,6 +463,9 @@ export class CmuxSelfHealingClient {
   }
 
   private nextReprobeDelayMs(): number {
+    if (this.hardAccessControlDenied) {
+      return this.opts.hardDenialReprobeMs ?? DEFAULT_HARD_DENIAL_REPROBE_MS;
+    }
     const baseMs = this.opts.reprobeIntervalMs ?? DEFAULT_TRANSPORT_REPROBE_MS;
     const previousMs = this.previousReprobeDelayMs || baseMs;
     const delayMs = decorrelatedJitterDelayMs({
@@ -475,8 +489,7 @@ export class CmuxSelfHealingClient {
   private isRecoverableSocketError(error: unknown): boolean {
     const isTransportError =
       error instanceof CmuxSocketError &&
-      (error.code === "connection_error" ||
-        error.code === "connection_closed");
+      (error.code === "connection_error" || error.code === "connection_closed");
     const message = error instanceof Error ? error.message : String(error);
     const hasRecoverableSignal =
       /\b(?:EPIPE|ECONNRESET|broken pipe)\b/i.test(message) ||
@@ -576,11 +589,7 @@ export class CmuxSelfHealingClient {
       recordTransportRetry();
       const delegate = this.delegate;
       try {
-        return await this.callDelegate(
-          payload.method,
-          payload.args,
-          delegate,
-        );
+        return await this.callDelegate(payload.method, payload.args, delegate);
       } catch (error) {
         lastError = error;
         if (delegate === this.opts.cli) {
@@ -727,14 +736,10 @@ export class CmuxSelfHealingClient {
       socketPath: result.socketPath,
       error: result.error ?? "Access denied",
     };
-    this.hardAccessControlDenied =
-      result.denied_reason === "access-control" ||
-      isCmuxAccessControlDenied(result.error ?? "");
-    if (this.hardAccessControlDenied) {
-      this.clearReprobe();
-    }
+    this.hardAccessControlDenied = true;
+    this.clearReprobe();
     this.opts.logger?.error(
-      `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}; hard state, daemon must be spawned from inside a cmux pane`,
+      `[cmuxlayer] transport denied: access-control (${result.socketPath}): ${this.transportDenial.error}; hard state, daemon must be spawned from inside a cmux pane; slow recovery re-probe active`,
     );
   }
 
@@ -759,7 +764,7 @@ export class CmuxSelfHealingClient {
     const denialClass =
       result.denied_reason === "access-control" ||
       (typeof result.error === "string" &&
-        this.isDenialClassError(result.error));
+        isCmuxAccessControlDenied(result.error));
     if (result.usable) {
       this.resetUpstreamFailureEvidence();
       return false;
@@ -802,10 +807,7 @@ export class CmuxSelfHealingClient {
   }
 
   private logUpstreamFailureProgress(now: number): void {
-    if (
-      now - this.lastUpstreamFailureLogAt <
-      DENIAL_PROGRESS_LOG_INTERVAL_MS
-    ) {
+    if (now - this.lastUpstreamFailureLogAt < DENIAL_PROGRESS_LOG_INTERVAL_MS) {
       return;
     }
     this.lastUpstreamFailureLogAt = now;

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -620,7 +620,7 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
     health.selected_transport.transport_error
   ) {
     warnings.push(
-      `cmuxlayer control transport denied: access-control; ${health.selected_transport.transport_error}`,
+      `ERROR: cmuxlayer control transport denied: access-control; ${health.selected_transport.transport_error}. Remedy: daemon must be spawned from inside a cmux pane.`,
     );
   } else if (
     health.selected_transport.transport_degraded === true &&
@@ -834,7 +834,7 @@ function formatDaemonLifecycle(
     lines.push(
       `lifecycle lock: holder=${lock.holder ?? "none"} held_for_ms=${
         lock.held_for_ms ?? 0
-      } queue_depth=${lock.queue_depth} timeouts=${lock.timeouts} forced_releases=${lock.forced_releases}`,
+      } queue_depth=${lock.queue_depth} timeouts=${lock.timeouts} forced_releases=${lock.forced_releases} sweep_skipped_mutations=${lock.sweep_skipped_mutations}`,
     );
     if (lock.last_timeout) {
       lines.push(

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -541,6 +541,13 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
       `lifecycle lock was force-released ${lifecycle.lifecycle_lock.forced_releases} time(s); an operation never settled.`,
     );
   }
+  const skippedSweepMutations =
+    lifecycle?.lifecycle_lock?.sweep_skipped_mutations ?? 0;
+  if (skippedSweepMutations > 0) {
+    warnings.push(
+      `WARNING: lifecycle sweep skipped destructive reconciliation ${skippedSweepMutations} time(s); registry garbage collection is read-only until socket-backed complete topology recovers.`,
+    );
+  }
   // #530: a stranded/unrestorable socket, or any recorded daemon lifecycle
   // error, must be visible rather than living only in a log line.
   if (lifecycle?.last_error) {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -21,11 +21,6 @@ import {
   recordDaemonLifecycleError,
 } from "./daemon-lifecycle-state.js";
 import { callerContextFromEnv } from "./caller-context.js";
-import {
-  candidateSocketPathsForOpts,
-  probeSocketHealth,
-  type SocketProbeResult,
-} from "./cmux-socket-probe.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
@@ -51,7 +46,6 @@ export interface DaemonFirstEntryOptions {
   output?: Writable;
   logger?: Pick<Console, "error">;
   probeDaemon?: (socketPath: string) => Promise<boolean>;
-  probeCmuxSocket?: () => Promise<SocketProbeResult>;
   spawnDaemon?: (opts: SpawnDaemonOptions) => Promise<unknown> | unknown;
   runProxy?: (opts: CmuxLayerProxyOptions) => Promise<CmuxLayerProxy>;
   startInProcess?: (opts: StartInProcessOptions) => Promise<McpServer>;
@@ -68,26 +62,6 @@ function isEnabled(value: string | undefined): boolean {
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-async function probeEntryCmuxSocket(
-  env: NodeJS.ProcessEnv,
-): Promise<SocketProbeResult> {
-  const candidates = candidateSocketPathsForOpts({
-    socketPath: env.CMUX_SOCKET_PATH?.trim() || undefined,
-  });
-  let lastResult: SocketProbeResult = {
-    usable: false,
-    socketPath: candidates[0] ?? "unknown",
-  };
-  for (const socketPath of candidates) {
-    const result = await probeSocketHealth(socketPath);
-    if (result.usable || result.denied_reason === "access-control") {
-      return result;
-    }
-    lastResult = result;
-  }
-  return lastResult;
 }
 
 function terminateSpawnedDaemon(
@@ -490,8 +464,6 @@ export async function runDaemonFirstEntry(
   const logger = opts.logger ?? console;
   const socketPath = resolveDefaultDaemonSocketPath(env);
   const probeDaemon = opts.probeDaemon ?? probeDaemonSocket;
-  const probeCmuxSocket =
-    opts.probeCmuxSocket ?? (() => probeEntryCmuxSocket(env));
   const runProxy = opts.runProxy ?? runProxyRuntime;
   const spawnDaemon = opts.spawnDaemon ?? spawnDaemonProcess;
   const startInProcess = opts.startInProcess ?? startInProcessRuntime;
@@ -545,14 +517,6 @@ export async function runDaemonFirstEntry(
 
   if (await probeDaemon(socketPath)) {
     return startProxy();
-  }
-
-  const cmuxProbe = await probeCmuxSocket();
-  if (cmuxProbe.denied_reason === "access-control") {
-    return fallback(
-      `daemon autostart suppressed because this proxy is denied by cmux at ${cmuxProbe.socketPath}; ` +
-        "daemon must be spawned from inside a cmux pane",
-    );
   }
 
   let spawnedDaemon: unknown;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -21,6 +21,11 @@ import {
   recordDaemonLifecycleError,
 } from "./daemon-lifecycle-state.js";
 import { callerContextFromEnv } from "./caller-context.js";
+import {
+  candidateSocketPathsForOpts,
+  probeSocketHealth,
+  type SocketProbeResult,
+} from "./cmux-socket-probe.js";
 
 const DEFAULT_AUTOSTART_TIMEOUT_MS = 5_000;
 const DEFAULT_AUTOSTART_POLL_MS = 50;
@@ -46,6 +51,7 @@ export interface DaemonFirstEntryOptions {
   output?: Writable;
   logger?: Pick<Console, "error">;
   probeDaemon?: (socketPath: string) => Promise<boolean>;
+  probeCmuxSocket?: () => Promise<SocketProbeResult>;
   spawnDaemon?: (opts: SpawnDaemonOptions) => Promise<unknown> | unknown;
   runProxy?: (opts: CmuxLayerProxyOptions) => Promise<CmuxLayerProxy>;
   startInProcess?: (opts: StartInProcessOptions) => Promise<McpServer>;
@@ -62,6 +68,26 @@ function isEnabled(value: string | undefined): boolean {
 
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function probeEntryCmuxSocket(
+  env: NodeJS.ProcessEnv,
+): Promise<SocketProbeResult> {
+  const candidates = candidateSocketPathsForOpts({
+    socketPath: env.CMUX_SOCKET_PATH?.trim() || undefined,
+  });
+  let lastResult: SocketProbeResult = {
+    usable: false,
+    socketPath: candidates[0] ?? "unknown",
+  };
+  for (const socketPath of candidates) {
+    const result = await probeSocketHealth(socketPath);
+    if (result.usable || result.denied_reason === "access-control") {
+      return result;
+    }
+    lastResult = result;
+  }
+  return lastResult;
 }
 
 function terminateSpawnedDaemon(
@@ -464,6 +490,8 @@ export async function runDaemonFirstEntry(
   const logger = opts.logger ?? console;
   const socketPath = resolveDefaultDaemonSocketPath(env);
   const probeDaemon = opts.probeDaemon ?? probeDaemonSocket;
+  const probeCmuxSocket =
+    opts.probeCmuxSocket ?? (() => probeEntryCmuxSocket(env));
   const runProxy = opts.runProxy ?? runProxyRuntime;
   const spawnDaemon = opts.spawnDaemon ?? spawnDaemonProcess;
   const startInProcess = opts.startInProcess ?? startInProcessRuntime;
@@ -517,6 +545,14 @@ export async function runDaemonFirstEntry(
 
   if (await probeDaemon(socketPath)) {
     return startProxy();
+  }
+
+  const cmuxProbe = await probeCmuxSocket();
+  if (cmuxProbe.denied_reason === "access-control") {
+    return fallback(
+      `daemon autostart suppressed because this proxy is denied by cmux at ${cmuxProbe.socketPath}; ` +
+        "daemon must be spawned from inside a cmux pane",
+    );
   }
 
   let spawnedDaemon: unknown;

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import {
   createDefaultToolPalette,
 } from "./palette.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
+import { getTransportHealth } from "./cmux-transport-self-heal.js";
 import {
   createFileSystemSeatManifestWriter,
   type SeatManifestWriter,
@@ -11445,6 +11446,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         stateMgr,
         registry,
         {
+          getTransportHealth: () => getTransportHealth(client),
+          supportsStableSurfaceReads: true,
           log: (message, eventOpts) => client.log(message, eventOpts),
           listWorkspaces: () => client.listWorkspaces(),
           setStatus: (key, value, statusOpts) =>

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -46,10 +46,7 @@ export interface SurfaceTopologyClient {
   }): Promise<CmuxPaneSurfaces>;
 }
 
-export type SurfaceObserverIdProvider = () =>
-  | string
-  | null
-  | undefined;
+export type SurfaceObserverIdProvider = () => string | null | undefined;
 
 /**
  * `undefined` means observer scoping is intentionally disabled for a legacy
@@ -311,7 +308,11 @@ export async function collectSurfaceTopology(
   for (const workspaceRef of workspaceRefs) {
     try {
       const panes = await client.listPanes({ workspace: workspaceRef });
-      if (!panes.panes || panes.panes.length === 0) continue;
+      if (!Array.isArray(panes.panes)) {
+        snapshot.complete = false;
+        continue;
+      }
+      if (panes.panes.length === 0) continue;
 
       const columnIndex = deriveRoleColumnIndex(panes.panes);
       const columnCount = new Set(columnIndex.values()).size;
@@ -349,10 +350,14 @@ export async function collectSurfaceTopology(
           });
         }
       }
-      const partitioned = partitionPaneSurfacesByMembership(panes.panes, rawGroups, {
-        workspace_ref: panes.workspace_ref ?? workspaceRef,
-        window_ref: panes.window_ref,
-      });
+      const partitioned = partitionPaneSurfacesByMembership(
+        panes.panes,
+        rawGroups,
+        {
+          workspace_ref: panes.workspace_ref ?? workspaceRef,
+          window_ref: panes.window_ref,
+        },
+      );
       for (const pane of panes.panes) {
         const expectedSurfaceRefs = new Set(pane.surface_refs);
         const observedGroup = partitioned.find(
@@ -378,7 +383,9 @@ export async function collectSurfaceTopology(
         }
       }
       for (const group of partitioned) {
-        const pane = panes.panes.find((candidate) => candidate.ref === group.pane_ref);
+        const pane = panes.panes.find(
+          (candidate) => candidate.ref === group.pane_ref,
+        );
         for (const surface of group.surfaces) {
           const surfaceIndex = pane?.surface_refs?.indexOf(surface.ref) ?? -1;
           const surfaceId =

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -13,6 +13,8 @@ import type {
 export type SurfaceTopology = AgentTopologyHealthInput;
 
 export interface SurfaceTopologySnapshot {
+  /** Engine-local generation assigned to the observation used by one sweep. */
+  generation?: number;
   /** Stable observer owner that produced this completed observation. */
   observerId?: string | null;
   /** Observer epoch that authorized this completed observation. */

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -13,6 +13,8 @@ import type {
 export type SurfaceTopology = AgentTopologyHealthInput;
 
 export interface SurfaceTopologySnapshot {
+  /** Observer epoch that authorized this completed observation. */
+  observerEpoch?: SurfaceObserverEpoch;
   complete: boolean;
   /** Canonical surface rows captured by this same topology enumeration. */
   surfaces: CmuxSurface[];
@@ -295,6 +297,7 @@ export async function collectSurfaceTopology(
   }
 
   const snapshot: SurfaceTopologySnapshot = {
+    observerEpoch,
     complete: true,
     surfaces: [],
     workspaceBySurface: new Map(),

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -13,6 +13,8 @@ import type {
 export type SurfaceTopology = AgentTopologyHealthInput;
 
 export interface SurfaceTopologySnapshot {
+  /** Stable observer owner that produced this completed observation. */
+  observerId?: string | null;
   /** Observer epoch that authorized this completed observation. */
   observerEpoch?: SurfaceObserverEpoch;
   complete: boolean;
@@ -280,10 +282,13 @@ export function enrichSurfaceIdsFromPanes(
 export async function collectSurfaceTopology(
   client: SurfaceTopologyClient,
   workspace?: string,
-  observerIdProvider?: SurfaceObserverIdProvider,
+  observerEpochProvider?: SurfaceObserverIdProvider,
+  observerIdProvider:
+    SurfaceObserverIdProvider | undefined = observerEpochProvider,
 ): Promise<SurfaceTopologySnapshot | null> {
-  const observerEpoch = captureSurfaceObserverEpoch(observerIdProvider);
-  if (observerEpoch === null) {
+  const observerEpoch = captureSurfaceObserverEpoch(observerEpochProvider);
+  const observerId = captureSurfaceObserverEpoch(observerIdProvider);
+  if (observerEpoch === null || observerId === null) {
     return null;
   }
 
@@ -297,6 +302,7 @@ export async function collectSurfaceTopology(
   }
 
   const snapshot: SurfaceTopologySnapshot = {
+    observerId,
     observerEpoch,
     complete: true,
     surfaces: [],
@@ -448,7 +454,10 @@ export async function collectSurfaceTopology(
     snapshot.complete = false;
   }
 
-  if (!isSurfaceObserverEpochCurrent(observerEpoch, observerIdProvider)) {
+  if (
+    !isSurfaceObserverEpochCurrent(observerEpoch, observerEpochProvider) ||
+    !isSurfaceObserverEpochCurrent(observerId, observerIdProvider)
+  ) {
     return null;
   }
 

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -14,6 +14,8 @@ export type SurfaceTopology = AgentTopologyHealthInput;
 
 export interface SurfaceTopologySnapshot {
   complete: boolean;
+  /** Canonical surface rows captured by this same topology enumeration. */
+  surfaces: CmuxSurface[];
   workspaceBySurface: Map<string, string>;
   titleBySurface: Map<string, string>;
   topologyBySurface: Map<string, SurfaceTopology>;
@@ -297,6 +299,7 @@ export async function collectSurfaceTopology(
 
   const snapshot: SurfaceTopologySnapshot = {
     complete: true,
+    surfaces: [],
     workspaceBySurface: new Map(),
     titleBySurface: new Map(),
     topologyBySurface: new Map(),
@@ -381,7 +384,17 @@ export async function collectSurfaceTopology(
           const surfaceId =
             surface.id ??
             (surfaceIndex >= 0 ? pane?.surface_ids?.[surfaceIndex] : undefined);
+          const surfaceWorkspaceRef =
+            group.workspace_ref?.trim() || workspaceRef.trim() || undefined;
           identityPairs.push({ surfaceRef: surface.ref, surfaceId });
+          snapshot.surfaces.push({
+            ...surface,
+            ...(surfaceId ? { id: surfaceId } : {}),
+            ...(surfaceWorkspaceRef
+              ? { workspace_ref: surfaceWorkspaceRef }
+              : { workspace_ref: undefined }),
+            pane_ref: group.pane_ref,
+          });
           snapshot.workspaceBySurface.set(
             surface.ref,
             group.workspace_ref ?? workspaceRef,

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -50,6 +50,7 @@ import { dispatch, readInbox, writeHeartbeat } from "../src/inbox.js";
 import { readWatchRegistry } from "../src/watch-spec.js";
 import { useHarnessHome } from "./helpers/harness-home.js";
 import { persistProductionProcessRecord } from "./helpers/production-process-record.js";
+import type { SurfaceTopologySnapshot } from "../src/surface-topology.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-agents-test-engine");
 // #482/#492: `resumable` reads the transcript store, so these tests own a
@@ -11347,6 +11348,55 @@ Session ID: ${sessionId}`,
       expect(stateMgr.readState(record.agent_id)).toMatchObject({
         surface_id: "surface:stale",
         surface_uuid: stableUuid,
+        surface_observer_id: "cmux:/tmp/cmux-primary.sock",
+        workspace_id: "workspace:stale",
+      });
+    });
+
+    it("refuses a sweep topology override after the surface observer changes", async () => {
+      engine.dispose();
+      let currentObserverId = "cmux:/tmp/cmux-primary.sock";
+      const stableUuid = "11111111-2222-4333-8444-555555555555";
+      const registry = new AgentRegistry(stateMgr, async () => [], {
+        observerIdProvider: () => currentObserverId,
+      });
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+      });
+      const record = makeRecord({
+        agent_id: "stale-sweep-observer-route",
+        surface_id: "surface:stale",
+        surface_uuid: stableUuid,
+        surface_observer_id: currentObserverId,
+        workspace_id: "workspace:stale",
+        state: "working",
+      });
+      stateMgr.writeState(record);
+      registry.set(record.agent_id, record);
+      const topology: SurfaceTopologySnapshot = {
+        observerEpoch: currentObserverId,
+        complete: true,
+        surfaces: [
+          {
+            ...makeSurface("surface:fresh"),
+            id: stableUuid,
+            workspace_ref: "workspace:fresh",
+          },
+        ],
+        workspaceBySurface: new Map([["surface:fresh", "workspace:fresh"]]),
+        titleBySurface: new Map([["surface:fresh", "fresh"]]),
+        topologyBySurface: new Map(),
+        surfaceIdByRef: new Map([["surface:fresh", stableUuid]]),
+        surfaceRefById: new Map([[stableUuid.toLowerCase(), "surface:fresh"]]),
+      };
+      currentObserverId = "cmux:/tmp/cmux-secondary.sock";
+
+      await expect(
+        engine.resolveAgentIoRoute(record.agent_id, topology),
+      ).rejects.toThrow(/surface observer changed|refusing to mutate/i);
+      expect(stateMgr.readState(record.agent_id)).toMatchObject({
+        surface_id: "surface:stale",
         surface_observer_id: "cmux:/tmp/cmux-primary.sock",
         workspace_id: "workspace:stale",
       });

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -85,6 +85,7 @@ function mockSpawnExit(code: number): {
 
 function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
   return {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
       workspace: opts?.workspace ?? "ws:1",
       surface: "surface:new",

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -46,6 +46,7 @@ function makeTempFleetPublisher(): FleetSidebarPublisher {
 
 function makeClient() {
   return {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     currentSocketPath: vi.fn(() => "/tmp/cmux-app-test.sock"),
     listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     listPanes: vi.fn().mockResolvedValue({ panes: [] }),
@@ -416,7 +417,8 @@ describe("CmuxAppServerRuntime", () => {
       expect(publisher.publish).toHaveBeenCalledWith(
         expect.objectContaining({
           state: "unknown",
-          observedLiveSurfaceRefs: [],
+          observedLiveSurfaceRefs: null,
+          observedLiveSurfaceUuids: null,
           snapshot: {
             seatCount: 0,
             activeCount: 0,

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -123,7 +123,7 @@ describe("CmuxPersistentSocket V1 demux", () => {
       await expect(socket.call("system.ping")).rejects.toMatchObject({
         code: "connection_error",
         message: "Connect timeout after 40ms",
-        transport_phase: "connect",
+        transport_phase: "response",
       });
       expect(Date.now() - startedAt).toBeLessThan(250);
     } finally {

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -1,8 +1,8 @@
-import net from "node:net";
+import * as net from "node:net";
 import { EventEmitter } from "node:events";
 import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CmuxPersistentSocket } from "../src/cmux-persistent-socket.js";
 import { CmuxSocketError } from "../src/cmux-socket-error.js";
 
@@ -56,8 +56,51 @@ async function startLineServer(
 
 describe("CmuxPersistentSocket V1 demux", () => {
   afterEach(async () => {
+    vi.useRealTimers();
     await Promise.allSettled(servers.splice(0).map(stopServer));
     rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("rejects when the connect leg never settles", async () => {
+    vi.useFakeTimers();
+    class HangingConnectSocket extends EventEmitter {
+      setTimeout(ms: number, listener: () => void): this {
+        setTimeout(listener, ms);
+        return this;
+      }
+
+      destroy(): this {
+        return this;
+      }
+    }
+    const hangingSocket = new HangingConnectSocket();
+    const socket = new CmuxPersistentSocket({
+      socketPath: socketPath("hanging-connect"),
+      connectTimeoutMs: 25,
+      timeoutMs: 500,
+      createConnection: () => hangingSocket as unknown as net.Socket,
+    });
+    const call = socket.call("system.ping").then(
+      () => ({ status: "fulfilled" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    const result = Promise.race([
+      call,
+      new Promise<{ status: "still-pending" }>((resolve) =>
+        setTimeout(() => resolve({ status: "still-pending" }), 50),
+      ),
+    ]);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(result).resolves.toMatchObject({
+      status: "rejected",
+      error: {
+        code: "connection_error",
+        message: "Connect timeout after 25ms",
+        transport_phase: "connect",
+      },
+    });
   });
 
   it("rejects a JSON-like malformed frame instead of resolving the pending V1 request", async () => {

--- a/tests/cmux-persistent-socket.test.ts
+++ b/tests/cmux-persistent-socket.test.ts
@@ -8,7 +8,10 @@ import { CmuxSocketError } from "../src/cmux-socket-error.js";
 
 const TEST_ROOT = join("/tmp", "cmux-persistent-socket-test");
 const INTERLEAVED_STATUS_FRAME = readFileSync(
-  new URL("./fixtures/cmux-interleaved-sidebar-status-frame.txt", import.meta.url),
+  new URL(
+    "./fixtures/cmux-interleaved-sidebar-status-frame.txt",
+    import.meta.url,
+  ),
   "utf8",
 ).trim();
 const servers: net.Server[] = [];
@@ -103,6 +106,46 @@ describe("CmuxPersistentSocket V1 demux", () => {
     });
   });
 
+  it("rejects at the connect deadline when the socket connects but never responds", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("connected-no-response");
+    await startLineServer(path, () => {
+      // Accept the request but deliberately never produce a response frame.
+    });
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      connectTimeoutMs: 40,
+      timeoutMs: 500,
+    });
+    const startedAt = Date.now();
+
+    try {
+      await expect(socket.call("system.ping")).rejects.toMatchObject({
+        code: "connection_error",
+        message: "Connect timeout after 40ms",
+        transport_phase: "connect",
+      });
+      expect(Date.now() - startedAt).toBeLessThan(250);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("backs off from two seconds to a bounded fifteen-second cap", () => {
+    const socket = new CmuxPersistentSocket({
+      backoff: { jitter: false },
+    });
+
+    socket.incrementBackoff();
+    expect(socket.currentBackoffMs()).toBe(2_000);
+    socket.incrementBackoff();
+    expect(socket.currentBackoffMs()).toBe(4_000);
+    socket.incrementBackoff();
+    socket.incrementBackoff();
+    socket.incrementBackoff();
+    expect(socket.currentBackoffMs()).toBe(15_000);
+  });
+
   it("rejects a JSON-like malformed frame instead of resolving the pending V1 request", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("malformed-v1");
@@ -122,9 +165,9 @@ describe("CmuxPersistentSocket V1 demux", () => {
     });
 
     try {
-      await expect(socket.sendLine("set_status first active")).rejects.toMatchObject(
-        { code: "protocol_error" },
-      );
+      await expect(
+        socket.sendLine("set_status first active"),
+      ).rejects.toMatchObject({ code: "protocol_error" });
       const second = socket.sendLine("set_status second active");
 
       await expect(second).resolves.toBe("OK");
@@ -505,14 +548,17 @@ describe("CmuxPersistentSocket V1 demux", () => {
         rejectAllPending: (error: CmuxSocketError) => void;
       };
       internals.rejectAllPending(
-        new CmuxSocketError(`Socket error: ${error.message}`, "connection_error", {
-          transportPhase: "response",
-        }),
+        new CmuxSocketError(
+          `Socket error: ${error.message}`,
+          "connection_error",
+          {
+            transportPhase: "response",
+          },
+        ),
       );
     });
     (socket as unknown as { connected: boolean }).connected = true;
-    (socket as unknown as { socket: EmittingSocket }).socket =
-      transport;
+    (socket as unknown as { socket: EmittingSocket }).socket = transport;
 
     await expect(socket.call("surface.send_text")).rejects.toMatchObject({
       code: "connection_error",
@@ -534,7 +580,10 @@ describe("CmuxPersistentSocket V1 demux", () => {
         })}\n`,
       );
     });
-    const socket = new CmuxPersistentSocket({ socketPath: path, timeoutMs: 500 });
+    const socket = new CmuxPersistentSocket({
+      socketPath: path,
+      timeoutMs: 500,
+    });
 
     try {
       expect(socket.currentConnectionGeneration()).toBe(0);

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -554,6 +554,42 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("treats access-control denial as a hard state without periodic re-probes", async () => {
+    vi.useFakeTimers();
+    const socketPath = join(
+      tmpdir(),
+      `cmux-hard-access-denial-${process.pid}.sock`,
+    );
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: false,
+      socketPath,
+      error: ACCESS_CONTROL_DENIED_TEXT,
+      denied_reason: "access-control" as const,
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath,
+      initialDenial: {
+        denied_reason: "access-control",
+        socketPath,
+        error: ACCESS_CONTROL_DENIED_TEXT,
+      },
+      reprobeIntervalMs: 5,
+      reprobeCapMs: 5,
+      random: () => 0,
+      probeSocketHealth,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(probeSocketHealth).not.toHaveBeenCalled();
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      denied_reason: "access-control",
+    });
+    client.stop();
+  });
+
   it("counts upstream probe failures until a usable socket probe resets them", () => {
     const client = wrapCliWithSelfHeal(new CmuxClient(), {
       socketPath: "/tmp/cmux-preserve-denial.sock",

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -304,7 +304,8 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
 
     await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
     await waitForExpectation(
-      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
+      async () =>
+        expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
       { timeout: 1_000, interval: 5 },
     );
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -318,10 +319,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   });
 
   it("signals retirement after repeated upstream connection failures", async () => {
-    const socketPath = join(
-      tmpdir(),
-      `cmux-upstream-dead-${process.pid}.sock`,
-    );
+    const socketPath = join(tmpdir(), `cmux-upstream-dead-${process.pid}.sock`);
     let probeCountAtRetirement: number | undefined;
     const probeSocketHealth = vi.fn().mockResolvedValue({
       usable: false,
@@ -446,7 +444,10 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   });
 
   it("preserves the transport error when the irrecoverable callback throws", async () => {
-    const socketPath = join(tmpdir(), `cmux-callback-throw-${process.pid}.sock`);
+    const socketPath = join(
+      tmpdir(),
+      `cmux-callback-throw-${process.pid}.sock`,
+    );
     const logger = { error: vi.fn() };
     const onIrrecoverableTransport = vi.fn(() => {
       throw new Error("retirement callback failed");
@@ -471,9 +472,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
 
     await waitForExpectation(
       async () =>
-        expect(
-          (client as any).upstreamProbeFailures,
-        ).toBeGreaterThanOrEqual(1),
+        expect((client as any).upstreamProbeFailures).toBeGreaterThanOrEqual(1),
       { timeout: 1_000, interval: 5 },
     );
     await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
@@ -505,7 +504,8 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     });
 
     await waitForExpectation(
-      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
+      async () =>
+        expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(1),
       { timeout: 1_000, interval: 5 },
     );
     expect(logger.error).toHaveBeenCalledWith(
@@ -515,12 +515,19 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   });
 
   it("counts the factory initial denial as the first socket denial", async () => {
-    const socketPath = join(tmpdir(), `cmux-initial-denial-${process.pid}.sock`);
+    const socketPath = join(
+      tmpdir(),
+      `cmux-initial-denial-${process.pid}.sock`,
+    );
     const onIrrecoverableTransport = vi.fn();
     const exec = vi.fn().mockRejectedValue(new Error("Broken pipe (errno 32)"));
     const probeSocketHealth = vi
       .fn()
-      .mockResolvedValueOnce({ usable: false, socketPath, error: "write EPIPE" })
+      .mockResolvedValueOnce({
+        usable: false,
+        socketPath,
+        error: "write EPIPE",
+      })
       .mockResolvedValue({
         usable: false,
         socketPath,
@@ -554,7 +561,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
-  it("treats access-control denial as a hard state without periodic re-probes", async () => {
+  it("backs off access-control denial to a slow recovery probe", async () => {
     vi.useFakeTimers();
     const socketPath = join(
       tmpdir(),
@@ -575,6 +582,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       },
       reprobeIntervalMs: 5,
       reprobeCapMs: 5,
+      hardDenialReprobeMs: 300_000,
       random: () => 0,
       probeSocketHealth,
     });
@@ -585,6 +593,36 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     expect(getTransportHealth(client)).toMatchObject({
       mode: "cli",
       degraded: true,
+      denied_reason: "access-control",
+    });
+
+    await vi.advanceTimersByTimeAsync(240_000);
+    await vi.runAllTicks();
+
+    expect(probeSocketHealth).toHaveBeenCalledTimes(1);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      denied_reason: "access-control",
+    });
+    client.stop();
+  });
+
+  it("classifies EPIPE as transport failure without an access-control remedy", () => {
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath: "/tmp/cmux-epipe-classification.sock",
+      reprobeIntervalMs: 60_000,
+    });
+    const internals = client as any;
+
+    expect(
+      internals.recordProbeResult({
+        usable: false,
+        socketPath: "/tmp/cmux-epipe-classification.sock",
+        error: "write EPIPE",
+      }),
+    ).toBe(false);
+    expect(getTransportHealth(client)).not.toMatchObject({
       denied_reason: "access-control",
     });
     client.stop();
@@ -718,7 +756,8 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
 
     await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
     await waitForExpectation(
-      async () => expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(2),
+      async () =>
+        expect(probeSocketHealth.mock.calls.length).toBeGreaterThan(2),
       { timeout: 1_000, interval: 5 },
     );
     await expect(client.listWorkspaces()).rejects.toThrow(/errno 32/i);
@@ -841,6 +880,42 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     client.stop();
   });
 
+  it("latches access-control denial from an active socket before downgrading", async () => {
+    const socketPath = join(tmpdir(), `cmux-active-denial-${process.pid}.sock`);
+    const logger = { error: vi.fn() };
+    const cli = new CmuxClient({
+      exec: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      }),
+      bin: "cmux",
+    });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      ping: vi.fn().mockRejectedValue(new Error(ACCESS_CONTROL_DENIED_TEXT)),
+    } as unknown as CmuxSocketClient;
+
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      logger,
+      hardDenialReprobeMs: 300_000,
+    });
+
+    await expect(client.ping()).rejects.toThrow(ACCESS_CONTROL_DENIED_TEXT);
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      current_socket_path: socketPath,
+      denied_reason: "access-control",
+      last_error: expect.stringContaining(ACCESS_CONTROL_DENIED_TEXT),
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("slow recovery re-probe active"),
+    );
+    client.stop();
+  });
+
   it("uses the same CLI env shape at boot and after socket re-degradation", async () => {
     const socketPath = join(tmpdir(), `cmux-env-parity-${process.pid}.sock`);
     const bootExec = vi.fn().mockResolvedValue({
@@ -934,7 +1009,9 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     expect(exec).toHaveBeenCalledWith(
       "cmux",
       [
-        "--json", "--id-format", "both",
+        "--json",
+        "--id-format",
+        "both",
         "send",
         "--surface",
         "surface:1",
@@ -985,10 +1062,10 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
 
   it("surfaces exhausted transport state and retry count", async () => {
     vi.useFakeTimers();
-    const transportFailure = Object.assign(
-      new Error("write ECONNRESET"),
-      { code: 1, stderr: "write ECONNRESET" },
-    );
+    const transportFailure = Object.assign(new Error("write ECONNRESET"), {
+      code: 1,
+      stderr: "write ECONNRESET",
+    });
     const exec = vi.fn().mockRejectedValue(transportFailure);
     const client = wrapCliWithSelfHeal(new CmuxClient({ exec, bin: "cmux" }), {
       socketPath: "/tmp/retry-exhausted.sock",
@@ -1019,7 +1096,10 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       bin: "cmux",
     });
     const responseFailure = Object.assign(
-      new CmuxSocketError("connection reset after response", "connection_error"),
+      new CmuxSocketError(
+        "connection reset after response",
+        "connection_error",
+      ),
       { transport_phase: "response" },
     );
     const socket = {
@@ -1040,7 +1120,10 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
   });
 
   it("forwards deleteWorkspace through the self-healing transport", async () => {
-    const socketPath = join(tmpdir(), `cmux-delete-workspace-${process.pid}.sock`);
+    const socketPath = join(
+      tmpdir(),
+      `cmux-delete-workspace-${process.pid}.sock`,
+    );
     const cli = new CmuxClient({
       exec: vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" }),
       bin: "cmux",
@@ -1104,13 +1187,11 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     const socket = {
       currentSocketPath: () => socketPath,
       disconnect: vi.fn(),
-      send: vi
-        .fn()
-        .mockRejectedValue(
-          new CmuxSocketError("Socket error: ECONNRESET", "connection_error", {
-            transportPhase: "write",
-          }),
-        ),
+      send: vi.fn().mockRejectedValue(
+        new CmuxSocketError("Socket error: ECONNRESET", "connection_error", {
+          transportPhase: "write",
+        }),
+      ),
       ping: vi
         .fn()
         .mockRejectedValue(

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -538,6 +538,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       retryAttempts: 1,
       reprobeIntervalMs: 5,
       reprobeCapMs: 5,
+      hardDenialReprobeMs: 5,
       random: () => 0,
       initialDenial: {
         denied_reason: "access-control",
@@ -605,6 +606,36 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       degraded: true,
       denied_reason: "access-control",
     });
+    client.stop();
+  });
+
+  it("uses authoritative initial denial metadata for the slow recovery cadence", async () => {
+    vi.useFakeTimers();
+    const socketPath = join(
+      tmpdir(),
+      `cmux-initial-denial-${process.pid}.sock`,
+    );
+    const probeSocketHealth = vi.fn().mockResolvedValue({
+      usable: false,
+      socketPath,
+      error: "permission rejected",
+      denied_reason: "access-control" as const,
+    });
+    const client = wrapCliWithSelfHeal(new CmuxClient(), {
+      socketPath,
+      initialDenial: {
+        denied_reason: "access-control",
+        socketPath,
+        error: "permission rejected",
+      },
+      reprobeIntervalMs: 5,
+      hardDenialReprobeMs: 300_000,
+      probeSocketHealth,
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(probeSocketHealth).not.toHaveBeenCalled();
     client.stop();
   });
 
@@ -913,6 +944,40 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("slow recovery re-probe active"),
     );
+    client.stop();
+  });
+
+  it("latches access-control denial from a forwarded socket operation", async () => {
+    const socketPath = join(
+      tmpdir(),
+      `cmux-forwarded-denial-${process.pid}.sock`,
+    );
+    const cli = new CmuxClient({
+      exec: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ workspaces: [] }),
+        stderr: "",
+      }),
+      bin: "cmux",
+    });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      listWorkspaces: vi
+        .fn()
+        .mockRejectedValue(new Error(ACCESS_CONTROL_DENIED_TEXT)),
+    } as unknown as CmuxSocketClient;
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      hardDenialReprobeMs: 300_000,
+    });
+
+    await expect(client.listWorkspaces()).resolves.toEqual({ workspaces: [] });
+    expect(getTransportHealth(client)).toMatchObject({
+      mode: "cli",
+      degraded: true,
+      denied_reason: "access-control",
+      last_error: expect.stringContaining(ACCESS_CONTROL_DENIED_TEXT),
+    });
     client.stop();
   });
 

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -714,9 +714,40 @@ describe("control health", () => {
       transport_error: ACCESS_CONTROL_DENIED_TEXT,
     });
     expect(health.warnings).toContain(
-      `cmuxlayer control transport denied: access-control; ${ACCESS_CONTROL_DENIED_TEXT}`,
+      `ERROR: cmuxlayer control transport denied: access-control; ${ACCESS_CONTROL_DENIED_TEXT}. Remedy: daemon must be spawned from inside a cmux pane.`,
     );
-    expect(formatControlHealth(health)).toContain(ACCESS_CONTROL_DENIED_TEXT);
+    expect(formatControlHealth(health)).toContain(
+      "ERROR: cmuxlayer control transport denied",
+    );
+    expect(formatControlHealth(health)).toContain(
+      "daemon must be spawned from inside a cmux pane",
+    );
+  });
+
+  it("reports skipped destructive sweep mutations in control_health", async () => {
+    const health = await collectControlHealth({
+      homeDir: TEST_ROOT,
+      tmpDir: TEST_ROOT,
+      execFile: async () => ({ stdout: "" }),
+      lifecycleLock: {
+        holder: null,
+        held_for_ms: null,
+        queue_depth: 0,
+        acquire_timeout_ms: 45_000,
+        hold_timeout_ms: 120_000,
+        forced_releases: 0,
+        sweep_skipped_mutations: 2,
+        timeouts: 0,
+        last_timeout: null,
+      },
+    });
+
+    expect(
+      health.daemon_lifecycle.lifecycle_lock?.sweep_skipped_mutations,
+    ).toBe(2);
+    expect(formatControlHealth(health)).toContain(
+      "sweep_skipped_mutations=2",
+    );
   });
 
   it("periodically appends control health snapshots without tool invocation", async () => {

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -103,9 +109,15 @@ describe("control health", () => {
     const prodSocket = join(stateDir, "cmux-501.sock");
     const nightlySocket = join(tmp, "cmux-nightly.sock");
     writeFileSync(join(stateDir, "last-socket-path"), `${prodSocket}\n`);
-    writeFileSync(join(stateDir, "nightly-last-socket-path"), `${nightlySocket}\n`);
+    writeFileSync(
+      join(stateDir, "nightly-last-socket-path"),
+      `${nightlySocket}\n`,
+    );
     writeFileSync(join(tmp, "cmux-last-socket-path"), `${prodSocket}\n`);
-    writeFileSync(join(tmp, "cmux-nightly-last-socket-path"), `${nightlySocket}\n`);
+    writeFileSync(
+      join(tmp, "cmux-nightly-last-socket-path"),
+      `${nightlySocket}\n`,
+    );
     writeFileSync(prodSocket, "");
     writeFileSync(nightlySocket, "");
 
@@ -140,17 +152,8 @@ describe("control health", () => {
         currentSocketPath: () => nightlySocket,
       },
       execFile: async (file, args) => {
-        if (
-          file === "ps" &&
-          args.join(" ") === "ax -o pid= -o command="
-        ) {
-          expect(args).toEqual([
-            "ax",
-            "-o",
-            "pid=",
-            "-o",
-            "command=",
-          ]);
+        if (file === "ps" && args.join(" ") === "ax -o pid= -o command=") {
+          expect(args).toEqual(["ax", "-o", "pid=", "-o", "command="]);
           return {
             stdout: [
               "100 /Applications/Other.app/Contents/MacOS/cmux-helper",
@@ -293,10 +296,16 @@ describe("control health", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-bounded");
     const tmp = join(TEST_ROOT, "tmp-bounded");
-    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-bounded.json");
+    const monitorRegistryPath = join(
+      TEST_ROOT,
+      "monitor-registry-bounded.json",
+    );
     mkdirSync(home, { recursive: true });
     mkdirSync(tmp, { recursive: true });
-    writeFileSync(monitorRegistryPath, JSON.stringify({ version: 1, monitors: [] }));
+    writeFileSync(
+      monitorRegistryPath,
+      JSON.stringify({ version: 1, monitors: [] }),
+    );
     const tracker = new SurfaceWriteLivenessTracker({
       now: () => Date.parse("2026-07-11T12:00:00.000Z"),
     });
@@ -327,7 +336,10 @@ describe("control health", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-malformed-registry");
     const tmp = join(TEST_ROOT, "tmp-malformed-registry");
-    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-malformed.json");
+    const monitorRegistryPath = join(
+      TEST_ROOT,
+      "monitor-registry-malformed.json",
+    );
     mkdirSync(home, { recursive: true });
     mkdirSync(tmp, { recursive: true });
     writeFileSync(monitorRegistryPath, "{not-json");
@@ -347,7 +359,9 @@ describe("control health", () => {
       collapsed: 0,
       error: expect.stringMatching(/malformed|json/i),
     });
-    expect(formatControlHealth(health)).toMatch(/monitor registry: unavailable/i);
+    expect(formatControlHealth(health)).toMatch(
+      /monitor registry: unavailable/i,
+    );
   });
 
   it("treats an absent monitor registry as an empty healthy registry", async () => {
@@ -425,7 +439,10 @@ describe("control health", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-invalid-monitor-record");
     const tmp = join(TEST_ROOT, "tmp-invalid-monitor-record");
-    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-invalid-record.json");
+    const monitorRegistryPath = join(
+      TEST_ROOT,
+      "monitor-registry-invalid-record.json",
+    );
     mkdirSync(home, { recursive: true });
     mkdirSync(tmp, { recursive: true });
     writeFileSync(
@@ -452,10 +469,16 @@ describe("control health", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-untracked-surface");
     const tmp = join(TEST_ROOT, "tmp-untracked-surface");
-    const monitorRegistryPath = join(TEST_ROOT, "monitor-registry-untracked.json");
+    const monitorRegistryPath = join(
+      TEST_ROOT,
+      "monitor-registry-untracked.json",
+    );
     mkdirSync(home, { recursive: true });
     mkdirSync(tmp, { recursive: true });
-    writeFileSync(monitorRegistryPath, JSON.stringify({ version: 1, monitors: [] }));
+    writeFileSync(
+      monitorRegistryPath,
+      JSON.stringify({ version: 1, monitors: [] }),
+    );
     const rawHealth = await collectControlHealth({
       homeDir: home,
       tmpDir: tmp,
@@ -485,15 +508,26 @@ describe("control health", () => {
     const controlHealth = (server as any)._registeredTools["control_health"];
 
     try {
-      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
       nowMs += 1_000;
-      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
       const first = await controlHealth.handler({}, {} as any);
       nowMs += 1_000;
-      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
       const second = await controlHealth.handler({}, {} as any);
-      const firstHealth = first.structuredContent.health.self_heal.pane_pty_dead;
-      const secondHealth = second.structuredContent.health.self_heal.pane_pty_dead;
+      const firstHealth =
+        first.structuredContent.health.self_heal.pane_pty_dead;
+      const secondHealth =
+        second.structuredContent.health.self_heal.pane_pty_dead;
 
       expect(firstHealth).toMatchObject({
         count: 1,
@@ -527,9 +561,15 @@ describe("control health", () => {
       writeError = Object.assign(new Error("broken pipe"), { code: "EPIPE" });
 
       nowMs += 31_000;
-      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
       nowMs += 1_000;
-      await sendKey.handler({ surface: "surface:untracked", key: "return" }, {} as any);
+      await sendKey.handler(
+        { surface: "surface:untracked", key: "return" },
+        {} as any,
+      );
       const nextEpisode = await controlHealth.handler({}, {} as any);
       expect(
         nextEpisode.structuredContent.health.self_heal.pane_pty_dead.surfaces[0]
@@ -554,7 +594,9 @@ describe("control health", () => {
         stdin_is_tty: false,
         env: { CMUX_SOCKET_PATH: nightlySocket, PATH: "/bin" },
         path_entries: ["/bin"],
-        cmux_resolution: [{ path: "/Applications/cmux NIGHTLY.app/bin/cmux", exists: true }],
+        cmux_resolution: [
+          { path: "/Applications/cmux NIGHTLY.app/bin/cmux", exists: true },
+        ],
       },
       selected_transport: {
         client_class: "CmuxSocketClient",
@@ -745,8 +787,9 @@ describe("control health", () => {
     expect(
       health.daemon_lifecycle.lifecycle_lock?.sweep_skipped_mutations,
     ).toBe(2);
-    expect(formatControlHealth(health)).toContain(
-      "sweep_skipped_mutations=2",
+    expect(formatControlHealth(health)).toContain("sweep_skipped_mutations=2");
+    expect(health.warnings).toContain(
+      "WARNING: lifecycle sweep skipped destructive reconciliation 2 time(s); registry garbage collection is read-only until socket-backed complete topology recovers.",
     );
   });
 

--- a/tests/crash-resume-index.test.ts
+++ b/tests/crash-resume-index.test.ts
@@ -47,6 +47,7 @@ function makeClient(
   workspaceId = "workspace:old",
 ): CmuxClient {
   return {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     newSplit: vi.fn().mockResolvedValue({
       workspace: "workspace:new",
       surface: "surface:new",

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -17,6 +17,10 @@ function createEntryOptions(
     logger: { error: vi.fn() },
     output: { write: vi.fn() } as unknown as Writable,
     probeDaemon: vi.fn().mockResolvedValue(true),
+    probeCmuxSocket: vi.fn().mockResolvedValue({
+      usable: true,
+      socketPath: "/tmp/cmux.sock",
+    }),
     runProxy: vi.fn().mockResolvedValue({ stop: vi.fn() }),
     spawnDaemon: vi.fn(),
     startInProcess: vi.fn().mockResolvedValue({
@@ -85,6 +89,31 @@ describe("daemon-first MCP entry", () => {
     expect(opts.startInProcess).not.toHaveBeenCalled();
   });
 
+  it("does not autostart a daemon when this proxy is denied by cmux", async () => {
+    const logger = { error: vi.fn() };
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/denied-parent.sock" },
+      logger,
+      probeDaemon: vi.fn().mockResolvedValue(false),
+      probeCmuxSocket: vi.fn().mockResolvedValue({
+        usable: false,
+        socketPath: "/tmp/cmux.sock",
+        denied_reason: "access-control",
+        error: "Access denied - only processes started inside cmux can connect",
+      }),
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(opts.spawnDaemon).not.toHaveBeenCalled();
+    expect(opts.runProxy).not.toHaveBeenCalled();
+    expect(opts.startInProcess).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/daemon must be spawned from inside a cmux pane/i),
+    );
+  });
+
   it("falls back to in-process mode with a loud warning when daemon start fails", async () => {
     const logger = { error: vi.fn() };
     const opts = createEntryOptions({
@@ -103,7 +132,9 @@ describe("daemon-first MCP entry", () => {
     expect(opts.startInProcess).toHaveBeenCalledWith(
       expect.objectContaining({
         fallbackWarnings: [
-          expect.stringContaining("daemon unavailable; using heavy in-process runtime"),
+          expect.stringContaining(
+            "daemon unavailable; using heavy in-process runtime",
+          ),
         ],
       }),
     );
@@ -191,8 +222,7 @@ describe("daemon-first MCP entry", () => {
     const logger = { error: vi.fn() };
     const opts = createEntryOptions({
       env: {
-        CMUXLAYER_DEFAULT_PALETTE:
-          "list_surfaces,control_health,read_screen",
+        CMUXLAYER_DEFAULT_PALETTE: "list_surfaces,control_health,read_screen",
       },
       logger,
     });

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -17,10 +17,6 @@ function createEntryOptions(
     logger: { error: vi.fn() },
     output: { write: vi.fn() } as unknown as Writable,
     probeDaemon: vi.fn().mockResolvedValue(true),
-    probeCmuxSocket: vi.fn().mockResolvedValue({
-      usable: true,
-      socketPath: "/tmp/cmux.sock",
-    }),
     runProxy: vi.fn().mockResolvedValue({ stop: vi.fn() }),
     spawnDaemon: vi.fn(),
     startInProcess: vi.fn().mockResolvedValue({
@@ -89,31 +85,6 @@ describe("daemon-first MCP entry", () => {
     expect(opts.startInProcess).not.toHaveBeenCalled();
   });
 
-  it("does not autostart a daemon when this proxy is denied by cmux", async () => {
-    const logger = { error: vi.fn() };
-    const opts = createEntryOptions({
-      env: { CMUXLAYER_DAEMON_SOCKET: "/tmp/denied-parent.sock" },
-      logger,
-      probeDaemon: vi.fn().mockResolvedValue(false),
-      probeCmuxSocket: vi.fn().mockResolvedValue({
-        usable: false,
-        socketPath: "/tmp/cmux.sock",
-        denied_reason: "access-control",
-        error: "Access denied - only processes started inside cmux can connect",
-      }),
-    });
-
-    const result = await runDaemonFirstEntry(opts);
-
-    expect(result.mode).toBe("in-process");
-    expect(opts.spawnDaemon).not.toHaveBeenCalled();
-    expect(opts.runProxy).not.toHaveBeenCalled();
-    expect(opts.startInProcess).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringMatching(/daemon must be spawned from inside a cmux pane/i),
-    );
-  });
-
   it("falls back to in-process mode with a loud warning when daemon start fails", async () => {
     const logger = { error: vi.fn() };
     const opts = createEntryOptions({
@@ -132,9 +103,7 @@ describe("daemon-first MCP entry", () => {
     expect(opts.startInProcess).toHaveBeenCalledWith(
       expect.objectContaining({
         fallbackWarnings: [
-          expect.stringContaining(
-            "daemon unavailable; using heavy in-process runtime",
-          ),
+          expect.stringContaining("daemon unavailable; using heavy in-process runtime"),
         ],
       }),
     );
@@ -222,7 +191,8 @@ describe("daemon-first MCP entry", () => {
     const logger = { error: vi.fn() };
     const opts = createEntryOptions({
       env: {
-        CMUXLAYER_DEFAULT_PALETTE: "list_surfaces,control_health,read_screen",
+        CMUXLAYER_DEFAULT_PALETTE:
+          "list_surfaces,control_health,read_screen",
       },
       logger,
     });

--- a/tests/quality-tracking.test.ts
+++ b/tests/quality-tracking.test.ts
@@ -18,6 +18,7 @@ const TEST_DIR = join(tmpdir(), "cmux-agents-test-quality");
 
 function makeMockClient(overrides?: Partial<CmuxClient>): CmuxClient {
   return {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     newSplit: vi.fn().mockResolvedValue({
       workspace: "ws:1",
       surface: "surface:new",

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -59,6 +59,7 @@ const DEAD_SHELL_SCREEN = "etanheyman@mac cmuxlayer % ";
 
 function makeMockClient(): CmuxClient {
   return {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     newSplit: vi.fn().mockImplementation(async (_direction, opts) => ({
       workspace: opts?.workspace ?? "ws:1",
       surface: "surface:new",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -862,6 +862,7 @@ describe("Claude channels", () => {
     });
 
     const mockClient = {
+      getTransportHealth: () => ({ mode: "socket", degraded: false }),
       listWorkspaces: vi
         .fn()
         .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),
@@ -1000,6 +1001,7 @@ describe("Claude channels", () => {
     });
 
     const mockClient = {
+      getTransportHealth: () => ({ mode: "socket", degraded: false }),
       listWorkspaces: vi
         .fn()
         .mockResolvedValue({ workspaces: [{ ref: "workspace:1" }] }),

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -172,6 +172,7 @@ describe("Sidebar Sync", () => {
   let liveSurfaces: CmuxSurface[];
   let inboxOpts: { baseDir: string };
   let publishedFleetPublications: FleetSidebarPublication[];
+  let sweepDebugLog: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     delete process.env.CMUXLAYER_EXPERIMENTAL_PROMPT_AUTO_RESOLVE;
@@ -241,6 +242,7 @@ describe("Sidebar Sync", () => {
       },
     );
     publishedFleetPublications = [];
+    sweepDebugLog = vi.fn();
     inboxOpts = { baseDir: join(TEST_DIR, "inbox") };
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
@@ -248,6 +250,7 @@ describe("Sidebar Sync", () => {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
       inboxOpts,
+      sweepDebugLog,
       fleetSidebarPublisher: {
         publish: (publication) => {
           if (!("snapshot" in publication)) {
@@ -686,6 +689,141 @@ describe("Sidebar Sync", () => {
     );
     expect(publishedAgentIds).not.toContain(second.agent_id);
     expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
+  });
+
+  it("drops every planned sweep side effect when the observer changes during a screen read", async () => {
+    engine.dispose();
+    (
+      mockClient as unknown as Record<string, unknown>
+    ).supportsStableSurfaceReads = true;
+    const observerId = "cmux:/tmp/cmux-primary.sock";
+    let observerEpoch = `${observerId}@socket:1`;
+    const stableUuid = "11111111-2222-4333-8444-555555555553";
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces, {
+      observerIdProvider: () => observerId,
+      observerEpochProvider: () => observerEpoch,
+    });
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: (publication) => {
+          if ("snapshot" in publication) {
+            publishedFleetPublications.push(publication);
+          }
+        },
+        dispose: () => {},
+      },
+    });
+    const agent = makeRecord({
+      agent_id: "transactional-epoch-agent",
+      surface_id: "surface:one",
+      surface_uuid: stableUuid,
+      surface_observer_id: observerId,
+      workspace_id: "workspace:test",
+      state: "ready",
+      role: "worker",
+      cli_session_id: "session-transactional",
+      task_done_candidate_at: "2026-08-24T00:00:00.000Z",
+    });
+    stateMgr.writeState(agent);
+    registry.set(agent.agent_id, agent);
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:one"),
+        id: stableUuid,
+        workspace_ref: "workspace:test",
+      },
+    ];
+    vi.spyOn(registry, "reconcile").mockResolvedValue(new Set());
+    const sidebarSnapshot = (
+      engine as unknown as {
+        sidebarSnapshot: Map<string, unknown>;
+      }
+    ).sidebarSnapshot;
+    sidebarSnapshot.set(agent.agent_id, {
+      statusValue: "before",
+      surfaceId: agent.surface_id,
+      workspaceId: agent.workspace_id,
+      healthSignature: "before",
+    });
+    const beforeSidebar = [...sidebarSnapshot.entries()];
+    let releaseRead: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      mockClient.readScreen.mockImplementation(async (surface: string) => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseRead = release;
+        });
+        observerEpoch = `${observerId}@socket:2`;
+        return {
+          surface,
+          text: "Implemented the fix.\nTASK_DONE",
+          lines: 20,
+          scrollback_used: false,
+        };
+      });
+    });
+
+    const sweep = engine.runSweep();
+    await readStarted;
+    expect(engine.lifecycleLockState().holder).toBeNull();
+    releaseRead?.();
+    await sweep;
+
+    expect(stateMgr.readState(agent.agent_id)).toMatchObject({
+      state: "ready",
+      version: agent.version,
+    });
+    expect(registry.get(agent.agent_id)).toMatchObject({ state: "ready" });
+    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
+    expect(mockClient.notify).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).not.toHaveBeenCalled();
+    expect(mockClient.setStatuses).not.toHaveBeenCalled();
+    expect([...sidebarSnapshot.entries()]).toEqual(beforeSidebar);
+    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
+  });
+
+  it("applies a healthy sweep plan and reads each agent screen once", async () => {
+    (
+      mockClient as unknown as Record<string, unknown>
+    ).supportsStableSurfaceReads = true;
+    for (let index = 1; index <= 2; index += 1) {
+      const stableUuid = `11111111-2222-4333-8444-55555555556${index}`;
+      const agent = makeRecord({
+        agent_id: `transactional-healthy-${index}`,
+        surface_id: `surface:${index}`,
+        surface_uuid: stableUuid,
+        workspace_id: "workspace:test",
+        state: "working",
+        role: "worker",
+        cli_session_id: `session-${index}`,
+      });
+      stateMgr.writeState(agent);
+      liveSurfaces.push({
+        ...makeSurface(`surface:${index}`),
+        id: stableUuid,
+        workspace_ref: "workspace:test",
+      });
+    }
+    useActiveCodexScreen(mockClient);
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+
+    for (const surface of liveSurfaces) {
+      expect(mockClient.readScreen).toHaveBeenCalledTimes(2);
+      expect(mockClient.readScreen).toHaveBeenCalledWith(
+        surface.id,
+        expect.objectContaining({ workspace: "workspace:test" }),
+      );
+    }
+    expect(mockClient.setStatuses).toHaveBeenCalledTimes(1);
+    expect(sweepDebugLog).toHaveBeenCalledWith(
+      expect.stringMatching(/sweep timing.*build_total_ms=.*apply_ms=/i),
+    );
+    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(0);
   });
 
   it("enumerates topology once through live-agent sidebar and liveness paths", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -573,9 +573,119 @@ describe("Sidebar Sync", () => {
       surface_id: "surface:stale",
       surface_uuid: stableUuid,
     });
-    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBeGreaterThan(
-      0,
+    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
+  });
+
+  it("stops sidebar updates when the observer epoch changes during an earlier agent read", async () => {
+    engine.dispose();
+    (
+      mockClient as unknown as Record<string, unknown>
+    ).supportsStableSurfaceReads = true;
+    const observerId = "cmux:/tmp/cmux-primary.sock";
+    let observerEpoch = `${observerId}@socket:1`;
+    const firstUuid = "11111111-2222-4333-8444-555555555551";
+    const secondUuid = "11111111-2222-4333-8444-555555555552";
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces, {
+      observerIdProvider: () => observerId,
+      observerEpochProvider: () => observerEpoch,
+    });
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: (publication) => {
+          if ("snapshot" in publication) {
+            publishedFleetPublications.push(publication);
+          }
+        },
+        dispose: () => {},
+      },
+    });
+    const first = makeRecord({
+      agent_id: "epoch-read-agent-1",
+      surface_id: "surface:one",
+      surface_uuid: firstUuid,
+      surface_observer_id: observerId,
+      workspace_id: "workspace:test",
+      state: "working",
+      role: "worker",
+      cli_session_id: "session-1",
+    });
+    const second = makeRecord({
+      agent_id: "epoch-read-agent-2",
+      surface_id: "surface:stale-two",
+      surface_uuid: secondUuid,
+      surface_observer_id: observerId,
+      workspace_id: "workspace:stale",
+      state: "working",
+      role: "worker",
+      cli_session_id: "session-2",
+    });
+    for (const record of [first, second]) {
+      stateMgr.writeState(record);
+      registry.set(record.agent_id, record);
+    }
+    vi.spyOn(registry, "reconcile").mockResolvedValue(new Set());
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:one"),
+        id: firstUuid,
+        workspace_ref: "workspace:test",
+      },
+      {
+        ...makeSurface("surface:two"),
+        id: secondUuid,
+        workspace_ref: "workspace:test",
+      },
+    ];
+    let releaseFirstRead: (() => void) | undefined;
+    const firstReadStarted = new Promise<void>((resolve) => {
+      mockClient.readScreen.mockImplementation(async (surface: string) => {
+        if (surface.toLowerCase() === firstUuid.toLowerCase()) {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstRead = release;
+          });
+        }
+        return {
+          surface,
+          text: "gpt-5.6 · Working",
+          lines: 20,
+          scrollback_used: false,
+        };
+      });
+    });
+
+    const sweep = engine.runSweep();
+    await firstReadStarted;
+    observerEpoch = `${observerId}@socket:2`;
+    releaseFirstRead?.();
+    await sweep;
+
+    expect(registry.get(second.agent_id)).toMatchObject({
+      surface_id: "surface:stale-two",
+      workspace_id: "workspace:stale",
+      surface_observer_id: observerId,
+    });
+    expect(stateMgr.readState(second.agent_id)).toMatchObject({
+      surface_id: "surface:stale-two",
+      workspace_id: "workspace:stale",
+      surface_observer_id: observerId,
+    });
+    expect(mockClient.setStatus).not.toHaveBeenCalledWith(
+      second.agent_id,
+      expect.anything(),
+      expect.anything(),
     );
+    const publishedAgentIds = publishedFleetPublications.flatMap(
+      (publication) =>
+        publication.snapshot.lanes.flatMap((lane) =>
+          lane.seats.map((seat) => seat.agentId),
+        ),
+    );
+    expect(publishedAgentIds).not.toContain(second.agent_id);
+    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
   });
 
   it("enumerates topology once through live-agent sidebar and liveness paths", async () => {
@@ -666,9 +776,10 @@ describe("Sidebar Sync", () => {
       },
     ];
     await engine.getRegistry().reconstitute();
-    let releaseRead!: () => void;
+    let releaseRead: (() => void) | undefined;
     const readStarted = new Promise<void>((resolve) => {
       mockClient.readScreen.mockImplementation(async (surface: string) => {
+        releaseRead?.();
         liveSurfaces = [
           {
             ...makeSurface("surface:new"),
@@ -694,7 +805,7 @@ describe("Sidebar Sync", () => {
     const concurrentRoute = await engine.resolveAgentIoRoute(
       "concurrent-route-agent",
     );
-    releaseRead();
+    releaseRead?.();
     await sweep;
 
     expect(concurrentRoute.surface_id).toBe("surface:new");

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -172,7 +172,6 @@ describe("Sidebar Sync", () => {
   let liveSurfaces: CmuxSurface[];
   let inboxOpts: { baseDir: string };
   let publishedFleetPublications: FleetSidebarPublication[];
-  let sweepDebugLog: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     delete process.env.CMUXLAYER_EXPERIMENTAL_PROMPT_AUTO_RESOLVE;
@@ -242,7 +241,6 @@ describe("Sidebar Sync", () => {
       },
     );
     publishedFleetPublications = [];
-    sweepDebugLog = vi.fn();
     inboxOpts = { baseDir: join(TEST_DIR, "inbox") };
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
@@ -250,7 +248,6 @@ describe("Sidebar Sync", () => {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
       inboxOpts,
-      sweepDebugLog,
       fleetSidebarPublisher: {
         publish: (publication) => {
           if (!("snapshot" in publication)) {
@@ -689,141 +686,6 @@ describe("Sidebar Sync", () => {
     );
     expect(publishedAgentIds).not.toContain(second.agent_id);
     expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
-  });
-
-  it("drops every planned sweep side effect when the observer changes during a screen read", async () => {
-    engine.dispose();
-    (
-      mockClient as unknown as Record<string, unknown>
-    ).supportsStableSurfaceReads = true;
-    const observerId = "cmux:/tmp/cmux-primary.sock";
-    let observerEpoch = `${observerId}@socket:1`;
-    const stableUuid = "11111111-2222-4333-8444-555555555553";
-    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces, {
-      observerIdProvider: () => observerId,
-      observerEpochProvider: () => observerEpoch,
-    });
-    engine = new AgentEngine(stateMgr, registry, mockClient, {
-      spawnPreflight: async () => {},
-      sessionIdentityResolver: () => null,
-      inboxOpts,
-      fleetSidebarPublisher: {
-        publish: (publication) => {
-          if ("snapshot" in publication) {
-            publishedFleetPublications.push(publication);
-          }
-        },
-        dispose: () => {},
-      },
-    });
-    const agent = makeRecord({
-      agent_id: "transactional-epoch-agent",
-      surface_id: "surface:one",
-      surface_uuid: stableUuid,
-      surface_observer_id: observerId,
-      workspace_id: "workspace:test",
-      state: "ready",
-      role: "worker",
-      cli_session_id: "session-transactional",
-      task_done_candidate_at: "2026-08-24T00:00:00.000Z",
-    });
-    stateMgr.writeState(agent);
-    registry.set(agent.agent_id, agent);
-    liveSurfaces = [
-      {
-        ...makeSurface("surface:one"),
-        id: stableUuid,
-        workspace_ref: "workspace:test",
-      },
-    ];
-    vi.spyOn(registry, "reconcile").mockResolvedValue(new Set());
-    const sidebarSnapshot = (
-      engine as unknown as {
-        sidebarSnapshot: Map<string, unknown>;
-      }
-    ).sidebarSnapshot;
-    sidebarSnapshot.set(agent.agent_id, {
-      statusValue: "before",
-      surfaceId: agent.surface_id,
-      workspaceId: agent.workspace_id,
-      healthSignature: "before",
-    });
-    const beforeSidebar = [...sidebarSnapshot.entries()];
-    let releaseRead: (() => void) | undefined;
-    const readStarted = new Promise<void>((resolve) => {
-      mockClient.readScreen.mockImplementation(async (surface: string) => {
-        resolve();
-        await new Promise<void>((release) => {
-          releaseRead = release;
-        });
-        observerEpoch = `${observerId}@socket:2`;
-        return {
-          surface,
-          text: "Implemented the fix.\nTASK_DONE",
-          lines: 20,
-          scrollback_used: false,
-        };
-      });
-    });
-
-    const sweep = engine.runSweep();
-    await readStarted;
-    expect(engine.lifecycleLockState().holder).toBeNull();
-    releaseRead?.();
-    await sweep;
-
-    expect(stateMgr.readState(agent.agent_id)).toMatchObject({
-      state: "ready",
-      version: agent.version,
-    });
-    expect(registry.get(agent.agent_id)).toMatchObject({ state: "ready" });
-    expect(mockClient.notifyLifecycleEvent).not.toHaveBeenCalled();
-    expect(mockClient.notify).not.toHaveBeenCalled();
-    expect(mockClient.setStatus).not.toHaveBeenCalled();
-    expect(mockClient.setStatuses).not.toHaveBeenCalled();
-    expect([...sidebarSnapshot.entries()]).toEqual(beforeSidebar);
-    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(1);
-  });
-
-  it("applies a healthy sweep plan and reads each agent screen once", async () => {
-    (
-      mockClient as unknown as Record<string, unknown>
-    ).supportsStableSurfaceReads = true;
-    for (let index = 1; index <= 2; index += 1) {
-      const stableUuid = `11111111-2222-4333-8444-55555555556${index}`;
-      const agent = makeRecord({
-        agent_id: `transactional-healthy-${index}`,
-        surface_id: `surface:${index}`,
-        surface_uuid: stableUuid,
-        workspace_id: "workspace:test",
-        state: "working",
-        role: "worker",
-        cli_session_id: `session-${index}`,
-      });
-      stateMgr.writeState(agent);
-      liveSurfaces.push({
-        ...makeSurface(`surface:${index}`),
-        id: stableUuid,
-        workspace_ref: "workspace:test",
-      });
-    }
-    useActiveCodexScreen(mockClient);
-    await engine.getRegistry().reconstitute();
-
-    await engine.runSweep();
-
-    for (const surface of liveSurfaces) {
-      expect(mockClient.readScreen).toHaveBeenCalledTimes(2);
-      expect(mockClient.readScreen).toHaveBeenCalledWith(
-        surface.id,
-        expect.objectContaining({ workspace: "workspace:test" }),
-      );
-    }
-    expect(mockClient.setStatuses).toHaveBeenCalledTimes(1);
-    expect(sweepDebugLog).toHaveBeenCalledWith(
-      expect.stringMatching(/sweep timing.*build_total_ms=.*apply_ms=/i),
-    );
-    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBe(0);
   });
 
   it("enumerates topology once through live-agent sidebar and liveness paths", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -12,7 +12,10 @@ import { StateManager } from "../src/state-manager.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { ack, dispatch, writeHeartbeat } from "../src/inbox.js";
 import { AGENT_HEALTH_MONITOR_MAX_AGE_MS } from "../src/agent-health-input.js";
-import { readMonitorRegistry, registerMonitor } from "../src/monitor-registry.js";
+import {
+  readMonitorRegistry,
+  registerMonitor,
+} from "../src/monitor-registry.js";
 import type { CmuxClient } from "../src/cmux-client.js";
 import { generateAgentId, type AgentRecord } from "../src/agent-types.js";
 import type { CmuxSurface, CmuxNewSplitResult } from "../src/types.js";
@@ -90,6 +93,7 @@ function makeMockClient(overrides?: Partial<CmuxClient>): MockClient {
     log: vi.fn().mockResolvedValue(undefined),
     notify: vi.fn().mockResolvedValue(undefined),
     notifyLifecycleEvent: vi.fn().mockResolvedValue(undefined),
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     ...overrides,
   } as unknown as MockClient;
 }
@@ -178,9 +182,8 @@ describe("Sidebar Sync", () => {
     liveSurfaces = [];
     const workspaceForSurface = (surface: CmuxSurface): string =>
       surface.workspace_ref ??
-      stateMgr
-        .listStates()
-        .find((record) => record.surface_id === surface.ref)?.workspace_id ??
+      stateMgr.listStates().find((record) => record.surface_id === surface.ref)
+        ?.workspace_id ??
       "workspace:test";
     mockClient.listWorkspaces.mockImplementation(async () => ({
       workspaces: [...new Set(liveSurfaces.map(workspaceForSurface))].map(
@@ -222,7 +225,10 @@ describe("Sidebar Sync", () => {
       },
     );
     mockClient.listPaneSurfaces.mockImplementation(
-      async ({ workspace, pane }: { workspace?: string; pane?: string } = {}) => {
+      async ({
+        workspace,
+        pane,
+      }: { workspace?: string; pane?: string } = {}) => {
         const workspaceRef = workspace ?? "workspace:test";
         return {
           workspace_ref: workspaceRef,
@@ -457,15 +463,15 @@ describe("Sidebar Sync", () => {
     });
   });
 
-  it("enumerates topology once per sweep regardless of agent count", async () => {
-    let clientTopologyEnumerations = 0;
-    let registryTopologyEnumerations = 0;
-    (mockClient as unknown as Record<string, unknown>).supportsStableSurfaceReads =
-      true;
+  it("fails closed when transport health is unknown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-24T12:00:00.000Z"));
+    delete (mockClient as unknown as Record<string, unknown>)
+      .getTransportHealth;
     for (let index = 1; index <= 3; index += 1) {
       stateMgr.writeState(
         makeRecord({
-          agent_id: `topology-agent-${index}`,
+          agent_id: `unknown-health-agent-${index}`,
           surface_id: `surface:${index}`,
           state: "done",
           role: "worker",
@@ -473,9 +479,49 @@ describe("Sidebar Sync", () => {
         }),
       );
     }
-    // Keep the rows absent from this authoritative non-empty snapshot so the
-    // test isolates lifecycle/sidebar topology reuse from per-seat screen I/O.
-    liveSurfaces = [makeSurface("surface:live-unmanaged")];
+    liveSurfaces = [makeSurface("surface:1")];
+    const removeState = vi.spyOn(stateMgr, "removeState");
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+    vi.setSystemTime(new Date("2026-08-24T12:01:00.000Z"));
+    await engine.runSweep();
+
+    expect(removeState).not.toHaveBeenCalled();
+    expect(engine.getRegistry().list()).toHaveLength(3);
+    expect(engine.lifecycleLockState()).toMatchObject({
+      sweep_skipped_mutations: 2,
+    });
+  });
+
+  it("enumerates topology once through live-agent sidebar and liveness paths", async () => {
+    let clientTopologyEnumerations = 0;
+    let registryTopologyEnumerations = 0;
+    (
+      mockClient as unknown as Record<string, unknown>
+    ).supportsStableSurfaceReads = true;
+    (mockClient as unknown as Record<string, unknown>).getTransportHealth =
+      () => ({ mode: "socket", degraded: false });
+    for (let index = 1; index <= 3; index += 1) {
+      const stableUuid = `11111111-2222-4333-8444-55555555555${index}`;
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: `topology-agent-${index}`,
+          surface_id: `surface:${index}`,
+          surface_uuid: stableUuid,
+          workspace_id: "workspace:test",
+          state: "working",
+          role: "worker",
+          cli_session_id: `session-${index}`,
+        }),
+      );
+      liveSurfaces.push({
+        ...makeSurface(`surface:${index}`),
+        id: stableUuid,
+        workspace_ref: "workspace:test",
+      });
+    }
+    useActiveCodexScreen(mockClient);
     const originalListWorkspaces =
       mockClient.listWorkspaces.getMockImplementation()!;
     mockClient.listWorkspaces.mockImplementation(async () => {
@@ -509,6 +555,65 @@ describe("Sidebar Sync", () => {
       clientTopologyEnumerations: 1,
       registryTopologyEnumerations: 0,
     });
+    expect(mockClient.readScreen).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not expose a sweep snapshot to concurrent terminal routing", async () => {
+    const stableUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    (
+      mockClient as unknown as Record<string, unknown>
+    ).supportsStableSurfaceReads = true;
+    (mockClient as unknown as Record<string, unknown>).getTransportHealth =
+      () => ({ mode: "socket", degraded: false });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "concurrent-route-agent",
+        surface_id: "surface:old",
+        surface_uuid: stableUuid,
+        workspace_id: "workspace:test",
+        state: "working",
+      }),
+    );
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:old"),
+        id: stableUuid,
+        workspace_ref: "workspace:test",
+      },
+    ];
+    await engine.getRegistry().reconstitute();
+    let releaseRead!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      mockClient.readScreen.mockImplementation(async (surface: string) => {
+        liveSurfaces = [
+          {
+            ...makeSurface("surface:new"),
+            id: stableUuid,
+            workspace_ref: "workspace:test",
+          },
+        ];
+        resolve();
+        await new Promise<void>((release) => {
+          releaseRead = release;
+        });
+        return {
+          surface,
+          text: "gpt-5.6 · Working",
+          lines: 20,
+          scrollback_used: false,
+        };
+      });
+    });
+
+    const sweep = engine.runSweep();
+    await readStarted;
+    const concurrentRoute = await engine.resolveAgentIoRoute(
+      "concurrent-route-agent",
+    );
+    releaseRead();
+    await sweep;
+
+    expect(concurrentRoute.surface_id).toBe("surface:new");
   });
 
   it("publishes the canonical observed UUID when persisted casing differs", async () => {
@@ -561,8 +666,6 @@ describe("Sidebar Sync", () => {
 
   it("publishes no mixed row when the stable UUID moves during the screen read", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
-    (mockClient as unknown as Record<string, unknown>).supportsStableSurfaceReads =
-      true;
     stateMgr.writeState(
       makeRecord({
         agent_id: "mid-sweep-move",
@@ -610,9 +713,9 @@ describe("Sidebar Sync", () => {
       return snapshot;
     });
     mockClient.readScreen.mockImplementation(async (surface: string) => ({
-      surface: surface === stableUuid ? "surface:new" : surface,
+      surface,
       text:
-        surface === stableUuid
+        surface === "surface:new"
           ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
           : "Claude Code\nWhat can I help you with?\n> ",
       lines: 20,
@@ -622,7 +725,7 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(mockClient.readScreen).toHaveBeenCalledWith(
-      stableUuid,
+      "surface:new",
       expect.anything(),
     );
     expect(mockClient.setStatus).not.toHaveBeenCalled();
@@ -814,8 +917,7 @@ describe("Sidebar Sync", () => {
     });
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:42",
-      text:
-        "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
+      text: "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
       lines: 30,
       scrollback_used: false,
     });
@@ -902,15 +1004,13 @@ describe("Sidebar Sync", () => {
     mockClient.readScreen
       .mockResolvedValueOnce({
         surface: "surface:42",
-        text:
-          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
+        text: "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
         lines: 30,
         scrollback_used: false,
       })
       .mockResolvedValue({
         surface: "surface:42",
-        text:
-          "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\nImplemented the fix.\nTASK_DONE",
+        text: "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\nImplemented the fix.\nTASK_DONE",
         lines: 30,
         scrollback_used: false,
       });
@@ -922,13 +1022,13 @@ describe("Sidebar Sync", () => {
     await engine.initialize(terminalDiscovery);
 
     expect(deferredTranscriptResolver).not.toHaveBeenCalled();
-    expect(engine.getAgentState("cmuxlayerCodex-pending-startup")).toMatchObject(
-      {
-        state: "done",
-        cli_session_id: null,
-        transcript_session_capture_deferred: true,
-      },
-    );
+    expect(
+      engine.getAgentState("cmuxlayerCodex-pending-startup"),
+    ).toMatchObject({
+      state: "done",
+      cli_session_id: null,
+      transcript_session_capture_deferred: true,
+    });
 
     engine.dispose();
     const restartedRegistry = new AgentRegistry(
@@ -984,13 +1084,13 @@ describe("Sidebar Sync", () => {
         state: "done",
       }),
     );
-    expect(engine.getAgentState("cmuxlayerCodex-pending-startup")).toMatchObject(
-      {
-        state: "done",
-        cli_session_id: null,
-        transcript_session_capture_deferred: true,
-      },
-    );
+    expect(
+      engine.getAgentState("cmuxlayerCodex-pending-startup"),
+    ).toMatchObject({
+      state: "done",
+      cli_session_id: null,
+      transcript_session_capture_deferred: true,
+    });
 
     updateRecordSpy.mockRestore();
     await engine.runSweep();
@@ -1179,16 +1279,14 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(deferredTranscriptResolver).not.toHaveBeenCalled();
-    expect(
-      engine.getAgentState("gemini-stale-deferred-capture"),
-    ).toMatchObject({ transcript_session_capture_deferred: false });
+    expect(engine.getAgentState("gemini-stale-deferred-capture")).toMatchObject(
+      { transcript_session_capture_deferred: false },
+    );
 
     vi.setSystemTime(startedAt.getTime() + 6_000);
     await engine.runSweep();
 
-    expect(
-      engine.getAgentState("gemini-stale-deferred-capture"),
-    ).toBeNull();
+    expect(engine.getAgentState("gemini-stale-deferred-capture")).toBeNull();
   });
 
   it("treats an empty first-connect enumeration as unknown, not authoritative empty", async () => {
@@ -1288,8 +1386,7 @@ describe("Sidebar Sync", () => {
     });
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:42",
-      text:
-        "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
+      text: "gpt-5.4 high · 87% left · ~/Gits/cmuxlayer\n• Working (1s • esc to interrupt)",
       lines: 30,
       scrollback_used: false,
     });
@@ -1321,7 +1418,9 @@ describe("Sidebar Sync", () => {
   it("preserves the last generated fleet when topology enumeration is unknown", async () => {
     stateMgr.writeState(makeRecord());
     liveSurfaces = [makeSurface("surface:42")];
-    mockClient.listWorkspaces.mockRejectedValue(new Error("socket unavailable"));
+    mockClient.listWorkspaces.mockRejectedValue(
+      new Error("socket unavailable"),
+    );
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
@@ -1346,7 +1445,7 @@ describe("Sidebar Sync", () => {
     expect(publishedFleetPublications).toEqual([
       expect.objectContaining({
         state: "unknown",
-        observedLiveSurfaceRefs: [],
+        observedLiveSurfaceRefs: null,
       }),
     ]);
   });
@@ -1389,8 +1488,7 @@ describe("Sidebar Sync", () => {
       pane_ref: "pane:notes",
       surfaces: liveSurfaces,
     });
-    const newlySurfacelessAgentIds =
-      await engine.getRegistry().reconstitute();
+    const newlySurfacelessAgentIds = await engine.getRegistry().reconstitute();
     engine.enableStartupPurge({ retainAgentIds: newlySurfacelessAgentIds });
 
     await engine.runSweep();
@@ -1533,13 +1631,15 @@ describe("Sidebar Sync", () => {
 
     await engine.runSweep();
 
-    expect(engine.getAgentState("possibly-live-voicelayer-codex")).toMatchObject({
+    expect(
+      engine.getAgentState("possibly-live-voicelayer-codex"),
+    ).toMatchObject({
       surface_id: "surface:possibly-live",
       state: "working",
     });
     expect(publishedFleetPublications.at(-1)).toMatchObject({
       state: "unknown",
-      observedLiveSurfaceRefs: [],
+      observedLiveSurfaceRefs: null,
     });
   }, 10_000);
 
@@ -1636,8 +1736,7 @@ describe("Sidebar Sync", () => {
     ];
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:no-progress",
-      text:
-        "Claude Code\n✻ Baking… (1s · ↑ 4)\n🤖 Opus 4.8 | ⏱️ 1s\n⏵⏵ bypass permissions on",
+      text: "Claude Code\n✻ Baking… (1s · ↑ 4)\n🤖 Opus 4.8 | ⏱️ 1s\n⏵⏵ bypass permissions on",
       lines: 4,
       scrollback_used: false,
     });
@@ -1646,9 +1745,9 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(
-      publishedFleetPublications.at(-1)?.snapshot.lanes.flatMap(
-        (lane) => lane.seats,
-      ),
+      publishedFleetPublications
+        .at(-1)
+        ?.snapshot.lanes.flatMap((lane) => lane.seats),
     ).toEqual([
       expect.objectContaining({
         agentId: "no-transcript-progress",
@@ -1659,8 +1758,7 @@ describe("Sidebar Sync", () => {
     vi.setSystemTime(startedAt.getTime() + 120_001);
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:no-progress",
-      text:
-        "Claude Code\n✻ Baking… (2m 1s · ↑ 99)\n🤖 Opus 4.8 | ⏱️ 2m\n⏵⏵ bypass permissions on",
+      text: "Claude Code\n✻ Baking… (2m 1s · ↑ 99)\n🤖 Opus 4.8 | ⏱️ 2m\n⏵⏵ bypass permissions on",
       lines: 4,
       scrollback_used: false,
     });
@@ -1668,9 +1766,9 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(
-      publishedFleetPublications.at(-1)?.snapshot.lanes.flatMap(
-        (lane) => lane.seats,
-      ),
+      publishedFleetPublications
+        .at(-1)
+        ?.snapshot.lanes.flatMap((lane) => lane.seats),
     ).toEqual([
       expect.objectContaining({
         agentId: "no-transcript-progress",
@@ -2016,7 +2114,8 @@ describe("Sidebar Sync", () => {
     ];
     mockClient.readScreen.mockImplementation(async (surface: string) => {
       const text = screens.get(surface);
-      if (text === undefined) throw new Error(`missing prompt-freeze screen for ${surface}`);
+      if (text === undefined)
+        throw new Error(`missing prompt-freeze screen for ${surface}`);
       return {
         surface,
         text,
@@ -2092,7 +2191,8 @@ describe("Sidebar Sync", () => {
         cli: "codex" as const,
         kind: "resolve" as const,
         screen: fixture("codex-update-menu"),
-        recovered: "gpt-5.6-sol high · 83% left\n› Find and fix a bug in @filename",
+        recovered:
+          "gpt-5.6-sol high · 83% left\n› Find and fix a bug in @filename",
       },
       {
         name: "real-human-question",
@@ -2410,7 +2510,9 @@ describe("Sidebar Sync", () => {
           role: "worker",
           parent_agent_id: parentId,
           spawn_depth: 1,
-          state: entry.name.includes("spinner-over-picker") ? "working" : "idle",
+          state: entry.name.includes("spinner-over-picker")
+            ? "working"
+            : "idle",
           blocked_on_prompt: false,
           blocked_on_prompt_since: null,
         }),
@@ -2449,11 +2551,7 @@ describe("Sidebar Sync", () => {
         const entry = cases.find(
           (candidate) => candidate.surfaceRef === surface,
         );
-        if (
-          key === "escape" &&
-          entry?.kind === "resolve" &&
-          entry.recovered
-        ) {
+        if (key === "escape" && entry?.kind === "resolve" && entry.recovered) {
           screensBySurface.set(surface, entry.recovered);
         }
       },
@@ -2461,7 +2559,9 @@ describe("Sidebar Sync", () => {
     await engine.getRegistry().reconstitute();
 
     await engine.runSweep();
-    expect(engine.getAgentState("prompt-redirect-active-over-picker")).toMatchObject({
+    expect(
+      engine.getAgentState("prompt-redirect-active-over-picker"),
+    ).toMatchObject({
       halt_last_progress_signature: expect.any(String),
     });
     await engine.runSweep();
@@ -2618,8 +2718,7 @@ describe("Sidebar Sync", () => {
         id: surfaceUuid,
         title: "cmuxlayerClaude [surface:1025]",
         workspace_ref: "workspace:cmuxlayer",
-        current_directory:
-          "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
+        current_directory: "/Users/example/Gits/cmuxlayer/.worktrees/id-churn",
         working_directory_source: "surface",
       },
     ];
@@ -2670,8 +2769,7 @@ describe("Sidebar Sync", () => {
 
     mockClient.readScreen.mockResolvedValue({
       surface: "surface:1025",
-      text:
-        "Claude Code\nWorking (1s)\nImplementing the requested follow-up after the overlay.",
+      text: "Claude Code\nWorking (1s)\nImplementing the requested follow-up after the overlay.",
       lines: 30,
       scrollback_used: false,
     });
@@ -2704,10 +2802,9 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(engine.getAgentState("stale-surface-error")).toBeNull();
-    expect(mockClient.clearStatus).toHaveBeenCalledWith(
-      "stale-surface-error",
-      { workspace: "workspace:previous-session" },
-    );
+    expect(mockClient.clearStatus).toHaveBeenCalledWith("stale-surface-error", {
+      workspace: "workspace:previous-session",
+    });
   });
 
   it("does not emit channel notifications for initial spawned rows", async () => {
@@ -3792,8 +3889,7 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     const spawnedCalls = mockClient.log.mock.calls.filter(
-      (call) =>
-        typeof call[0] === "string" && call[0].startsWith("spawned:"),
+      (call) => typeof call[0] === "string" && call[0].startsWith("spawned:"),
     );
     expect(spawnedCalls).toHaveLength(0);
     expect(

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -421,6 +421,96 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("skips destructive mutations when CLI topology is degraded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-24T12:00:00.000Z"));
+    (mockClient as unknown as Record<string, unknown>).getTransportHealth =
+      () => ({
+        mode: "cli",
+        degraded: true,
+        denied_reason: "access-control",
+      });
+    for (let index = 1; index <= 3; index += 1) {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: `degraded-agent-${index}`,
+          surface_id: `surface:${index}`,
+          state: "done",
+          role: "worker",
+          cli_session_id: `session-${index}`,
+        }),
+      );
+    }
+    liveSurfaces = [makeSurface("surface:1")];
+    const removeState = vi.spyOn(stateMgr, "removeState");
+    await engine.getRegistry().reconstitute();
+
+    await engine.runSweep();
+    vi.setSystemTime(new Date("2026-08-24T12:01:00.000Z"));
+    await engine.runSweep();
+
+    expect(removeState).not.toHaveBeenCalled();
+    expect(mockClient.readScreen).not.toHaveBeenCalled();
+    expect(engine.getRegistry().list()).toHaveLength(3);
+    expect(engine.lifecycleLockState()).toMatchObject({
+      sweep_skipped_mutations: 2,
+    });
+  });
+
+  it("enumerates topology once per sweep regardless of agent count", async () => {
+    let clientTopologyEnumerations = 0;
+    let registryTopologyEnumerations = 0;
+    (mockClient as unknown as Record<string, unknown>).supportsStableSurfaceReads =
+      true;
+    for (let index = 1; index <= 3; index += 1) {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: `topology-agent-${index}`,
+          surface_id: `surface:${index}`,
+          state: "done",
+          role: "worker",
+          cli_session_id: `session-${index}`,
+        }),
+      );
+    }
+    // Keep the rows absent from this authoritative non-empty snapshot so the
+    // test isolates lifecycle/sidebar topology reuse from per-seat screen I/O.
+    liveSurfaces = [makeSurface("surface:live-unmanaged")];
+    const originalListWorkspaces =
+      mockClient.listWorkspaces.getMockImplementation()!;
+    mockClient.listWorkspaces.mockImplementation(async () => {
+      clientTopologyEnumerations += 1;
+      return originalListWorkspaces();
+    });
+    engine.dispose();
+    const registry = new AgentRegistry(stateMgr, async () => {
+      registryTopologyEnumerations += 1;
+      return liveSurfaces;
+    });
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    await registry.reconstitute();
+    clientTopologyEnumerations = 0;
+    registryTopologyEnumerations = 0;
+
+    await engine.runSweep();
+
+    expect({
+      clientTopologyEnumerations,
+      registryTopologyEnumerations,
+    }).toEqual({
+      clientTopologyEnumerations: 1,
+      registryTopologyEnumerations: 0,
+    });
+  });
+
   it("publishes the canonical observed UUID when persisted casing differs", async () => {
     const observedUuid = "078D1A5B-A3F4-40A5-8A59-A6C840BAF832";
     const persistedUuid = observedUuid.toLowerCase();
@@ -471,6 +561,8 @@ describe("Sidebar Sync", () => {
 
   it("publishes no mixed row when the stable UUID moves during the screen read", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
+    (mockClient as unknown as Record<string, unknown>).supportsStableSurfaceReads =
+      true;
     stateMgr.writeState(
       makeRecord({
         agent_id: "mid-sweep-move",
@@ -518,9 +610,9 @@ describe("Sidebar Sync", () => {
       return snapshot;
     });
     mockClient.readScreen.mockImplementation(async (surface: string) => ({
-      surface,
+      surface: surface === stableUuid ? "surface:new" : surface,
       text:
-        surface === "surface:new"
+        surface === stableUuid
           ? "gpt-5.5 xhigh · 99% left · ~/Gits/cmuxlayer\nWorking (1s • esc to interrupt)"
           : "Claude Code\nWhat can I help you with?\n> ",
       lines: 20,
@@ -530,7 +622,7 @@ describe("Sidebar Sync", () => {
     await engine.runSweep();
 
     expect(mockClient.readScreen).toHaveBeenCalledWith(
-      "surface:new",
+      stableUuid,
       expect.anything(),
     );
     expect(mockClient.setStatus).not.toHaveBeenCalled();

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -461,6 +461,15 @@ describe("Sidebar Sync", () => {
     expect(engine.lifecycleLockState()).toMatchObject({
       sweep_skipped_mutations: 2,
     });
+
+    (mockClient as unknown as Record<string, unknown>).getTransportHealth =
+      () => ({ mode: "socket", degraded: false });
+    liveSurfaces = [1, 2, 3].map((index) => makeSurface(`surface:${index}`));
+    await engine.runSweep();
+
+    expect(engine.lifecycleLockState()).toMatchObject({
+      sweep_skipped_mutations: 0,
+    });
   });
 
   it("fails closed when transport health is unknown", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -172,6 +172,7 @@ describe("Sidebar Sync", () => {
   let liveSurfaces: CmuxSurface[];
   let inboxOpts: { baseDir: string };
   let publishedFleetPublications: FleetSidebarPublication[];
+  let sweepDebugLogs: string[];
 
   beforeEach(() => {
     delete process.env.CMUXLAYER_EXPERIMENTAL_PROMPT_AUTO_RESOLVE;
@@ -241,12 +242,14 @@ describe("Sidebar Sync", () => {
       },
     );
     publishedFleetPublications = [];
+    sweepDebugLogs = [];
     inboxOpts = { baseDir: join(TEST_DIR, "inbox") };
     const surfaceProvider = async () => liveSurfaces;
     const registry = new AgentRegistry(stateMgr, surfaceProvider);
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
+      sweepDebugLog: (message) => sweepDebugLogs.push(message),
       inboxOpts,
       fleetSidebarPublisher: {
         publish: (publication) => {
@@ -518,6 +521,7 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
+      sweepDebugLog: (message) => sweepDebugLogs.push(message),
       inboxOpts,
       fleetSidebarPublisher: {
         publish: () => {},
@@ -730,6 +734,7 @@ describe("Sidebar Sync", () => {
     engine = new AgentEngine(stateMgr, registry, mockClient, {
       spawnPreflight: async () => {},
       sessionIdentityResolver: () => null,
+      sweepDebugLog: (message) => sweepDebugLogs.push(message),
       inboxOpts,
       fleetSidebarPublisher: {
         publish: () => {},
@@ -750,6 +755,82 @@ describe("Sidebar Sync", () => {
       registryTopologyEnumerations: 0,
     });
     expect(mockClient.readScreen).toHaveBeenCalledTimes(3);
+    expect(sweepDebugLogs.at(-1)).toMatch(
+      /sweep timing topology_ms=\d+.*sidebar_ms=\d+.*total_ms=\d+/,
+    );
+  });
+
+  it("guards every sweep-reachable mutation helper before its first side effect", () => {
+    const source = readFileSync(
+      new URL("../src/agent-engine.ts", import.meta.url),
+      "utf8",
+    );
+    const guardedHelpers = [
+      "maybeCaptureBootSessionId",
+      "maybeMarkBootReady",
+      "maybeMarkTaskDone",
+      "maybeMarkCliExited",
+      "maybeEscalateLiveHalt",
+      "maybeResolvePrompt",
+      "logLifecycleEvent",
+      "notifyLifecycleEventForSweep",
+      "publishSweepStatus",
+      "evictSurfacelessForSweep",
+      "purgeTerminalForSweep",
+      "removeStateForSweep",
+      "reconcileRolePlacements",
+      "markIntentionalSurfaceCloses",
+    ];
+
+    for (const helper of guardedHelpers) {
+      const declaration = [
+        `private async ${helper}(`,
+        `private ${helper}(`,
+        `async ${helper}(`,
+      ]
+        .map((needle) => source.indexOf(needle))
+        .filter((offset) => offset >= 0)
+        .sort((left, right) => left - right)[0];
+      expect(declaration, `${helper} must exist`).toBeGreaterThanOrEqual(0);
+      const bodyStart = source.indexOf("{", declaration);
+      expect(
+        source.slice(bodyStart + 1, bodyStart + 420),
+        `${helper} must guard before writing or dispatching`,
+      ).toMatch(/assertSweepInputCurrent\(/);
+    }
+  });
+
+  it("yields the remaining sweep phases to a queued interactive waiter", async () => {
+    const registry = engine.getRegistry();
+    let releaseReconcile: (() => void) | undefined;
+    const reconcileStarted = new Promise<void>((resolve) => {
+      vi.spyOn(registry, "reconcile").mockImplementation(async () => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseReconcile = release;
+        });
+        return new Set();
+      });
+    });
+    const evict = vi.spyOn(registry, "evictSurfaceless");
+    liveSurfaces = [makeSurface("surface:one")];
+
+    const sweep = engine.runSweep();
+    await reconcileStarted;
+    let waiterRan = false;
+    const waiter = engine.runLifecycleMutation(
+      async () => {
+        waiterRan = true;
+      },
+      { label: "interactive-test" },
+    );
+    expect(engine.lifecycleLockState().queue_depth).toBe(1);
+    releaseReconcile?.();
+    await Promise.all([sweep, waiter]);
+
+    expect(waiterRan).toBe(true);
+    expect(evict).not.toHaveBeenCalled();
+    expect(engine.lifecycleLockState().sweep_yielded).toBe(1);
   });
 
   it("does not expose a sweep snapshot to concurrent terminal routing", async () => {

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -503,6 +503,81 @@ describe("Sidebar Sync", () => {
     });
   });
 
+  it("skips every snapshot-backed mutation when the observer epoch changes after collection", async () => {
+    engine.dispose();
+    (mockClient as unknown as Record<string, unknown>).moveSurface = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const observerId = "cmux:/tmp/cmux-primary.sock";
+    let observerEpoch = `${observerId}@socket:1`;
+    const stableUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const registry = new AgentRegistry(stateMgr, async () => liveSurfaces, {
+      observerIdProvider: () => observerId,
+      observerEpochProvider: () => observerEpoch,
+    });
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      inboxOpts,
+      fleetSidebarPublisher: {
+        publish: () => {},
+        dispose: () => {},
+      },
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "epoch-race-agent",
+        surface_id: "surface:stale",
+        surface_uuid: stableUuid,
+        surface_observer_id: observerId,
+        workspace_id: "workspace:test",
+        state: "done",
+        role: "worker",
+        surface_provenance: "cmuxlayer_spawn",
+      }),
+    );
+    registry.set("epoch-race-agent", stateMgr.readState("epoch-race-agent")!);
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:witness"),
+        id: "11111111-2222-4333-8444-555555555555",
+        workspace_ref: "workspace:test",
+      },
+    ];
+
+    const reconcile = vi.spyOn(registry, "reconcile");
+    const evictSurfaceless = vi.spyOn(registry, "evictSurfaceless");
+    const purgeTerminal = vi.spyOn(registry, "purgeTerminal");
+    const purgeAllTerminal = vi.spyOn(registry, "purgeAllTerminal");
+    const removeState = vi.spyOn(stateMgr, "removeState");
+    const engineWithReaper = engine as unknown as {
+      reapChannelMarkersBestEffort: () => Promise<void>;
+    };
+    engineWithReaper.reapChannelMarkersBestEffort = async () => {
+      observerEpoch = `${observerId}@socket:2`;
+    };
+
+    await engine.runSweep();
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(evictSurfaceless).not.toHaveBeenCalled();
+    expect(purgeTerminal).not.toHaveBeenCalled();
+    expect(purgeAllTerminal).not.toHaveBeenCalled();
+    expect(removeState).not.toHaveBeenCalled();
+    expect(mockClient.moveSurface).not.toHaveBeenCalled();
+    expect(mockClient.setStatus).not.toHaveBeenCalled();
+    expect(mockClient.setStatuses).not.toHaveBeenCalled();
+    expect(mockClient.clearStatus).not.toHaveBeenCalled();
+    expect(registry.get("epoch-race-agent")).toMatchObject({
+      state: "done",
+      surface_id: "surface:stale",
+      surface_uuid: stableUuid,
+    });
+    expect(engine.lifecycleLockState().sweep_skipped_mutations).toBeGreaterThan(
+      0,
+    );
+  });
+
   it("enumerates topology once through live-agent sidebar and liveness paths", async () => {
     let clientTopologyEnumerations = 0;
     let registryTopologyEnumerations = 0;

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -266,7 +266,7 @@ describe("collectSurfaceTopology", () => {
     expect(snapshot).toBeNull();
   });
 
-  it("records the observer epoch that authorized a completed snapshot", async () => {
+  it("records the observer owner and epoch that authorized a completed snapshot", async () => {
     const observerId = "cmux:/tmp/cmux-primary.sock";
     const client = makeTopologyClient(
       [pane("pane:right", 0, ["surface:1"])],
@@ -285,7 +285,10 @@ describe("collectSurfaceTopology", () => {
       () => observerId,
     );
 
-    expect(snapshot?.observerEpoch).toBe(observerId);
+    expect(snapshot).toMatchObject({
+      observerId,
+      observerEpoch: observerId,
+    });
   });
 
   it("resolves a stale ref through the stable UUID from the same topology observation", async () => {

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -266,6 +266,28 @@ describe("collectSurfaceTopology", () => {
     expect(snapshot).toBeNull();
   });
 
+  it("records the observer epoch that authorized a completed snapshot", async () => {
+    const observerId = "cmux:/tmp/cmux-primary.sock";
+    const client = makeTopologyClient(
+      [pane("pane:right", 0, ["surface:1"])],
+      [
+        {
+          workspace_ref: "workspace:1",
+          pane_ref: "pane:right",
+          surfaces: [surface("surface:1")],
+        },
+      ],
+    );
+
+    const snapshot = await collectSurfaceTopology(
+      client,
+      "workspace:1",
+      () => observerId,
+    );
+
+    expect(snapshot?.observerEpoch).toBe(observerId);
+  });
+
   it("resolves a stale ref through the stable UUID from the same topology observation", async () => {
     const surfaceUuid = "369F3724-02E9-4ACF-9F23-5CBA7AFCCF9B";
     const panes = [

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -93,10 +93,7 @@ function makeRecord(overrides: Partial<AgentRecord>): AgentRecord {
   };
 }
 
-function makeTopologyClient(
-  panes: CmuxPane[],
-  groups: CmuxPaneSurfaces[],
-) {
+function makeTopologyClient(panes: CmuxPane[], groups: CmuxPaneSurfaces[]) {
   return {
     listWorkspaces: vi.fn().mockResolvedValue({
       workspaces: [workspace("workspace:1")],
@@ -194,6 +191,19 @@ describe("enrichSurfaceIdsFromPanes", () => {
 });
 
 describe("collectSurfaceTopology", () => {
+  it("marks malformed pane enumeration incomplete", async () => {
+    const client = makeTopologyClient([], []);
+    client.listPanes.mockResolvedValueOnce({
+      workspace_ref: "workspace:1",
+      window_ref: "window:1",
+      panes: null,
+    } as never);
+
+    const snapshot = await collectSurfaceTopology(client, "workspace:1");
+
+    expect(snapshot).toMatchObject({ complete: false, surfaces: [] });
+  });
+
   it("returns null when a configured surface observer is unknown", async () => {
     const client = makeTopologyClient(
       [pane("pane:right", 0, ["surface:1"])],
@@ -333,7 +343,10 @@ describe("collectSurfaceTopology", () => {
   });
 
   it("keeps usable pane topology when another pane surface lookup fails", async () => {
-    const panes = [pane("pane:ok", 0, ["surface:ok"]), pane("pane:gone", 1, [])];
+    const panes = [
+      pane("pane:ok", 0, ["surface:ok"]),
+      pane("pane:gone", 1, []),
+    ];
     const client = {
       listWorkspaces: vi.fn().mockResolvedValue({
         workspaces: [workspace("workspace:1")],
@@ -391,9 +404,7 @@ describe("collectSurfaceTopology", () => {
         pane_ref: "pane:two-seats",
         // The command succeeded, but cmux returned only one of the two surfaces
         // advertised by the same pane observation.
-        surfaces: [
-          { ...surface("surface:first"), id: firstUuid },
-        ],
+        surfaces: [{ ...surface("surface:first"), id: firstUuid }],
       },
     ];
 
@@ -428,9 +439,7 @@ describe("collectSurfaceTopology", () => {
         workspace_ref: "workspace:1",
         window_ref: "window:1",
         pane_ref: "pane:first",
-        surfaces: [
-          { ...surface("surface:first", "first"), id: duplicateUuid },
-        ],
+        surfaces: [{ ...surface("surface:first", "first"), id: duplicateUuid }],
       },
       {
         workspace_ref: "workspace:1",
@@ -588,22 +597,21 @@ describe("collectSurfaceTopology", () => {
       "workspace:1",
     );
     expect(snapshot).not.toBeNull();
-    const lead = makeRecord({ surface_id: "surface:lead-left", role: undefined });
+    const lead = makeRecord({
+      surface_id: "surface:lead-left",
+      role: undefined,
+    });
     const worker = makeRecord({
       surface_id: "surface:worker-right",
       role: undefined,
     });
 
-    expect(
-      healthFor(lead, snapshot),
-    ).toEqual({
+    expect(healthFor(lead, snapshot)).toEqual({
       status: "healthy",
       issue_codes: [],
       issues: [],
     });
-    expect(
-      healthFor(worker, snapshot),
-    ).toEqual({
+    expect(healthFor(worker, snapshot)).toEqual({
       status: "healthy",
       issue_codes: [],
       issues: [],

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -291,6 +291,38 @@ describe("collectSurfaceTopology", () => {
     });
   });
 
+  it("rejects a snapshot when only its distinct observer owner changes", async () => {
+    let observerId = "cmux:/tmp/cmux-primary.sock";
+    const observerEpoch = "cmux-route@socket:1";
+    const client = makeTopologyClient(
+      [pane("pane:right", 0, ["surface:1"])],
+      [
+        {
+          workspace_ref: "workspace:1",
+          pane_ref: "pane:right",
+          surfaces: [surface("surface:1")],
+        },
+      ],
+    );
+    const listPaneSurfaces = client.listPaneSurfaces.getMockImplementation()!;
+    client.listPaneSurfaces.mockImplementation(async (opts) => {
+      const result = await listPaneSurfaces(opts);
+      observerId = "cmux:/tmp/cmux-secondary.sock";
+      return result;
+    });
+
+    const snapshot = await collectSurfaceTopology(
+      client,
+      "workspace:1",
+      () => observerEpoch,
+      () => observerId,
+    );
+
+    expect(observerEpoch).toBe("cmux-route@socket:1");
+    expect(observerId).toBe("cmux:/tmp/cmux-secondary.sock");
+    expect(snapshot).toBeNull();
+  });
+
   it("resolves a stale ref through the stable UUID from the same topology observation", async () => {
     const surfaceUuid = "369F3724-02E9-4ACF-9F23-5CBA7AFCCF9B";
     const panes = [

--- a/tests/topology-contract.test.ts
+++ b/tests/topology-contract.test.ts
@@ -163,6 +163,7 @@ function engineFixture(): {
   let liveSurfaces: CmuxSurface[] = [];
   const publications: FleetSidebarPublication[] = [];
   const client = {
+    getTransportHealth: () => ({ mode: "socket", degraded: false }),
     newSplit: vi.fn().mockResolvedValue({
       workspace: "workspace:fleet",
       surface: "surface:new",


### PR DESCRIPTION
## Summary

- make explicit cmux access-control denial a hard state with an actionable control-health ERROR and a five-minute recovery probe
- make degraded, unknown-health, or incomplete-topology sweeps read-only
- bound the persistent-socket connect leg at about two seconds and retry backoff at fifteen seconds
- pass one observed topology snapshot explicitly through each production sweep without leaking it to concurrent callers

## Verification

- round-two focused regression suite: 7 files, 617 passed
- final bot-fix focused suite: 2 files, 47 passed
- typecheck passed in the current environment and with both socket variables unset
- exact-head pre-push hook: 145 files passed; 3340 passed, 1 skipped; exit 0
- isolated degraded-daemon smoke: ERROR/remedy present, sweep_skipped_mutations=1, state count 9 before and after, evictions=0
- healthy normal-path trace: one complete topology enumeration sequence in the observed sweep window

Fixes #538

## Reviewer scope note

Stable socket-backed sweep reads target the surface UUID and validate the returned binding before publication. This is a real behavior change beyond the issue's four named fixes, retained as defense-in-depth against ref recycling and binding drift. Legacy/non-stable readers keep the original fresh post-read route guard, including the restored mid-sweep-move regression.

— cmuxlayerCodex-89aff7e6 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-89aff7e6","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03465","ts":"2026-08-24T16:57:31Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent lifecycle reconciliation, topology authorization, and when registry rows are evicted—incorrect gating could leave ghosts or skip needed cleanup; transport/daemon startup paths are also security-sensitive.
> 
> **Overview**
> **Lifecycle sweeps** now collect one surface topology snapshot per tick and gate destructive work (registry reconcile, evict, terminal purge, role placement) on a healthy socket transport plus complete, observer-current topology. When those checks fail, sweeps stay read-only, count skipped mutations for diagnostics, and can yield early if lifecycle mutations are queued. Sidebar sync and per-agent sweep steps repeatedly call `assertSweepInputCurrent` so stale snapshots cannot mutate state or publish status.
> 
> **Transport and entry behavior:** explicit cmux access-control denial becomes a latched “hard” state with slow (5-minute) reprobe, clearer health ERROR/remedy text, and no daemon autostart when the proxy is denied. **Persistent socket** connect attempts are bounded (~2s) with tighter exponential backoff (2s–15s cap).
> 
> **Surface I/O:** clients that advertise stable reads use surface UUIDs for sweep screen reads and binding checks; topology collection now carries observer id/epoch, canonical `surfaces`, and stricter completeness rules. Registry eviction/purge can reuse the sweep’s surface list instead of re-enumerating. Automatic archive/reap of done/idle agents during sweeps is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01af44d72787ccc6a72f47075079b2b5727d3a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `AgentEngine` lifecycle sweeps against degraded transport and stale topology
> - Gate lifecycle sweep mutations in `AgentEngine` via `assertSweepInputCurrent`, which skips side effects when transport is degraded, topology is incomplete, or observer epoch changes mid-sweep
> - Skip daemon autostart in `runDaemonFirstEntry` when `probeEntryCmuxSocket` detects access-control denial, falling back to in-process runtime
> - Add a hard access-control denial state to `CmuxSelfHealingClient` that suppresses fast re-probes for 300s using `DEFAULT_HARD_DENIAL_REPROBE_MS`
> - Add a 2000ms connect timeout and update backoff defaults to 2000ms base / 15000ms max in `CmuxPersistentSocket`
> - Behavioral Change: `collectSurfaceTopology` may now return `null` if observer epoch or id is absent or stale; `CmuxPersistentSocket` now times out the connect leg independently after 2000ms
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01af44d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented destructive updates when connection health or surface information is uncertain.
  - Improved detection of stale topology data during concurrent changes.
  - Added connection timeouts and more reliable recovery from transport failures.
  - Access-control denials now remain clearly identified with recovery guidance.
  - Daemon startup now falls back safely when socket access is denied.

- **Behavior Changes**
  - Completed agents and idle workers are no longer automatically archived or closed.
  - Sweeps reuse consistent surface information to reduce redundant updates.

- **Diagnostics**
  - Health reporting now shows skipped lifecycle mutations and read-only reconciliation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->