### PR TITLE
fix: require composer transition for key submit verification

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5643,6 +5643,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verified: boolean | null;
     submit_verification_reason: SubmitKeyVerificationReason | null;
   }> => {
+    const baselineComposerInput =
+      opts.baseline === null
+        ? null
+        : extractComposerInputRegion(opts.baseline.text);
+    if (
+      opts.baseline?.parsed.control_state !== "permission_prompt" &&
+      baselineComposerInput !== null &&
+      baselineComposerInput.trim() === ""
+    ) {
+      return {
+        submit_verified: null,
+        submit_verification_reason: "submit_evidence_absent",
+      };
+    }
+
     const startedAt = Date.now();
     let sawReadableScreen = false;
 
@@ -5659,10 +5674,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ) {
         return { submit_verified: true, submit_verification_reason: null };
       }
-      const baselineComposerInput =
-        opts.baseline === null
-          ? null
-          : extractComposerInputRegion(opts.baseline.text);
       const composerInput = extractComposerInputRegion(snapshot.text);
       if (
         baselineComposerInput !== null &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -5632,8 +5632,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
    * AIDEV-NOTE (#484/#500): key mode writes no payload, so post-key composer
    * contents cannot prove whether this key landed. Positive evidence comes
    * from an observed state transition (especially permission_prompt being
-   * dismissed) or a composer that visibly clears; otherwise the result stays
-   * unknown rather than inventing `composer_still_populated`.
+   * dismissed) or a composer observed populated before the key and empty
+   * afterward; otherwise the result stays unknown rather than inventing
+   * `composer_still_populated`.
    */
   const verifySubmitKeyOutcome = async (opts: {
     surface: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5659,10 +5659,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ) {
         return { submit_verified: true, submit_verification_reason: null };
       }
+      const baselineComposerInput =
+        opts.baseline === null
+          ? null
+          : extractComposerInputRegion(opts.baseline.text);
       const composerInput = extractComposerInputRegion(snapshot.text);
-      if (composerInput !== null && composerInput.trim() === "") {
-        // The composer is readable and empty: it let go of its contents. This
-        // is positive proof for a composer submit. A "working" status alone
+      if (
+        baselineComposerInput !== null &&
+        baselineComposerInput.trim() !== "" &&
+        composerInput !== null &&
+        composerInput.trim() === ""
+      ) {
+        // The composer was populated before Return and is now readable and
+        // empty: it visibly let go of its contents. A "working" status alone
         // deliberately does not count: the reported target was already
         // working on its previous turn, so status cannot distinguish "my
         // submit started a turn" from "a turn was already running" -- and a

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -301,6 +301,9 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
     expect(data.submit_verified).toBeNull();
     expect(data.submit_verification_reason).toBe("submit_evidence_absent");
     expect(data.WARNING).toMatch(/submit not verified/i);
+    expect(exec.calls.filter((args) => args.includes("read-screen"))).toHaveLength(
+      1,
+    );
   });
 
   it("verifies Return when a Codex permission prompt is dismissed", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -287,6 +287,22 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
     expect(data.submit_verification_reason).toBeNull();
   });
 
+  it("does not verify Return when the composer was already empty", async () => {
+    const exec = makeExec({
+      screen: () => WORKING_AND_CLEARED_CLAUDE_SCREEN,
+    });
+
+    const result = await sendKey(makeServer(exec), "return");
+
+    const data = payload(result);
+    expect(result.isError).toBeUndefined();
+    expect(data.ok).toBe(true);
+    expect(data.key_dispatched).toBe(true);
+    expect(data.submit_verified).toBeNull();
+    expect(data.submit_verification_reason).toBe("submit_evidence_absent");
+    expect(data.WARNING).toMatch(/submit not verified/i);
+  });
+
   it("verifies Return when a Codex permission prompt is dismissed", async () => {
     let approved = false;
     const exec = makeExec({


### PR DESCRIPTION
## Summary
- require `send_to({mode:"key"})` Return verification to observe a populated baseline composer becoming empty
- keep permission-prompt dismissal as independent positive evidence
- return `submit_verified:null` with `submit_evidence_absent` and the existing warning for empty-to-empty Return

Closes #506

## Red / green evidence
- RED: focused regression failed before the fix with `expected true to be null`
- GREEN: `tests/t2b-silent-failures.test.ts` — 28 passed
- spawn/resume parity: 57 passed across `spawn-resume-parity` and `resume-verification`

## Verification
- `env -u CMUXLAYER_FORCE_INPROCESS bun run typecheck` — exit 0
- `CMUXLAYER_FORCE_INPROCESS=1 bun run typecheck` — exit 0
- `env -u CMUXLAYER_FORCE_INPROCESS bunx vitest run --reporter=dot` — 145 files passed; 3,351 tests passed; 1 skipped
- `CMUXLAYER_FORCE_INPROCESS=1 bunx vitest run --reporter=dot` — 144 files passed; 3,350 tests passed; 1 failed; 1 skipped
- forced-env failure is pre-existing on exact main `e45a54c`: `live-topology-restart.test.ts` inherits `CMUXLAYER_FORCE_INPROCESS=1` and hits the FleetSidebarPublisher test output-path guard
- local CodeRabbit review was bounded at three minutes and stopped while still reporting `reviewing`; no findings were emitted

## Backlog
- Make `live-topology-restart.test.ts` isolate its child environment from ambient `CMUXLAYER_FORCE_INPROCESS`.

— cmuxlayerCodex-e75cc650 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-e75cc650","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03864","ts":"2026-08-25T10:19:21Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes receipt semantics for key-mode Return (more null/unverified outcomes), which callers may rely on for relay confirmation, but reduces false-positive submit claims.
> 
> **Overview**
> Tightens **Return-key submit verification** for `send_to({ mode: "key" })` so an already-empty composer can no longer be read as proof that a submit landed.
> 
> **`verifySubmitKeyOutcome`** now captures baseline composer text up front. If the pane was not on a permission prompt and the composer was empty before the key, it **short-circuits** with `submit_verified: null` and `submit_verification_reason: "submit_evidence_absent"` (no polling loop). Positive verification from a cleared composer requires a **visible transition**: non-empty baseline composer → empty after Return. **Permission-prompt dismissal** remains standalone positive evidence.
> 
> Adds a regression test: Return on a working screen with an empty composer stays unverified, surfaces the existing warning, and only performs one `read-screen`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05a76c4185778b7c6907a1b3d933cd2192187bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require composer transition for `verifySubmitKeyOutcome` submit verification
> Previously, submit verification returned success whenever the composer was observed empty after a keypress, regardless of its baseline state. Now `verifySubmitKeyOutcome` records the baseline composer input and only confirms a submit when the composer transitions from populated to empty (or a permission prompt is dismissed). If the composer is already empty at baseline and no permission prompt is present, it returns inconclusive immediately with reason `submit_evidence_absent` and skips polling. Adds a test for the baseline-empty case in [t2b-silent-failures.test.ts](https://github.com/EtanHey/cmuxlayer/pull/541/files#diff-69f9a76bee65e44729117e2558ada9c9511c2cfca8b3edcc9a246b046e8bc529). Risk: callers that relied on an empty composer alone to confirm submit will now receive `submit_verified: null` with `submit_verification_reason: 'submit_evidence_absent'` when the composer was already empty before the keypress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c05a76c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Return-key submission verification to avoid false positives when the composer was already empty.
  - Submission status now remains unverified when there is insufficient evidence that a message was submitted.

- **Tests**
  - Added regression coverage for silent submission failures and appropriate warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->