### PR TITLE
fix: preserve waiter and resume truth

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8604,7 +8604,6 @@ export class AgentEngine {
     const registration = this.selfRegistrationSessionLookup?.(agentOrSessionId);
     if (!registration) return null;
     const surfaceUuid = registration.surface_uuid.trim().toLowerCase();
-    const registrationCwd = registration.cwd?.trim() || null;
     const registrationCli = registration.cli?.trim().toLowerCase() || null;
     const records = this.stateMgr.listStates();
     const uniqueMatch = (
@@ -8621,13 +8620,6 @@ export class AgentEngine {
       surfaceMatches[0] ??
       (registration.pid
         ? uniqueMatch((record) => record.pid === registration.pid)
-        : null) ??
-      (registrationCwd
-        ? uniqueMatch(
-            (record) =>
-              record.launch_cwd === registrationCwd &&
-              (!registrationCli || record.cli === registrationCli),
-          )
         : null);
     if (
       !candidate ||

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -633,6 +633,8 @@ export interface AgentEngineOptions {
   spawnGuard?: SpawnGuard;
   postSpawnLivenessMs?: number;
   stopPostConditionTimeoutMs?: number;
+  /** Codex-only self-registration wait; clamped to the 2s product bound. */
+  spawnSessionCaptureTimeoutMs?: number;
   /**
    * Optional fallback override after self-registration misses. When supplied,
    * it replaces the filesystem transcript scan (primarily for hermetic tests).
@@ -797,6 +799,8 @@ const DEFAULT_SWEEP_IDLE_AFTER_SWEEPS = 3;
 const FLEET_SIDEBAR_WAKE_REPUBLISH_DELAY_MS = 500;
 const DEFAULT_POST_SPAWN_LIVENESS_MS = 5_000;
 const DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS = 1_000;
+const MAX_SPAWN_SESSION_CAPTURE_MS = 2_000;
+const SPAWN_SESSION_CAPTURE_POLL_MS = 50;
 const CHANNEL_MARKER_REAP_INTERVAL_MS = 60 * 60 * 1_000;
 const CHANNEL_MARKER_REAP_RETRY_MS = 60 * 1_000;
 const STOP_POST_CONDITION_POLL_MS = 50;
@@ -1577,6 +1581,7 @@ export class AgentEngine {
   private spawnGuard: SpawnGuard;
   private postSpawnLivenessMs: number;
   private stopPostConditionTimeoutMs: number;
+  private spawnSessionCaptureTimeoutMs: number;
   private roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -1835,6 +1840,13 @@ export class AgentEngine {
         process.env.CMUXLAYER_STOP_POST_CONDITION_TIMEOUT_MS,
         DEFAULT_STOP_POST_CONDITION_TIMEOUT_MS,
       );
+    this.spawnSessionCaptureTimeoutMs = Math.max(
+      0,
+      Math.min(
+        MAX_SPAWN_SESSION_CAPTURE_MS,
+        opts?.spawnSessionCaptureTimeoutMs ?? MAX_SPAWN_SESSION_CAPTURE_MS,
+      ),
+    );
     this.codexModelListRunner =
       opts?.codexModelListRunner ?? defaultCodexModelListRunner;
     this.spawnPreflight =
@@ -3834,6 +3846,27 @@ export class AgentEngine {
       return null;
     }
     return this.maybeCaptureBootSessionId(agent, {});
+  }
+
+  private async captureCodexSpawnSessionId(agentId: string): Promise<void> {
+    const deadline = Date.now() + this.spawnSessionCaptureTimeoutMs;
+    while (true) {
+      const current =
+        this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+      if (!current) return;
+      const captured = await this.maybeCaptureBootSessionId(current, {}, {
+        resolveTranscript: false,
+      });
+      if (captured.cli_session_id) return;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return;
+      await new Promise<void>((resolveSleep) =>
+        setTimeout(
+          resolveSleep,
+          Math.min(SPAWN_SESSION_CAPTURE_POLL_MS, remaining),
+        ),
+      );
+    }
   }
 
   private async retryDeferredTranscriptCaptures(): Promise<void> {
@@ -8390,23 +8423,20 @@ export class AgentEngine {
         error,
       );
     }
-    let returnedAgentId = agentId;
-    if (this.selfRegistrationSessionResolver) {
+    if (
+      spawnParams.cli === "codex" &&
+      this.selfRegistrationSessionResolver
+    ) {
       try {
-        const current = this.registry.get(agentId) ?? record;
-        returnedAgentId = (
-          await this.maybeCaptureBootSessionId(current, {}, {
-            resolveTranscript: false,
-          })
-        ).agent_id;
+        await this.captureCodexSpawnSessionId(agentId);
       } catch {
         // Registration is written by the launched harness. A later sweep keeps
         // retrying if the append has not landed by the time spawn returns.
       }
     }
-    this.schedulePostSpawnLivenessAssertion(returnedAgentId);
+    this.schedulePostSpawnLivenessAssertion(agentId);
     return {
-      agent_id: returnedAgentId,
+      agent_id: agentId,
       parent_agent_id: parentAgentId,
       surface_id: surface.surface,
       workspace_id: surface.workspace,
@@ -8722,7 +8752,7 @@ export class AgentEngine {
         state: initialState,
         elapsed: Date.now() - start,
         source: "immediate",
-        agent: toPublicAgent(initial),
+        agent: toPublicAgent({ ...initial, state: initialState }),
         error: initial.error ?? "Agent is in error state",
       };
     }
@@ -8734,7 +8764,7 @@ export class AgentEngine {
         state: initialState,
         elapsed: Date.now() - start,
         source: "immediate",
-        agent: toPublicAgent(initial),
+        agent: toPublicAgent({ ...initial, state: initialState }),
         error: "Agent has already completed",
       };
     }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3496,10 +3496,17 @@ export class AgentEngine {
         !hasCapturedProcessEvidence ||
         (existingFinal.pid === identity.pid &&
           existingFinal.pid_registered_at === identity.pid_registered_at);
+      const routeMatches =
+        existingFinal.surface_id === updated.surface_id &&
+        (existingFinal.surface_uuid ?? null) === (updated.surface_uuid ?? null) &&
+        (existingFinal.surface_observer_id ?? null) ===
+          (updated.surface_observer_id ?? null) &&
+        (existingFinal.workspace_id ?? null) === (updated.workspace_id ?? null);
       const canonicalFinal =
         existingFinal.cli_session_id === identity.session_id &&
         existingFinal.cli_session_path === sessionPath &&
         processEvidenceMatches &&
+        routeMatches &&
         existingFinal.transcript_session_capture_deferred !== true &&
         (existingFinal.transcript_session_capture_attempts ?? 0) === 0
           ? existingFinal
@@ -3507,6 +3514,11 @@ export class AgentEngine {
               cli_session_id: identity.session_id,
               cli_session_path: sessionPath,
               ...capturedProcessEvidence,
+              surface_id: updated.surface_id,
+              surface_uuid: updated.surface_uuid ?? null,
+              surface_observer_id: updated.surface_observer_id,
+              surface_provenance: updated.surface_provenance,
+              workspace_id: updated.workspace_id,
               transcript_session_capture_deferred: false,
               transcript_session_capture_attempts: 0,
             });
@@ -8420,7 +8432,7 @@ export class AgentEngine {
     agentId: string,
     opts?: { workspace?: string; force?: boolean },
   ): Promise<SpawnAgentResult> {
-    const agent = this.resolveResumeAgent(agentId);
+    let agent = this.resolveResumeAgent(agentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -8459,6 +8471,21 @@ export class AgentEngine {
     const requestedWorkspace =
       opts?.workspace ?? agent.workspace_id ?? undefined;
     this.spawnGuard.check(requestedWorkspace);
+    const persistedAgent = this.stateMgr.readState(agent.agent_id);
+    if (!persistedAgent) {
+      throw new Error(`Agent not found: ${agent.agent_id}`);
+    }
+    if (!persistedAgent.cli_session_id) {
+      agent = this.stateMgr.updateRecord(agent.agent_id, {
+        cli_session_id: agent.cli_session_id,
+        cli_session_path: agent.cli_session_path ?? null,
+      });
+      this.registry.set(agent.agent_id, agent);
+    } else if (persistedAgent.cli_session_id !== agent.cli_session_id) {
+      throw new Error(
+        `Agent "${agent.agent_id}" session identity changed during resume resolution`,
+      );
+    }
 
     let surface: CreatedAgentSurface | null = null;
     let surfaceBound = false;
@@ -8565,13 +8592,13 @@ export class AgentEngine {
       this.stateMgr.readState(agentOrSessionId);
     if (direct) return direct;
     const requestedSessionId = agentOrSessionId.trim().toLowerCase();
+    const capturedMatches = this.stateMgr.listStates().filter(
+      (record) =>
+        record.cli_session_id?.trim().toLowerCase() === requestedSessionId,
+    );
     const captured =
-      this.stateMgr
-        .listStates()
-        .find(
-          (record) =>
-            record.cli_session_id?.trim().toLowerCase() === requestedSessionId,
-        ) ?? null;
+      capturedMatches.length === 1 ? capturedMatches[0]! : null;
+    if (capturedMatches.length > 1) return null;
     if (captured) return captured;
 
     const registration = this.selfRegistrationSessionLookup?.(agentOrSessionId);
@@ -8602,17 +8629,21 @@ export class AgentEngine {
               (!registrationCli || record.cli === registrationCli),
           )
         : null);
-    if (!candidate) return null;
-    return this.finalizeCapturedSession(candidate, {
-      session_id: registration.session_id,
-      path: registration.session_path,
-      ...(registration.pid && registration.ts
-        ? {
-            pid: registration.pid,
-            pid_registered_at: new Date(registration.ts).toISOString(),
-          }
-        : {}),
-    });
+    if (
+      !candidate ||
+      !TERMINAL_STATES.has(candidate.state) ||
+      (registrationCli && candidate.cli !== registrationCli) ||
+      (candidate.cli_session_id &&
+        candidate.cli_session_id.trim().toLowerCase() !== requestedSessionId)
+    ) {
+      return null;
+    }
+    return {
+      ...candidate,
+      cli_session_id: registration.session_id,
+      cli_session_path:
+        registration.session_path ?? candidate.cli_session_path ?? null,
+    };
   }
 
   /**
@@ -9661,24 +9692,31 @@ export class AgentEngine {
           this.registry.evictExplicit(canonicalAgentId);
           return;
         }
-        const tombstone = this.stateMgr.updateRecord(canonicalAgentId, {
-          user_killed: true,
-          pid: null,
-        });
-        this.registry.set(canonicalAgentId, tombstone);
-        return;
+        const surfaceGone = await this.isAgentSurfaceGone(agent);
+        if (
+          surfaceGone &&
+          (this.isProcessConfirmedGone(agent) || agent.pid == null)
+        ) {
+          const tombstone = this.stateMgr.updateRecord(canonicalAgentId, {
+            user_killed: true,
+            pid: null,
+          });
+          this.registry.set(canonicalAgentId, tombstone);
+          return;
+        }
+      } else {
+        if (
+          agent.state === "error" &&
+          userInitiated &&
+          agent.user_killed !== true
+        ) {
+          const marked = this.stateMgr.updateRecord(canonicalAgentId, {
+            user_killed: true,
+          });
+          this.registry.set(canonicalAgentId, marked);
+        }
+        return; // Already stopped
       }
-      if (
-        agent.state === "error" &&
-        userInitiated &&
-        agent.user_killed !== true
-      ) {
-        const marked = this.stateMgr.updateRecord(canonicalAgentId, {
-          user_killed: true,
-        });
-        this.registry.set(canonicalAgentId, marked);
-      }
-      return; // Already stopped
     }
 
     let route = await this.resolveAgentStopIoRoute(canonicalAgentId);
@@ -9923,10 +9961,15 @@ export class AgentEngine {
           const done = this.stateMgr.transition(canonicalAgentId, "done");
           this.registry.set(canonicalAgentId, done);
         } catch {
-          const failed = this.stateMgr.transition(canonicalAgentId, "error", {
-            error: "Force stopped",
-          });
-          this.registry.set(canonicalAgentId, failed);
+          try {
+            const failed = this.stateMgr.transition(canonicalAgentId, "error", {
+              error: "Force stopped",
+            });
+            this.registry.set(canonicalAgentId, failed);
+          } catch {
+            const committed = this.stateMgr.readState(canonicalAgentId);
+            if (committed) this.registry.set(canonicalAgentId, committed);
+          }
         }
       }
       return;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8646,10 +8646,28 @@ export class AgentEngine {
       (record) => record.surface_uuid?.trim().toLowerCase() === surfaceUuid,
     );
     if (surfaceMatches.length > 1) return null;
+    const registrationCwd = registration.cwd
+      ? resolve(registration.cwd)
+      : null;
+    const registrationTimestamp =
+      typeof registration.ts === "number" ? registration.ts : Number.NaN;
     const candidate =
       surfaceMatches[0] ??
       (registration.pid
-        ? uniqueMatch((record) => record.pid === registration.pid)
+        ? uniqueMatch((record) => {
+            const recordTimestamp = Date.parse(record.created_at);
+            const recordCwd = record.launch_cwd ?? record.worktree_path;
+            return (
+              record.pid === registration.pid &&
+              Number.isFinite(registrationTimestamp) &&
+              Number.isFinite(recordTimestamp) &&
+              registrationTimestamp >= recordTimestamp &&
+              registrationCwd !== null &&
+              recordCwd !== null &&
+              recordCwd !== undefined &&
+              resolve(recordCwd) === registrationCwd
+            );
+          })
         : null);
     if (
       !candidate ||
@@ -9007,7 +9025,7 @@ export class AgentEngine {
     const startedAt = Date.now();
     const armed = await this.armWatch(spec);
     while (true) {
-      await sweepWatches({
+      const swept = await sweepWatches({
         registryPath: this.watchRegistryPath,
         now: this.watchRegistryNow,
         agentObservation: this.watchAgentObservation,
@@ -9020,7 +9038,7 @@ export class AgentEngine {
         throw new Error(`Watch disappeared during wait: ${armed.watch_id}`);
       }
       const elapsed = Date.now() - startedAt;
-      if (current.state === "fired") {
+      if (current.state === "fired" || swept.fired.includes(armed.watch_id)) {
         return { matched: true, elapsed, watch: current };
       }
       if (current.state === "failed") {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8977,7 +8977,7 @@ export class AgentEngine {
             state: liveState,
             elapsed,
             source: "sweep",
-            agent: toPublicAgent(current),
+            agent: toPublicAgent({ ...current, state: liveState }),
             error:
               current.error ?? `Agent entered terminal state: ${liveState}`,
           });

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -647,6 +647,10 @@ export interface AgentEngineOptions {
    * registry file — hermetic like `outboxDrain`/`closeForensicsRunner`.
    */
   selfRegistrationSessionResolver?: SessionIdentityResolver;
+  /** Reverse lookup used by resume_agent_id when callers supply a harness id. */
+  selfRegistrationSessionLookup?: (
+    sessionId: string,
+  ) => SelfRegistrationSessionEntry | null;
   roleSurfaceIdsProvider?: (
     liveSurfaceIds?: ReadonlySet<string>,
     workspace?: string,
@@ -738,6 +742,17 @@ export interface AgentEngineOptions {
   haltIdleWithoutDoneDwellMs?: number;
   haltWedgedDwellMs?: number;
   haltWedgedSweeps?: number;
+}
+
+export interface SelfRegistrationSessionEntry {
+  session_id: string;
+  surface_uuid: string;
+  cwd: string | null;
+  pid: number | null;
+  cli: string | null;
+  launcher: string | null;
+  session_path: string | null;
+  ts: number | null;
 }
 
 export type RolePlacementReconcileTrigger = "spawn" | "idle" | "boot";
@@ -1574,6 +1589,9 @@ export class AgentEngine {
   private sessionIdentityResolver: SessionIdentityResolver;
   private hasCustomSessionIdentityResolver: boolean;
   private selfRegistrationSessionResolver: SessionIdentityResolver | null;
+  private selfRegistrationSessionLookup:
+    | ((sessionId: string) => SelfRegistrationSessionEntry | null)
+    | null;
   private seatRegistry: SeatRegistry | null;
   private sweepTimer: ReturnType<typeof setTimeout> | null = null;
   private fleetSidebarWakeRepublishTimer: ReturnType<typeof setTimeout> | null =
@@ -1767,6 +1785,8 @@ export class AgentEngine {
     // app-server-runtime).
     this.selfRegistrationSessionResolver =
       opts?.selfRegistrationSessionResolver ?? null;
+    this.selfRegistrationSessionLookup =
+      opts?.selfRegistrationSessionLookup ?? null;
     const fallbackSessionIdentityResolver = opts?.sessionIdentityResolver;
     this.sessionIdentityResolver = (agent) =>
       this.resolveSessionIdentityWithSelfRegistration(
@@ -3068,9 +3088,7 @@ export class AgentEngine {
   }
 
   private canUseSelfRegistrationSessionResolver(agent: AgentRecord): boolean {
-    return (
-      agent.cli !== "codex" && this.canUseSelfRegistrationProcessEvidence(agent)
-    );
+    return this.canUseSelfRegistrationProcessEvidence(agent);
   }
 
   /**
@@ -3243,10 +3261,10 @@ export class AgentEngine {
   }
 
   /**
-   * Default session-identity resolution is harness-specific. Codex identity is
-   * sourced only from its rollout JSONL because its screen does not reliably
-   * expose the UUID and self-registration can race or carry unrelated identity.
-   * Claude/Cursor retain self-registration first, then transcript fallback.
+   * Default session-identity resolution is harness-specific. The registration
+   * row is keyed by the exact stable surface UUID and launch timestamp, so it is
+   * authoritative for Codex as well as Claude/Cursor; transcript scanning is a
+   * fallback only when that direct registration is absent.
    */
   private resolveSessionIdentityWithSelfRegistration(
     agent: AgentRecord,
@@ -8360,9 +8378,23 @@ export class AgentEngine {
         error,
       );
     }
-    this.schedulePostSpawnLivenessAssertion(agentId);
+    let returnedAgentId = agentId;
+    if (this.selfRegistrationSessionResolver) {
+      try {
+        const current = this.registry.get(agentId) ?? record;
+        returnedAgentId = (
+          await this.maybeCaptureBootSessionId(current, {}, {
+            resolveTranscript: false,
+          })
+        ).agent_id;
+      } catch {
+        // Registration is written by the launched harness. A later sweep keeps
+        // retrying if the append has not landed by the time spawn returns.
+      }
+    }
+    this.schedulePostSpawnLivenessAssertion(returnedAgentId);
     return {
-      agent_id: agentId,
+      agent_id: returnedAgentId,
       parent_agent_id: parentAgentId,
       surface_id: surface.surface,
       workspace_id: surface.workspace,
@@ -8388,8 +8420,7 @@ export class AgentEngine {
     agentId: string,
     opts?: { workspace?: string; force?: boolean },
   ): Promise<SpawnAgentResult> {
-    const agent =
-      this.registry.get(agentId) ?? this.stateMgr.readState(agentId);
+    const agent = this.resolveResumeAgent(agentId);
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`);
     }
@@ -8525,6 +8556,63 @@ export class AgentEngine {
       }
       throw error;
     }
+  }
+
+  /** Resolve either cmuxlayer's public label or the harness's full session id. */
+  resolveResumeAgent(agentOrSessionId: string): AgentRecord | null {
+    const direct =
+      this.registry.get(agentOrSessionId) ??
+      this.stateMgr.readState(agentOrSessionId);
+    if (direct) return direct;
+    const requestedSessionId = agentOrSessionId.trim().toLowerCase();
+    const captured =
+      this.stateMgr
+        .listStates()
+        .find(
+          (record) =>
+            record.cli_session_id?.trim().toLowerCase() === requestedSessionId,
+        ) ?? null;
+    if (captured) return captured;
+
+    const registration = this.selfRegistrationSessionLookup?.(agentOrSessionId);
+    if (!registration) return null;
+    const surfaceUuid = registration.surface_uuid.trim().toLowerCase();
+    const registrationCwd = registration.cwd?.trim() || null;
+    const registrationCli = registration.cli?.trim().toLowerCase() || null;
+    const records = this.stateMgr.listStates();
+    const uniqueMatch = (
+      predicate: (record: AgentRecord) => boolean,
+    ): AgentRecord | null => {
+      const matches = records.filter(predicate);
+      return matches.length === 1 ? matches[0]! : null;
+    };
+    const surfaceMatches = records.filter(
+      (record) => record.surface_uuid?.trim().toLowerCase() === surfaceUuid,
+    );
+    if (surfaceMatches.length > 1) return null;
+    const candidate =
+      surfaceMatches[0] ??
+      (registration.pid
+        ? uniqueMatch((record) => record.pid === registration.pid)
+        : null) ??
+      (registrationCwd
+        ? uniqueMatch(
+            (record) =>
+              record.launch_cwd === registrationCwd &&
+              (!registrationCli || record.cli === registrationCli),
+          )
+        : null);
+    if (!candidate) return null;
+    return this.finalizeCapturedSession(candidate, {
+      session_id: registration.session_id,
+      path: registration.session_path,
+      ...(registration.pid && registration.ts
+        ? {
+            pid: registration.pid,
+            pid_registered_at: new Date(registration.ts).toISOString(),
+          }
+        : {}),
+    });
   }
 
   /**
@@ -9569,7 +9657,15 @@ export class AgentEngine {
 
     if (TERMINAL_STATES.has(agent.state)) {
       if (force) {
-        this.registry.evictExplicit(canonicalAgentId);
+        if (!agent.cli_session_id) {
+          this.registry.evictExplicit(canonicalAgentId);
+          return;
+        }
+        const tombstone = this.stateMgr.updateRecord(canonicalAgentId, {
+          user_killed: true,
+          pid: null,
+        });
+        this.registry.set(canonicalAgentId, tombstone);
         return;
       }
       if (
@@ -9812,7 +9908,27 @@ export class AgentEngine {
     }
 
     if (force) {
-      this.registry.evict(canonicalAgentId);
+      const current = this.registry.get(canonicalAgentId) ?? agent;
+      if (!current.cli_session_id) {
+        this.registry.evictExplicit(canonicalAgentId);
+        return;
+      }
+      const tombstone = this.stateMgr.updateRecord(canonicalAgentId, {
+        user_killed: true,
+        pid: null,
+      });
+      this.registry.set(canonicalAgentId, tombstone);
+      if (!TERMINAL_STATES.has(current.state)) {
+        try {
+          const done = this.stateMgr.transition(canonicalAgentId, "done");
+          this.registry.set(canonicalAgentId, done);
+        } catch {
+          const failed = this.stateMgr.transition(canonicalAgentId, "error", {
+            error: "Force stopped",
+          });
+          this.registry.set(canonicalAgentId, failed);
+        }
+      }
       return;
     }
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -107,6 +107,7 @@ export function deriveSurfaceObserverId(
 }
 
 export const SURFACE_EVICTION_CONFIRMATION_MS = 5_000;
+export const MAX_RESUMABLE_TOMBSTONES = 50;
 
 /**
  * Absence window for rows NO live observer claims (#480).
@@ -706,6 +707,7 @@ export class AgentRegistry {
     for (const record of stateFiles) {
       this.agents.set(record.agent_id, record);
     }
+    this.pruneResumableTombstones();
 
     return this.reconcileSurfaces(opts);
   }
@@ -723,6 +725,7 @@ export class AgentRegistry {
         this.agents.set(record.agent_id, record);
       }
     }
+    this.pruneResumableTombstones();
 
     return this.reconcileSurfaces(opts);
   }
@@ -1704,12 +1707,34 @@ export class AgentRegistry {
     const resolved = this.resolveAlias(agentId);
     if (resolved !== agentId && record.agent_id === resolved) {
       this.agents.set(resolved, record);
+      this.pruneResumableTombstones();
       return;
     }
     if (agentId !== record.agent_id) {
       this.aliases.set(agentId, record.agent_id);
     }
     this.agents.set(record.agent_id, record);
+    this.pruneResumableTombstones();
+  }
+
+  private pruneResumableTombstones(): AgentRecord[] {
+    const tombstones = [...this.agents.values()]
+      .filter(shouldRetainForExplicitResume)
+      .sort((left, right) => {
+        const leftAt = Date.parse(left.updated_at);
+        const rightAt = Date.parse(right.updated_at);
+        const byUpdatedAt =
+          (Number.isFinite(rightAt) ? rightAt : 0) -
+          (Number.isFinite(leftAt) ? leftAt : 0);
+        return byUpdatedAt || right.agent_id.localeCompare(left.agent_id);
+      });
+    const removed: AgentRecord[] = [];
+    for (const tombstone of tombstones.slice(MAX_RESUMABLE_TOMBSTONES)) {
+      const removedAgentId = this.deleteAgentAndAliases(tombstone.agent_id);
+      this.stateMgr.removeState(removedAgentId);
+      removed.push(tombstone);
+    }
+    return removed;
   }
 
   rename(oldAgentId: string, newAgentId: string, record: AgentRecord): void {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -1732,6 +1732,7 @@ export class AgentRegistry {
     for (const tombstone of tombstones.slice(MAX_RESUMABLE_TOMBSTONES)) {
       const removedAgentId = this.deleteAgentAndAliases(tombstone.agent_id);
       this.stateMgr.removeState(removedAgentId);
+      this.stateMgr.getSurfaceSessionIndex().removeAgent(removedAgentId);
       removed.push(tombstone);
     }
     return removed;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -236,17 +236,19 @@ export function hasRecoverableCrashError(error: string | null): boolean {
  * #492: cmuxlayer never respawns a pane on its own, so a row that died on its
  * own is the operator's ONLY handle for an explicit `spawn_agent
  * ({resume_agent_id})`. Keep such a row (and its captured session) instead of
- * reaping it. A row someone MEANT to end is not retained -- that close was the
- * decision.
+ * reaping it. Closing a pane is no longer deletion of its resumable identity:
+ * terminal rows with a captured harness session are durable tombstones, so a
+ * lead can revive the same agent after either a crash or a deliberate close.
  */
 export function shouldRetainForExplicitResume(
   agent: Pick<AgentRecord, "state" | "user_killed" | "cli_session_id" | "error">,
 ): boolean {
   return (
-    agent.state === "error" &&
-    agent.user_killed !== true &&
+    (agent.state === "done" || agent.state === "error") &&
     !!agent.cli_session_id &&
-    hasRecoverableCrashError(agent.error)
+    (agent.user_killed === true ||
+      agent.state === "done" ||
+      hasRecoverableCrashError(agent.error))
   );
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -228,7 +228,18 @@ export function hasRecoverableCrashError(error: string | null): boolean {
     error.includes("disappeared") ||
     // Preserve resumability for legacy rows written by the deleted crash-recovery path.
     error.startsWith("Crash recovery failed:") ||
+    error.startsWith("Explicit resume failed:") ||
     error === CLI_EXIT_ERROR
+  );
+}
+
+export function isDeliberateCloseTombstone(
+  agent: Pick<AgentRecord, "state" | "user_killed" | "cli_session_id">,
+): boolean {
+  return (
+    (agent.state === "done" || agent.state === "error") &&
+    !!agent.cli_session_id &&
+    agent.user_killed === true
   );
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -233,12 +233,10 @@ export function hasRecoverableCrashError(error: string | null): boolean {
 }
 
 /**
- * #492: cmuxlayer never respawns a pane on its own, so a row that died on its
- * own is the operator's ONLY handle for an explicit `spawn_agent
- * ({resume_agent_id})`. Keep such a row (and its captured session) instead of
- * reaping it. Closing a pane is no longer deletion of its resumable identity:
- * terminal rows with a captured harness session are durable tombstones, so a
- * lead can revive the same agent after either a crash or a deliberate close.
+ * A deliberate agent close preserves the captured harness session as a
+ * resumable tombstone. Unexpected crashes keep their existing error behavior,
+ * but do not accumulate as durable resume rows; the registry also caps these
+ * deliberate-close tombstones so persistence remains bounded.
  */
 export function shouldRetainForExplicitResume(
   agent: Pick<AgentRecord, "state" | "user_killed" | "cli_session_id" | "error">,
@@ -246,9 +244,7 @@ export function shouldRetainForExplicitResume(
   return (
     (agent.state === "done" || agent.state === "error") &&
     !!agent.cli_session_id &&
-    (agent.user_killed === true ||
-      agent.state === "done" ||
-      hasRecoverableCrashError(agent.error))
+    agent.user_killed === true
   );
 }
 

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -233,10 +233,9 @@ export function hasRecoverableCrashError(error: string | null): boolean {
 }
 
 /**
- * A deliberate agent close preserves the captured harness session as a
- * resumable tombstone. Unexpected crashes keep their existing error behavior,
- * but do not accumulate as durable resume rows; the registry also caps these
- * deliberate-close tombstones so persistence remains bounded.
+ * A deliberate close or recoverable crash preserves the captured harness
+ * session as a resumable tombstone. The registry caps these tombstones so
+ * persistence remains bounded.
  */
 export function shouldRetainForExplicitResume(
   agent: Pick<AgentRecord, "state" | "user_killed" | "cli_session_id" | "error">,
@@ -244,7 +243,7 @@ export function shouldRetainForExplicitResume(
   return (
     (agent.state === "done" || agent.state === "error") &&
     !!agent.cli_session_id &&
-    agent.user_killed === true
+    (agent.user_killed === true || hasRecoverableCrashError(agent.error))
   );
 }
 

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -5,7 +5,10 @@ import type { CmuxClient } from "./cmux-client.js";
 import type { CmuxSocketClient } from "./cmux-socket-client.js";
 import { getTransportHealth } from "./cmux-transport-self-heal.js";
 import { AgentEngine, resolveSweepTiming } from "./agent-engine.js";
-import { makeSelfRegistrationSessionResolver } from "./self-registration.js";
+import {
+  makeSelfRegistrationSessionLookup,
+  makeSelfRegistrationSessionResolver,
+} from "./self-registration.js";
 import type { AgentRoute } from "./agent-types.js";
 import { createDefaultCloseForensicsRunner } from "./close-forensics.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
@@ -403,6 +406,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         monitorRegistryPath: defaultMonitorRegistryPath(),
         monitorRegistryNotify: httpNotifyMonitorDeadman,
         selfRegistrationSessionResolver: makeSelfRegistrationSessionResolver(),
+        selfRegistrationSessionLookup: makeSelfRegistrationSessionLookup(),
         inboxOpts: opts.inboxOpts,
         closeForensicsRunner: createDefaultCloseForensicsRunner({
           stateMgr: this.stateMgr,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,7 +25,10 @@ import {
   type CreateCmuxClientOptions,
 } from "./cmux-client-factory.js";
 import { createServer, createServerContext } from "./server.js";
-import { makeSelfRegistrationSessionResolver } from "./self-registration.js";
+import {
+  makeSelfRegistrationSessionLookup,
+  makeSelfRegistrationSessionResolver,
+} from "./self-registration.js";
 import { drainOutbox, httpDeliver } from "./outbox-drainer.js";
 import {
   defaultMonitorRegistryPath,
@@ -667,6 +670,9 @@ export class CmuxLayerDaemon {
           selfRegistrationSessionResolver:
             this.opts.selfRegistrationSessionResolver ??
             makeSelfRegistrationSessionResolver(),
+          selfRegistrationSessionLookup:
+            this.opts.selfRegistrationSessionLookup ??
+            makeSelfRegistrationSessionLookup(),
           surfaceObserverOwnerIdProvider:
             this.opts.surfaceObserverOwnerIdProvider,
           surfaceObserverEpochProvider: this.opts.surfaceObserverEpochProvider,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -382,7 +382,10 @@ export async function startInProcessRuntime(
     { defaultWatchRegistryPath, httpNotifyWatch },
     { ensureNodeMaxOldSpaceEnv, installHeapGuard },
     { FleetSidebarPublisher },
-    { makeSelfRegistrationSessionResolver },
+    {
+      makeSelfRegistrationSessionLookup,
+      makeSelfRegistrationSessionResolver,
+    },
   ] = await Promise.all([
     import("@modelcontextprotocol/sdk/server/stdio.js"),
     import("./stdio-lifecycle.js"),
@@ -411,6 +414,7 @@ export async function startInProcessRuntime(
     watchNotify: httpNotifyWatch,
     enableCloseForensics: true,
     selfRegistrationSessionResolver: makeSelfRegistrationSessionResolver(),
+    selfRegistrationSessionLookup: makeSelfRegistrationSessionLookup(),
     fleetSidebarPublisher: new FleetSidebarPublisher(),
     defaultPalette: opts.env?.CMUXLAYER_DEFAULT_PALETTE,
     ...(explicitStateDir ? { stateDir: explicitStateDir } : {}),

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -22,7 +22,7 @@
  * session_id + surface_uuid to bind, never fabricate an id.
  */
 
-import { closeSync, openSync, readSync, statSync } from "node:fs";
+import { closeSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentRecord } from "./agent-types.js";
@@ -521,6 +521,42 @@ export function makeSelfRegistrationSessionResolver(
           }
         : {}),
     };
+  };
+}
+
+/**
+ * Resolve an exact raw harness session id back to its newest registration row.
+ * Resume is rare, so this deliberately reads the append-only file directly;
+ * the hot per-sweep resolver above remains incrementally indexed by surface.
+ */
+export function makeSelfRegistrationSessionLookup(
+  options: SelfRegistrationResolverOptions = {},
+): (sessionId: string) => SelfRegistrationEntry | null {
+  const registryPath = options.registryPath ?? resolveSessionRegistryPath();
+  const readText = (): string | null => {
+    try {
+      return options.readFile
+        ? options.readFile(registryPath)
+        : readFileSync(registryPath, "utf8");
+    } catch {
+      return null;
+    }
+  };
+  return (sessionId: string): SelfRegistrationEntry | null => {
+    const requested = sessionId.trim().toLowerCase();
+    if (!requested) return null;
+    const text = readText();
+    if (!text) return null;
+    const matches = parseSelfRegistrationLines(text).filter(
+      (entry) => entry.session_id.trim().toLowerCase() === requested,
+    );
+    if (matches.length === 0) return null;
+    return matches.reduce((latest, entry) =>
+      (entry.ts ?? Number.NEGATIVE_INFINITY) >=
+      (latest.ts ?? Number.NEGATIVE_INFINITY)
+        ? entry
+        : latest,
+    );
   };
 }
 

--- a/src/self-registration.ts
+++ b/src/self-registration.ts
@@ -551,12 +551,7 @@ export function makeSelfRegistrationSessionLookup(
       (entry) => entry.session_id.trim().toLowerCase() === requested,
     );
     if (matches.length === 0) return null;
-    return matches.reduce((latest, entry) =>
-      (entry.ts ?? Number.NEGATIVE_INFINITY) >=
-      (latest.ts ?? Number.NEGATIVE_INFINITY)
-        ? entry
-        : latest,
-    );
+    return matches.at(-1)!;
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -135,6 +135,7 @@ import type {
 } from "./agent-types.js";
 import {
   bootPromptRegistryFields,
+  shouldRetainForExplicitResume,
   summarizeTaskSummary,
 } from "./agent-types.js";
 import {
@@ -10360,16 +10361,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!agentStopped) {
             // The stop itself failed: keep its verbatim ok:false/error and add
             // the surface half, which was never attempted.
-            return {
-              ...result,
-              structuredContent: {
-                ...rawStopContent,
-                scope: "agent",
-                agent_stopped: false,
-                surface_closed: false,
-                surface_close_skipped: "agent_stop_failed",
-              },
-            };
+            const reason =
+              typeof rawStopContent.error === "string"
+                ? rawStopContent.error
+                : "Agent stop could not establish a safe terminal I/O route";
+            const remedy =
+              "Refresh live topology with list_agents, verify the agent's current surface, then retry close_surface with force:true.";
+            return err(new Error(`close_surface scope=agent refused: ${reason}`), {
+              ...rawStopContent,
+              scope: "agent",
+              agent_stopped: false,
+              surface_closed: false,
+              surface_close_skipped: "agent_stop_failed",
+              reason,
+              remedy,
+              WARNING: remedy,
+            });
           }
           if (!boundSurface) {
             const data = {
@@ -14968,7 +14975,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     server.tool(
       "list_agents",
-      "List live-derived agents, including registry-persisted prompt blockage and pause state; filter to blocked agents or children with mine/parent_agent_id. Default summary returns flat addressable scalars only. Pass detail=full for provenance, health diagnostics, the full registry record, and up to 20 unresolved or attention delivery receipts.",
+      "List live-derived agents, including registry-persisted prompt blockage and pause state; filter to blocked agents or children with mine/parent_agent_id. Default summary returns flat addressable scalars and hides retained close tombstones; request a terminal state or detail=full to include them. Full detail also includes provenance, health diagnostics, the registry record, and up to 20 unresolved or attention delivery receipts.",
       {
         state: z
           .enum([
@@ -15140,10 +15147,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           },
         ) => {
           const registryObservedAt = Date.now();
+          const visibleRecords =
+            args.detail === "full" || requestedState !== undefined
+              ? records
+              : records.filter(
+                  (agent) => !shouldRetainForExplicitResume(agent),
+                );
           const uuidKey = (value: string | null | undefined) =>
             value?.trim().toLowerCase() || null;
           const rows = await Promise.all(
-            records.map(async (agent) => {
+            visibleRecords.map(async (agent) => {
               try {
                 const agentUuid = uuidKey(agent.surface_uuid);
                 const observedSurface = liveDiscovery?.rows.find((surface) => {
@@ -15669,12 +15682,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           await engine.stopAgent(args.agent_id, args.force, {
-            beforeSurfaceMutation: (route) =>
-              assertSurfaceMutationAllowed(
-                "stop_agent",
-                route.surface_id,
-                route.workspace_id ?? undefined,
-              ),
+            beforeSurfaceMutation: args.force
+              ? undefined
+              : (route) =>
+                  assertSurfaceMutationAllowed(
+                    "stop_agent",
+                    route.surface_id,
+                    route.workspace_id ?? undefined,
+                  ),
           });
           const state = engine.getAgentState(args.agent_id);
           appendCloseEvent({

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,6 +136,7 @@ import type {
 } from "./agent-types.js";
 import {
   bootPromptRegistryFields,
+  isDeliberateCloseTombstone,
   shouldRetainForExplicitResume,
   summarizeTaskSummary,
 } from "./agent-types.js";
@@ -11488,6 +11489,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         },
       });
     };
+    const watchRegistryPath =
+      opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json");
     const testProcess =
       process.env.VITEST === "true" || process.env.NODE_ENV === "test";
     const engine =
@@ -11692,8 +11695,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           monitorRegistryPath: opts?.monitorRegistryPath,
           monitorRegistryNow: opts?.monitorRegistryNow,
           monitorRegistryNotify: opts?.monitorRegistryNotify,
-          watchRegistryPath:
-            opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
+          watchRegistryPath,
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
             let externalDelivered = true;
@@ -12407,8 +12409,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ): Promise<string | null> => {
       try {
         const reportPath = resolve(coordination.report_path);
-        const watchRegistryPath =
-          opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json");
         const existing = readWatchRegistry({
           registryPath: watchRegistryPath,
         }).watches.find(
@@ -15167,7 +15167,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             (args.agent_ids?.length ?? 0) > 0
               ? records
               : records.filter(
-                  (agent) => !shouldRetainForExplicitResume(agent),
+                  (agent) => !isDeliberateCloseTombstone(agent),
                 );
           const uuidKey = (value: string | null | undefined) =>
             value?.trim().toLowerCase() || null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import {
   type AgentDeliveryReceipt,
   type AgentLifecycleEvent,
   type LifecycleLockState,
+  type SelfRegistrationSessionEntry,
   type SessionIdentityResolver,
   type SpawnAgentParams,
 } from "./agent-engine.js";
@@ -3348,6 +3349,9 @@ export interface CreateServerOptions {
    * `makeSelfRegistrationSessionResolver()`; unset in tests keeps HOME I/O out.
    */
   selfRegistrationSessionResolver?: SessionIdentityResolver;
+  selfRegistrationSessionLookup?: (
+    sessionId: string,
+  ) => SelfRegistrationSessionEntry | null;
   /** Async, throttled Codex rollout reader (primarily injectable for tests). */
   codexRolloutFillProvider?: CodexRolloutFillProvider;
   /** Override git worktree execution/home for tests. */
@@ -3523,6 +3527,9 @@ export interface CmuxServerContext {
   disableSpawnPreflight?: boolean;
   sessionIdentityResolver?: SessionIdentityResolver;
   selfRegistrationSessionResolver?: SessionIdentityResolver;
+  selfRegistrationSessionLookup?: (
+    sessionId: string,
+  ) => SelfRegistrationSessionEntry | null;
   lifecycleRegistry: AgentRegistry | null;
   lifecycleInitializer: (() => Promise<void>) | null;
   lifecycleStarted: boolean;
@@ -3675,6 +3682,7 @@ export function createServerContext(
     disableSpawnPreflight: opts?.disableSpawnPreflight,
     sessionIdentityResolver: opts?.sessionIdentityResolver,
     selfRegistrationSessionResolver: opts?.selfRegistrationSessionResolver,
+    selfRegistrationSessionLookup: opts?.selfRegistrationSessionLookup,
     lifecycleRegistry: opts?.lifecycleRegistry ?? null,
     lifecycleInitializer: opts?.lifecycleInitializer ?? null,
     lifecycleStarted: false,
@@ -11632,6 +11640,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           sessionIdentityResolver: context.sessionIdentityResolver,
           selfRegistrationSessionResolver:
             context.selfRegistrationSessionResolver,
+          selfRegistrationSessionLookup:
+            context.selfRegistrationSessionLookup,
           roleSurfaceIdsProvider: collectServerRoleSurfaceIds,
           inboxOpts,
           launchCommandSender: async ({
@@ -11678,9 +11688,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               registry.get(event.owner) ?? stateMgr.readState(event.owner);
             if (owner && lifecycleAgentInputDeliverer) {
               const text = (() => {
-                if (event.reason === "predicate_matched") {
+                if (
+                  event.reason === "predicate_matched" ||
+                  event.reason === "target_changed"
+                ) {
                   return event.target_kind === "file"
-                    ? `[report] done marker observed — read ${event.target}`
+                    ? `[report] changed — read ${event.target}`
                     : `[watch] agent predicate matched — inspect ${event.target}`;
                 }
                 if (event.reason === "target_missing") {
@@ -12378,7 +12391,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         await engine.armWatch({
           owner: parentAgentId,
           target: coordination.report_path,
-          marker: coordination.done_marker,
+          change: "content",
           deadline: Number.MAX_SAFE_INTEGER,
         });
         return null;
@@ -12857,7 +12870,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               );
             }
             await awaitLifecycleStart();
-            const existing = engine.getAgentState(args.resume_agent_id);
+            const existing = engine.resolveResumeAgent(args.resume_agent_id);
             if (!existing) {
               return err(new Error(`Agent not found: ${args.resume_agent_id}`));
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,7 @@ import {
 } from "./monitor-registry.js";
 import {
   WATCH_AGENT_PREDICATES,
+  readWatchRegistry,
   WatchArmError,
   type WatchNotify,
   type WatchSpec,
@@ -11737,7 +11738,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 const ownerDelivered =
                   delivery.delivery === "submitted" ||
                   delivery.delivery === "queued";
-                return ownerDelivered && externalDelivered;
+                return ownerDelivered;
               } catch {
                 // Keep notification_pending=true. A later lifecycle sweep uses
                 // the parent's refreshed route after a session restart.
@@ -12405,11 +12406,24 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       coordination: { report_path: string; done_marker: string },
     ): Promise<string | null> => {
       try {
-        await mkdir(dirname(coordination.report_path), { recursive: true });
-        await appendFile(coordination.report_path, "", "utf8");
+        const reportPath = resolve(coordination.report_path);
+        const watchRegistryPath =
+          opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json");
+        const existing = readWatchRegistry({
+          registryPath: watchRegistryPath,
+        }).watches.find(
+          (watch) =>
+            watch.owner === parentAgentId &&
+            watch.target === reportPath &&
+            watch.change === "content" &&
+            watch.state !== "failed",
+        );
+        if (existing) return null;
+        await mkdir(dirname(reportPath), { recursive: true });
+        await appendFile(reportPath, "", "utf8");
         await engine.armWatch({
           owner: parentAgentId,
-          target: coordination.report_path,
+          target: reportPath,
           change: "content",
           deadline: Number.MAX_SAFE_INTEGER,
         });
@@ -15148,7 +15162,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         ) => {
           const registryObservedAt = Date.now();
           const visibleRecords =
-            args.detail === "full" || requestedState !== undefined
+            args.detail === "full" ||
+            requestedState !== undefined ||
+            (args.agent_ids?.length ?? 0) > 0
               ? records
               : records.filter(
                   (agent) => !shouldRetainForExplicitResume(agent),
@@ -15682,14 +15698,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (args) => {
         try {
           await engine.stopAgent(args.agent_id, args.force, {
-            beforeSurfaceMutation: args.force
-              ? undefined
-              : (route) =>
-                  assertSurfaceMutationAllowed(
-                    "stop_agent",
-                    route.surface_id,
-                    route.workspace_id ?? undefined,
-                  ),
+            beforeSurfaceMutation: (route) =>
+              assertSurfaceMutationAllowed(
+                "stop_agent",
+                route.surface_id,
+                route.workspace_id ?? undefined,
+              ),
           });
           const state = engine.getAgentState(args.agent_id);
           appendCloseEvent({

--- a/src/server.ts
+++ b/src/server.ts
@@ -393,13 +393,17 @@ const WatchSpecArgsSchema = {
     .enum(WATCH_AGENT_PREDICATES)
     .optional()
     .describe(
-      "Agent screen-state predicate: thinking, working, idle, done, error; mutually exclusive with marker",
+      "Agent screen-state predicate: thinking, working, idle, done, error; mutually exclusive with marker and change",
     ),
   marker: z
     .string()
     .min(1)
     .optional()
-    .describe("Literal file marker; mutually exclusive with predicate"),
+    .describe("Literal file marker; mutually exclusive with predicate and change"),
+  change: z
+    .literal("content")
+    .optional()
+    .describe("Persistent file-content change watch; mutually exclusive with predicate and marker"),
   watermark: z
     .number()
     .int()
@@ -415,9 +419,17 @@ const WatchSpecArgsSchema = {
 
 const WatchSpecSchema = z
   .object(WatchSpecArgsSchema)
-  .refine((watch) => Boolean(watch.predicate) !== Boolean(watch.marker), {
-    message: "WatchSpec requires exactly one of predicate or marker",
-  });
+  .refine(
+    (watch) => {
+      const selectors = [watch.predicate, watch.marker, watch.change].filter(
+        (value) => value !== undefined,
+      );
+      return selectors.length === 1;
+    },
+    {
+      message: "WatchSpec requires exactly one of predicate, marker, or change",
+    },
+  );
 
 // Re-export for test access
 export { sanitizeTerminalInput } from "./sanitize.js";

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -390,6 +390,9 @@ export class StateManager {
       state: "creating",
       error: null,
       pid: null,
+      task_done_candidate_at: null,
+      task_done_detected_at: null,
+      halt_last_active_at: null,
       version: current.version + 1,
       updated_at: new Date().toISOString(),
     };

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { httpDeliver } from "./outbox-drainer.js";
 
 export type WatchState = "armed" | "firing" | "fired" | "failed";
@@ -35,6 +35,8 @@ export interface WatchSpec {
   target: string;
   predicate?: WatchAgentPredicate;
   marker?: string;
+  /** Persistently notify after each distinct file-content revision. */
+  change?: "content";
   watermark?: number;
   /** Absolute Unix timestamp in milliseconds. */
   deadline: number;
@@ -44,6 +46,7 @@ export interface WatchRecord extends WatchSpec {
   watch_id: string;
   target_kind: "file" | "agent";
   watermark?: number;
+  fingerprint?: string;
   armed_at_ms: number;
   last_heartbeat_at_ms: number;
   liveness_source: string;
@@ -64,7 +67,11 @@ export interface WatchRegistryFile {
 }
 
 export type WatchNotificationReason =
-  "predicate_matched" | "consumer_died" | "target_missing" | "deadline_elapsed";
+  | "predicate_matched"
+  | "target_changed"
+  | "consumer_died"
+  | "target_missing"
+  | "deadline_elapsed";
 
 export interface WatchNotification {
   watch_id: string;
@@ -182,6 +189,7 @@ function isWatchNotificationReason(
 ): value is WatchNotificationReason {
   return (
     value === "predicate_matched" ||
+    value === "target_changed" ||
     value === "consumer_died" ||
     value === "target_missing" ||
     value === "deadline_elapsed"
@@ -207,6 +215,9 @@ function isWatchRecord(value: unknown): value is WatchRecord {
     (value.liveness.source !== "process" && value.liveness.source !== "screen") ||
     !isFiniteNumber(value.liveness.observed_at_ms)
   ) {
+    return false;
+  }
+  if (value.fingerprint !== undefined && typeof value.fingerprint !== "string") {
     return false;
   }
   if (
@@ -266,10 +277,16 @@ function isWatchRecord(value: unknown): value is WatchRecord {
     return false;
   }
   if (value.target_kind === "file") {
-    return Boolean(cleanString(value.marker)) && value.predicate === undefined;
+    const hasMarker = Boolean(cleanString(value.marker));
+    const hasChange = value.change === "content";
+    return hasMarker !== hasChange && value.predicate === undefined;
   }
   if (value.target_kind === "agent") {
-    return isWatchAgentPredicate(value.predicate) && value.marker === undefined;
+    return (
+      isWatchAgentPredicate(value.predicate) &&
+      value.marker === undefined &&
+      value.change === undefined
+    );
   }
   return false;
 }
@@ -391,6 +408,10 @@ function countMarker(path: string, marker: string): number {
   return count;
 }
 
+function contentFingerprint(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
 function assertSpec(
   spec: WatchSpec,
   opts: WatchRegistryOptions,
@@ -400,16 +421,19 @@ function assertSpec(
   targetKind: "file" | "agent";
   predicate?: WatchAgentPredicate;
   marker?: string;
+  change?: "content";
 } {
   const owner = cleanString(spec.owner);
   const target = cleanString(spec.target);
   const predicate = cleanString(spec.predicate);
   const marker = cleanString(spec.marker);
-  if (!owner || !target || (predicate === null) === (marker === null)) {
+  const change = spec.change === "content" ? "content" : null;
+  const selectorCount = Number(predicate !== null) + Number(marker !== null) + Number(change !== null);
+  if (!owner || !target || selectorCount !== 1) {
     throw new WatchArmError(
       "invalid_watch_spec",
       target ?? "",
-      "WatchSpec requires owner, target, and exactly one of predicate or marker",
+      "WatchSpec requires owner, target, and exactly one of predicate, marker, or change",
     );
   }
   const now = nowMs(opts);
@@ -433,11 +457,11 @@ function assertSpec(
 
   const targetKind = isAbsolute(target) ? "file" : "agent";
   if (targetKind === "file") {
-    if (!marker || predicate) {
+    if ((!marker && !change) || predicate || Boolean(marker) === Boolean(change)) {
       throw new WatchArmError(
         "invalid_watch_spec",
         target,
-        "File WatchSpec targets require marker and do not accept predicate",
+        "File WatchSpec targets require exactly one of marker or change and do not accept predicate",
       );
     }
     if (!existsSync(target)) {
@@ -448,7 +472,7 @@ function assertSpec(
       );
     }
   } else {
-    if (!isWatchAgentPredicate(predicate) || marker) {
+    if (!isWatchAgentPredicate(predicate) || marker || change) {
       throw new WatchArmError(
         "invalid_watch_spec",
         target,
@@ -471,6 +495,7 @@ function assertSpec(
     targetKind,
     ...(isWatchAgentPredicate(predicate) ? { predicate } : {}),
     ...(marker ? { marker } : {}),
+    ...(change ? { change } : {}),
   };
 }
 
@@ -491,6 +516,7 @@ export async function armWatch(
   const watermark = checked.marker
     ? (spec.watermark ?? countMarker(target, checked.marker))
     : spec.watermark;
+  const fingerprint = checked.change ? contentFingerprint(target) : undefined;
   const agentObservation =
     checked.targetKind === "agent"
       ? await opts.agentObservation?.(target)
@@ -512,7 +538,9 @@ export async function armWatch(
     target,
     ...(checked.predicate ? { predicate: checked.predicate } : {}),
     ...(checked.marker ? { marker: checked.marker } : {}),
+    ...(checked.change ? { change: checked.change } : {}),
     ...(watermark !== undefined ? { watermark } : {}),
+    ...(fingerprint !== undefined ? { fingerprint } : {}),
     deadline: spec.deadline,
     target_kind: checked.targetKind,
     armed_at_ms: observedAt,
@@ -678,17 +706,24 @@ export async function sweepWatches(
 
       const observedValue =
         record.target_kind === "file"
-          ? countMarker(record.target, record.marker!)
+          ? record.change === "content"
+            ? contentFingerprint(record.target)
+            : countMarker(record.target, record.marker!)
           : (agentObservation?.state ?? "unknown");
       const matched =
         record.target_kind === "file"
-          ? typeof observedValue === "number" &&
-            observedValue > (record.watermark ?? 0)
+          ? record.change === "content"
+            ? typeof observedValue === "string" &&
+              observedValue !== record.fingerprint
+            : typeof observedValue === "number" &&
+              observedValue > (record.watermark ?? 0)
           : observedValue === record.predicate;
       if (matched) {
+        const reason: WatchNotificationReason =
+          record.change === "content" ? "target_changed" : "predicate_matched";
         const notification = notificationFor(
           record,
-          "predicate_matched",
+          reason,
           observedAt,
           observedValue,
         );
@@ -698,7 +733,7 @@ export async function sweepWatches(
           ...record,
           ...heartbeat,
           state: "fired" as const,
-          terminal_reason: "predicate_matched" as const,
+          terminal_reason: reason,
           terminal_at_ms: observedAt,
           observed_value: observedValue,
           notification_pending: true,
@@ -759,6 +794,27 @@ export async function sweepWatches(
           return record;
         }
         if (delivered) {
+          if (
+            record.change === "content" &&
+            typeof notification.observed_value === "string"
+          ) {
+            const {
+              terminal_reason: _terminalReason,
+              terminal_at_ms: _terminalAt,
+              notification_next_attempt_at_ms: _nextAttempt,
+              notification_delivered_at_ms: _previousDelivery,
+              ...persistent
+            } = record;
+            return {
+              ...persistent,
+              state: "armed" as const,
+              fingerprint: notification.observed_value,
+              observed_value: notification.observed_value,
+              notification_pending: false,
+              notification_attempts: 0,
+              notification_delivered_at_ms: observedAt,
+            };
+          }
           return {
             ...record,
             notification_pending: false,
@@ -791,8 +847,11 @@ export async function httpNotifyWatch(
       title: "Declared watch changed",
       body: `Watch ${event.watch_id} for ${event.owner}: ${event.reason}; target=${event.target}`,
       source: "cmuxlayer-watch-spec",
-      priority: event.reason === "predicate_matched" ? "normal" : "high",
-      dedupe_key: `${event.watch_id}:${event.reason}`,
+      priority:
+        event.reason === "predicate_matched" || event.reason === "target_changed"
+          ? "normal"
+          : "high",
+      dedupe_key: `${event.watch_id}:${event.reason}:${event.observed_value ?? ""}`,
     },
     notifyUrl,
   );

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -105,9 +105,20 @@ export interface WatchAgentObservation {
 export interface WatchRegistryOptions {
   registryPath?: string;
   now?: () => number;
+  contentFingerprintIo?: WatchContentFingerprintIo;
   agentObservation?: (
     agentId: string,
   ) => Promise<WatchAgentObservation> | WatchAgentObservation;
+}
+
+export interface WatchContentFingerprintIo {
+  stat: (path: string) => {
+    mtimeNs: bigint;
+    ctimeNs: bigint;
+    ino: bigint;
+    size: bigint;
+  };
+  read: (path: string) => Buffer;
 }
 
 export interface WatchSweepOptions extends WatchRegistryOptions {
@@ -408,10 +419,24 @@ function countMarker(path: string, marker: string): number {
   return count;
 }
 
-function contentFingerprint(path: string): string {
-  const stat = statSync(path, { bigint: true });
-  const digest = createHash("sha256").update(readFileSync(path)).digest("hex");
-  return [digest, stat.mtimeNs, stat.ctimeNs, stat.ino].join(":");
+function contentFingerprint(
+  path: string,
+  io: WatchContentFingerprintIo = {
+    stat: (target) => statSync(target, { bigint: true }),
+    read: (target) => readFileSync(target),
+  },
+): string {
+  const revision = (stat: ReturnType<WatchContentFingerprintIo["stat"]>) =>
+    [stat.mtimeNs, stat.ctimeNs, stat.ino, stat.size].join(":");
+  const before = io.stat(path);
+  let content = io.read(path);
+  let after = io.stat(path);
+  if (revision(before) !== revision(after)) {
+    content = io.read(path);
+    after = io.stat(path);
+  }
+  const digest = createHash("sha256").update(content).digest("hex");
+  return [digest, after.mtimeNs, after.ctimeNs, after.ino, after.size].join(":");
 }
 
 function assertSpec(
@@ -518,7 +543,9 @@ export async function armWatch(
   const watermark = checked.marker
     ? (spec.watermark ?? countMarker(target, checked.marker))
     : spec.watermark;
-  const fingerprint = checked.change ? contentFingerprint(target) : undefined;
+  const fingerprint = checked.change
+    ? contentFingerprint(target, opts.contentFingerprintIo)
+    : undefined;
   const agentObservation =
     checked.targetKind === "agent"
       ? await opts.agentObservation?.(target)
@@ -709,7 +736,7 @@ export async function sweepWatches(
       const observedValue =
         record.target_kind === "file"
           ? record.change === "content"
-            ? contentFingerprint(record.target)
+            ? contentFingerprint(record.target, opts.contentFingerprintIo)
             : countMarker(record.target, record.marker!)
           : (agentObservation?.state ?? "unknown");
       const matched =

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -409,7 +409,9 @@ function countMarker(path: string, marker: string): number {
 }
 
 function contentFingerprint(path: string): string {
-  return createHash("sha256").update(readFileSync(path)).digest("hex");
+  const stat = statSync(path, { bigint: true });
+  const digest = createHash("sha256").update(readFileSync(path)).digest("hex");
+  return [digest, stat.mtimeNs, stat.ctimeNs, stat.ino].join(":");
 }
 
 function assertSpec(

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4496,6 +4496,41 @@ Session ID: ${sessionId}`,
       });
     });
 
+    it("clamps the default Codex registration wait to two seconds", async () => {
+      const resolver = vi.fn(() => null);
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: resolver,
+      });
+      liveSurfaces = [makeSpawnSurface()];
+      let settled = false;
+
+      const pending = engine
+        .spawnAgent({
+          repo: "cmuxlayer",
+          model: "gpt-5.6-sol",
+          cli: "codex",
+          prompt: "Use the product timeout",
+        })
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
+
+      expect(settled).toBe(true);
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        cli_session_id: null,
+        transcript_session_capture_deferred: true,
+      });
+    });
+
     it("does not wait for non-Codex self-registration during spawn", async () => {
       const resolver = vi.fn(() => ({
         session_id: "5b9f4f35-2942-4c8b-b1af-d89d4e36c95d",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3932,7 +3932,12 @@ describe("AgentEngine", () => {
         }
 
         expect(mockClient.newSplit).not.toHaveBeenCalled();
-        expect(engine.getAgentState("agent-user-closed")).toBeNull();
+        expect(engine.getAgentState("agent-user-closed")).toMatchObject({
+          agent_id: "agent-user-closed",
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          state: "error",
+          user_killed: true,
+        });
       },
     );
 
@@ -4159,7 +4164,7 @@ describe("AgentEngine", () => {
       }
     });
 
-    it("uses Codex rollout identity instead of self-registration", async () => {
+    it("uses stable-surface self-registration before Codex rollout inference", async () => {
       const rolloutSessionId = "019fec96-588d-7000-8000-000000000000";
       const registeredSessionId = "aaaaaaaa-bbbb-7ccc-8ddd-eeeeeeeeeeee";
       const rolloutPath =
@@ -4202,13 +4207,13 @@ describe("AgentEngine", () => {
 
       await engine.captureBootSessionId("cmuxlayerCodex-pending-source");
 
-      expect(selfRegistrationResolver).not.toHaveBeenCalled();
-      expect(transcriptResolver).toHaveBeenCalledTimes(1);
-      expect(engine.getAgentState("cmuxlayerCodex-019fec96")).toMatchObject({
-        cli_session_id: rolloutSessionId,
-        cli_session_path: rolloutPath,
+      expect(selfRegistrationResolver).toHaveBeenCalledTimes(1);
+      expect(transcriptResolver).not.toHaveBeenCalled();
+      expect(engine.getAgentState("cmuxlayerCodex-aaaaaaaa")).toMatchObject({
+        cli_session_id: registeredSessionId,
+        cli_session_path: null,
       });
-      expect(engine.getAgentState("cmuxlayerCodex-aaaaaaaa")).toBeNull();
+      expect(engine.getAgentState("cmuxlayerCodex-019fec96")).toBeNull();
     });
 
     it("backfills Codex pid evidence only after rollout identity is durable", async () => {
@@ -12498,8 +12503,16 @@ Session ID: ${sessionId}`,
           expect(killCalls).toContainEqual([pid, 0]);
           expect(killCalls).not.toContainEqual([pid, "SIGKILL"]);
           if (force) {
-            expect(stateMgr.readState("agent-force-recycled-pid")).toBeNull();
-            expect(engine.getAgentState("agent-force-recycled-pid")).toBeNull();
+            expect(stateMgr.readState("agent-force-recycled-pid")).toMatchObject({
+              cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+              state: "done",
+              user_killed: true,
+            });
+            expect(engine.getAgentState("agent-force-recycled-pid")).toMatchObject({
+              cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+              state: "done",
+              user_killed: true,
+            });
           } else {
             expect(stateMgr.readState("agent-force-recycled-pid")).toMatchObject({
               state: "done",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4434,6 +4434,93 @@ Session ID: ${sessionId}`,
       expect(existsSync(stableMarker)).toBe(true);
     });
 
+    it("waits only for Codex self-registration during spawn", async () => {
+      const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";
+      let attempts = 0;
+      const resolver = vi.fn(() => {
+        attempts += 1;
+        return attempts >= 2 ? { session_id: sessionId, path: null } : null;
+      });
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: resolver,
+        spawnSessionCaptureTimeoutMs: 100,
+      });
+      liveSurfaces = [makeSpawnSurface()];
+
+      const pending = engine.spawnAgent({
+        repo: "cmuxlayer",
+        model: "gpt-5.6-sol",
+        cli: "codex",
+        prompt: "Capture Codex registration",
+      });
+      await vi.advanceTimersByTimeAsync(60);
+      const result = await pending;
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        agent_id: result.agent_id,
+        cli_session_id: sessionId,
+      });
+    });
+
+    it("bounds Codex registration capture and leaves lazy fallback enabled", async () => {
+      const resolver = vi.fn(() => null);
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: resolver,
+        spawnSessionCaptureTimeoutMs: 100,
+      });
+      liveSurfaces = [makeSpawnSurface()];
+
+      const pending = engine.spawnAgent({
+        repo: "cmuxlayer",
+        model: "gpt-5.6-sol",
+        cli: "codex",
+        prompt: "Return after the bounded registration window",
+      });
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await pending;
+
+      expect(resolver).toHaveBeenCalledTimes(3);
+      expect(engine.getAgentState(result.agent_id)).toMatchObject({
+        agent_id: result.agent_id,
+        cli_session_id: null,
+        transcript_session_capture_deferred: true,
+      });
+    });
+
+    it("does not wait for non-Codex self-registration during spawn", async () => {
+      const resolver = vi.fn(() => ({
+        session_id: "5b9f4f35-2942-4c8b-b1af-d89d4e36c95d",
+        path: null,
+      }));
+      engine.dispose();
+      const registry = new AgentRegistry(stateMgr, async () => liveSurfaces);
+      engine = new AgentEngine(stateMgr, registry, mockClient, {
+        spawnPreflight: async () => {},
+        sessionIdentityResolver: () => null,
+        selfRegistrationSessionResolver: resolver,
+      });
+      liveSurfaces = [makeSpawnSurface()];
+
+      const result = await engine.spawnAgent({
+        repo: "cmuxlayer",
+        model: "sonnet",
+        cli: "claude",
+        prompt: "Do not block this spawn",
+      });
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(engine.getAgentState(result.agent_id)?.cli_session_id).toBeNull();
+    });
+
     it("preserves a durable transcript path while backfilling pid-only registration evidence", async () => {
       const agentId = "cmuxlayerClaude-durable-path";
       const sessionId = "019d9aa5-93c0-7a52-9c47-9be1f7625f3e";

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -4645,8 +4645,8 @@ Session ID: ${sessionId}`,
           repo: "cmuxlayer",
           cli: "claude",
           state: "booting",
-          surface_id: "surface:existing-final",
-          surface_uuid: surfaceUuid,
+          surface_id: "surface:new-capture",
+          surface_uuid: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
           surface_provenance: "cmuxlayer_spawn",
           cli_session_id: null,
           cli_session_path: null,
@@ -4655,8 +4655,8 @@ Session ID: ${sessionId}`,
       );
       liveSurfaces = [
         {
-          ...makeSurface("surface:existing-final"),
-          id: surfaceUuid,
+          ...makeSurface("surface:new-capture"),
+          id: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
           workspace_ref: "ws:existing-final",
         },
       ];
@@ -4669,6 +4669,8 @@ Session ID: ${sessionId}`,
         cli_session_path: "/durable/claude/existing.jsonl",
         pid: process.pid,
         pid_registered_at: "2026-08-23T11:00:05.000Z",
+        surface_id: "surface:new-capture",
+        surface_uuid: "cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa",
       });
       expect(engine.getAgentState(pendingAgentId)).toMatchObject({
         agent_id: finalAgentId,
@@ -12573,6 +12575,63 @@ Session ID: ${sessionId}`,
       expect(mockClient.listPaneSurfaces).not.toHaveBeenCalled();
       expect(mockClient.sendKey).not.toHaveBeenCalled();
       expect(mockClient.closeSurface).not.toHaveBeenCalled();
+    });
+
+    it("force-closes a live terminal agent before retaining its resumable tombstone", async () => {
+      const agentId = "terminal-live-resumable";
+      const pid = 54321;
+      let processAlive = true;
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation(((targetPid: number, signal?: NodeJS.Signals | 0) => {
+          expect(targetPid).toBe(pid);
+          if (signal === "SIGKILL") {
+            processAlive = false;
+            return true;
+          }
+          if (!processAlive) {
+            throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+          }
+          return true;
+        }) as typeof process.kill);
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "done",
+          surface_id: "surface:terminal-live",
+          surface_uuid: null,
+          cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+          pid,
+          created_at: "2026-08-23T11:00:00.000Z",
+          pid_registered_at: "2026-08-23T11:00:05.000Z",
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:terminal-live")];
+      (mockClient.closeSurface as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          liveSurfaces = [makeSurface("surface:witness")];
+          (mockClient.listPanes as ReturnType<typeof vi.fn>).mockResolvedValue({
+            workspace_ref: "",
+            window_ref: "window:1",
+            panes: [],
+          });
+        },
+      );
+      await engine.getRegistry().reconstitute();
+      execFileSyncMock.mockReturnValue("Sun Aug 23 11:00:02 2026\n");
+
+      try {
+        await engine.stopAgent(agentId, true);
+
+        expect(mockClient.closeSurface).toHaveBeenCalled();
+        expect(stateMgr.readState(agentId)).toMatchObject({
+          state: "done",
+          user_killed: true,
+          pid: null,
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
     });
 
     it("rejects force stop when the pid remains alive after SIGKILL", async () => {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -3587,6 +3587,7 @@ describe("AgentRegistry", () => {
         stateMgr.writeState(
           makeRecord({
             agent_id: `closed-tombstone-${String(index).padStart(2, "0")}`,
+            surface_id: `surface:closed-${index}`,
             state: "done",
             cli_session_id: `session-${index}`,
             user_killed: true,
@@ -3609,6 +3610,18 @@ describe("AgentRegistry", () => {
       expect(retained).not.toContain("closed-tombstone-01");
       expect(stateMgr.readState("closed-tombstone-00")).toBeNull();
       expect(stateMgr.readState("closed-tombstone-51")).not.toBeNull();
+      expect(
+        stateMgr.getSurfaceSessionIndex().lookup({
+          workspace_id: null,
+          surface_id: "surface:closed-0",
+        }),
+      ).toBeNull();
+      expect(
+        stateMgr.getSurfaceSessionIndex().lookup({
+          workspace_id: null,
+          surface_id: "surface:closed-51",
+        }),
+      ).toMatchObject({ agent_id: "closed-tombstone-51" });
     });
   });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -3838,7 +3838,7 @@ describe("AgentRegistry", () => {
       expect(registry.get("uuid-agent-on-legacy-topology")).not.toBeNull();
     });
 
-    it("evicts an unclosed recoverable ghost when only a terminal same-seat record has a surface", async () => {
+    it("keeps a recoverable seat ghost when only a terminal same-seat record has a surface", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -3873,11 +3873,15 @@ describe("AgentRegistry", () => {
 
       await expect(
         registry.evictSurfaceless({ confirmationMs: 0 }),
-      ).resolves.toEqual(["coachClaude"]);
-      expect(registry.get("coachClaude")).toBeNull();
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        state: "error",
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
-    it("evicts an unclosed recoverable ghost when a stale same-seat record has only a shell surface", async () => {
+    it("keeps a recoverable seat ghost when a stale working same-seat record has only a shell surface", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -3941,8 +3945,12 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual(["coachClaude"]);
-      expect(registry.get("coachClaude")).toBeNull();
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        state: "error",
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
     it("evicts a confirmed recoverable ghost when discovery proves the live same-seat agent", async () => {
@@ -4012,7 +4020,7 @@ describe("AgentRegistry", () => {
       expect(registry.get("live-coach-record")).not.toBeNull();
     });
 
-    it("evicts an unclosed recoverable ghost when the live sibling resolves to another seat", async () => {
+    it("keeps a recoverable seat ghost when the live sibling surface resolves to another seat", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -4074,11 +4082,14 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual(["coachClaude"]);
-      expect(registry.get("coachClaude")).toBeNull();
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
-    it("evicts an unclosed recoverable ghost when seat classification returns a mismatch", async () => {
+    it("keeps a recoverable seat ghost when seat classification returns a mismatch", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -4141,11 +4152,14 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual(["coachClaude"]);
-      expect(registry.get("coachClaude")).toBeNull();
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
-    it("evicts an unclosed recoverable ghost when the observer epoch changes after proof", async () => {
+    it("keeps a recoverable seat ghost when the observer epoch changes after proof", async () => {
       let observerEpoch = "cmux:/tmp/test.sock@epoch-1";
       stateMgr.writeState(
         makeRecord({
@@ -4209,8 +4223,11 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual(["coachClaude"]);
-      expect(registry.get("coachClaude")).toBeNull();
+      ).resolves.toEqual([]);
+      expect(registry.get("coachClaude")).toMatchObject({
+        cli_session_id: "recover-me",
+        crash_recover: true,
+      });
     });
 
     it("resets the absence window when the same surface is observed live", async () => {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -3577,6 +3577,39 @@ describe("AgentRegistry", () => {
         pid: process.pid,
       });
     });
+
+    it("keeps only the newest fifty resumable close tombstones", async () => {
+      const registry = new AgentRegistry(stateMgr, async () => [
+        makeSurface("surface:witness"),
+      ]);
+      for (let index = 0; index < 52; index += 1) {
+        const timestamp = new Date(Date.UTC(2026, 7, 25, 10, 0, index));
+        stateMgr.writeState(
+          makeRecord({
+            agent_id: `closed-tombstone-${String(index).padStart(2, "0")}`,
+            state: "done",
+            cli_session_id: `session-${index}`,
+            user_killed: true,
+            pid: null,
+            created_at: timestamp.toISOString(),
+            updated_at: timestamp.toISOString(),
+          }),
+        );
+      }
+
+      await registry.reconstitute();
+
+      const retained = registry
+        .list()
+        .filter((record) => record.agent_id.startsWith("closed-tombstone-"))
+        .map((record) => record.agent_id)
+        .sort();
+      expect(retained).toHaveLength(50);
+      expect(retained).not.toContain("closed-tombstone-00");
+      expect(retained).not.toContain("closed-tombstone-01");
+      expect(stateMgr.readState("closed-tombstone-00")).toBeNull();
+      expect(stateMgr.readState("closed-tombstone-51")).not.toBeNull();
+    });
   });
 
   describe("purgeTerminal", () => {
@@ -3805,7 +3838,7 @@ describe("AgentRegistry", () => {
       expect(registry.get("uuid-agent-on-legacy-topology")).not.toBeNull();
     });
 
-    it("keeps a recoverable seat ghost when only a terminal same-seat record has a surface", async () => {
+    it("evicts an unclosed recoverable ghost when only a terminal same-seat record has a surface", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -3840,15 +3873,11 @@ describe("AgentRegistry", () => {
 
       await expect(
         registry.evictSurfaceless({ confirmationMs: 0 }),
-      ).resolves.toEqual([]);
-      expect(registry.get("coachClaude")).toMatchObject({
-        state: "error",
-        cli_session_id: "recover-me",
-        crash_recover: true,
-      });
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
     });
 
-    it("keeps a recoverable seat ghost when a stale working same-seat record has only a shell surface", async () => {
+    it("evicts an unclosed recoverable ghost when a stale same-seat record has only a shell surface", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -3912,12 +3941,8 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual([]);
-      expect(registry.get("coachClaude")).toMatchObject({
-        state: "error",
-        cli_session_id: "recover-me",
-        crash_recover: true,
-      });
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
     });
 
     it("evicts a confirmed recoverable ghost when discovery proves the live same-seat agent", async () => {
@@ -3987,7 +4012,7 @@ describe("AgentRegistry", () => {
       expect(registry.get("live-coach-record")).not.toBeNull();
     });
 
-    it("keeps a recoverable seat ghost when the live sibling surface resolves to another seat", async () => {
+    it("evicts an unclosed recoverable ghost when the live sibling resolves to another seat", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -4049,14 +4074,11 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual([]);
-      expect(registry.get("coachClaude")).toMatchObject({
-        cli_session_id: "recover-me",
-        crash_recover: true,
-      });
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
     });
 
-    it("keeps a recoverable seat ghost when seat classification returns a mismatch", async () => {
+    it("evicts an unclosed recoverable ghost when seat classification returns a mismatch", async () => {
       stateMgr.writeState(
         makeRecord({
           agent_id: "coachClaude",
@@ -4119,14 +4141,11 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual([]);
-      expect(registry.get("coachClaude")).toMatchObject({
-        cli_session_id: "recover-me",
-        crash_recover: true,
-      });
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
     });
 
-    it("keeps a recoverable seat ghost when the observer epoch changes after proof", async () => {
+    it("evicts an unclosed recoverable ghost when the observer epoch changes after proof", async () => {
       let observerEpoch = "cmux:/tmp/test.sock@epoch-1";
       stateMgr.writeState(
         makeRecord({
@@ -4190,11 +4209,8 @@ describe("AgentRegistry", () => {
           confirmationMs: 0,
           liveSeatProof: proof,
         }),
-      ).resolves.toEqual([]);
-      expect(registry.get("coachClaude")).toMatchObject({
-        cli_session_id: "recover-me",
-        crash_recover: true,
-      });
+      ).resolves.toEqual(["coachClaude"]);
+      expect(registry.get("coachClaude")).toBeNull();
     });
 
     it("resets the absence window when the same surface is observed live", async () => {

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -3,6 +3,7 @@ import {
   isValidTransition,
   assertValidTransition,
   generateAgentId,
+  shouldRetainForExplicitResume,
   VALID_TRANSITIONS,
   type AgentState,
 } from "../src/agent-types.js";
@@ -34,6 +35,19 @@ describe("VALID_TRANSITIONS", () => {
 
   it("error can only go to creating (restart)", () => {
     expect(VALID_TRANSITIONS.error).toEqual(["creating"]);
+  });
+});
+
+describe("shouldRetainForExplicitResume", () => {
+  it("retains an explicit-resume failure with a captured session", () => {
+    expect(
+      shouldRetainForExplicitResume({
+        state: "error",
+        user_killed: false,
+        cli_session_id: "session-to-retry",
+        error: "Explicit resume failed: harness unavailable",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -552,13 +552,15 @@ describe("CmuxLayerDaemon", () => {
     context.dispose();
   });
 
-  it("forwards a custom self-registration resolver into its lazy context", async () => {
+  it("forwards custom self-registration readers into its lazy context", async () => {
     const selfRegistrationSessionResolver = vi.fn(() => null);
+    const selfRegistrationSessionLookup = vi.fn(() => null);
     const daemon = new CmuxLayerDaemon({
       exec: createListSurfacesExec(),
       stateDir: stateDir("custom-self-registration-resolver-state"),
       skipAgentLifecycle: true,
       selfRegistrationSessionResolver,
+      selfRegistrationSessionLookup,
     });
 
     const context = await (
@@ -571,6 +573,9 @@ describe("CmuxLayerDaemon", () => {
 
     expect(context.selfRegistrationSessionResolver).toBe(
       selfRegistrationSessionResolver,
+    );
+    expect(context.selfRegistrationSessionLookup).toBe(
+      selfRegistrationSessionLookup,
     );
     context.dispose();
   });

--- a/tests/entry-watch-spec.test.ts
+++ b/tests/entry-watch-spec.test.ts
@@ -25,6 +25,7 @@ vi.mock("../src/fleet-sidebar.js", () => ({
   FleetSidebarPublisher: class {},
 }));
 vi.mock("../src/self-registration.js", () => ({
+  makeSelfRegistrationSessionLookup: vi.fn(() => null),
   makeSelfRegistrationSessionResolver: vi.fn(() => null),
 }));
 

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -290,6 +290,29 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     expect(result.source).toBe("sweep");
     expect(result.state).toBe("error");
     expect(result.agent?.state).toBe("error");
+  });
+
+  it("returns a synchronous content-watch match before persistent re-arm hides it", async () => {
+    vi.useFakeTimers();
+    const reportPath = join(TEST_DIR, "report.md");
+    writeFileSync(reportPath, "first", "utf8");
+    setTimeout(() => writeFileSync(reportPath, "second", "utf8"), 60);
+
+    const pending = engine.waitForWatch(
+      {
+        owner: "cmuxlayerClaude-parent",
+        target: reportPath,
+        change: "content",
+        deadline: 60_000,
+      },
+      3_000,
+    );
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await pending;
+
+    expect(result.matched).toBe(true);
+    expect(result.elapsed).toBeLessThan(3_000);
+    expect(result.watch.state).toBe("armed");
   });
 
   it("does not report a match from a record state the screen contradicts", async () => {

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -264,6 +264,34 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     },
   );
 
+  it("aligns the embedded agent when a polling wait later fails fast", async () => {
+    vi.useFakeTimers();
+    stateMgr.writeState(makeRecord({ state: "working" }));
+    await engine.getRegistry().reconstitute();
+    let observedState: "working" | "error" = "working";
+    engine.setLiveStateResolver((agent) => ({
+      state: observedState,
+      source: "screen",
+      registry_state: agent.state,
+      screen_state: observedState,
+      stale_registry_state: observedState !== agent.state,
+    }));
+
+    const pending = engine.waitFor(
+      "voicelayerClaude-2ac0d960",
+      "idle",
+      1_500,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    observedState = "error";
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await pending;
+
+    expect(result.source).toBe("sweep");
+    expect(result.state).toBe("error");
+    expect(result.agent?.state).toBe("error");
+  });
+
   it("does not report a match from a record state the screen contradicts", async () => {
     vi.useFakeTimers();
     stateMgr.writeState(makeRecord({ state: "idle" }));

--- a/tests/f1b-wait-for-watch-live-state.test.ts
+++ b/tests/f1b-wait-for-watch-live-state.test.ts
@@ -239,6 +239,31 @@ describe("F1b #473 — wait_for terminates on live state, never on a contradicte
     expect(result.error).toBe("Agent has already completed");
   });
 
+  it.each(["done", "error"] as const)(
+    "aligns the embedded agent when live evidence short-circuits as %s",
+    async (liveState) => {
+      stateMgr.writeState(makeRecord({ state: "working" }));
+      await engine.getRegistry().reconstitute();
+      engine.setLiveStateResolver((agent) => ({
+        state: liveState,
+        source: "screen",
+        registry_state: agent.state,
+        screen_state: liveState,
+        stale_registry_state: true,
+      }));
+
+      const result = await engine.waitFor(
+        "voicelayerClaude-2ac0d960",
+        "idle",
+        1_500,
+      );
+
+      expect(result.source).toBe("immediate");
+      expect(result.state).toBe(liveState);
+      expect(result.agent?.state).toBe(liveState);
+    },
+  );
+
   it("does not report a match from a record state the screen contradicts", async () => {
     vi.useFakeTimers();
     stateMgr.writeState(makeRecord({ state: "idle" }));

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -394,7 +394,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const afterFirstWake = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
     writeFileSync(
       child.report_path,
-      `STATUS: BLOCKED\nsecond stop\n${child.done_marker}\n`,
+      `STATUS: DONE\nfirst stop\n${child.done_marker}\n`,
       "utf8",
     );
     await engine.sweepWatchesBestEffort();

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -335,6 +335,8 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       }
       return baseExec(cmd, args);
     });
+    let watchNow = 1_000;
+    const unavailableExternalNotify = vi.fn().mockResolvedValue(false);
     server = createServer(
       withTestSurfaceObserver({
         exec,
@@ -342,6 +344,8 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         disableSpawnPreflight: true,
         inboxBaseDir: inboxDir,
         watchRegistryPath,
+        watchRegistryNow: () => watchNow,
+        watchNotify: unavailableExternalNotify,
       }),
     );
     let engine = server._registeredTools.interact._engine;
@@ -370,6 +374,8 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         disableSpawnPreflight: true,
         inboxBaseDir: inboxDir,
         watchRegistryPath,
+        watchRegistryNow: () => watchNow,
+        watchNotify: unavailableExternalNotify,
       }),
     );
     await server._registeredTools.list_agents.handler({}, {} as any);
@@ -392,6 +398,19 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ).toBe(true);
 
     const afterFirstWake = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    watchNow = 2_000;
+    await engine.sweepWatchesBestEffort();
+    const retryCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      afterFirstWake,
+    );
+    expect(
+      retryCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(child.report_path),
+        ),
+      ),
+    ).toBe(false);
+
     writeFileSync(
       child.report_path,
       `STATUS: DONE\nfirst stop\n${child.done_marker}\n`,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -301,7 +301,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(detail.done_marker).toBe(parsed.done_marker);
   });
 
-  it("automatically arms the parent's persistent watch on the child report", async () => {
+  it("wakes the parent for every report revision even when the terminal marker is unchanged", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -357,8 +357,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       expect.objectContaining({
         owner: parent.agent_id,
         target: child.report_path,
-        marker: child.done_marker,
-        watermark: 0,
+        change: "content",
         state: "armed",
       }),
     ]);
@@ -376,7 +375,11 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     await server._registeredTools.list_agents.handler({}, {} as any);
     engine = server._registeredTools.interact._engine;
     const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
-    appendFileSync(child.report_path, `${child.done_marker}\n`, "utf8");
+    writeFileSync(
+      child.report_path,
+      `STATUS: DONE\nfirst stop\n${child.done_marker}\n`,
+      "utf8",
+    );
     await engine.sweepWatchesBestEffort();
     const afterCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
     expect(
@@ -388,19 +391,33 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       ),
     ).toBe(true);
 
-    const rearmed = await engine.armWatch({
-      owner: parent.agent_id,
-      target: child.report_path,
-      marker: child.done_marker,
-      deadline: Number.MAX_SAFE_INTEGER,
-    });
-    expect(rearmed.watermark).toBe(1);
+    const afterFirstWake = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    writeFileSync(
+      child.report_path,
+      `STATUS: BLOCKED\nsecond stop\n${child.done_marker}\n`,
+      "utf8",
+    );
     await engine.sweepWatchesBestEffort();
+    const secondWakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      afterFirstWake,
+    );
     expect(
-      readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
-        (watch) => watch.watch_id === rearmed.watch_id,
-      )?.state,
-    ).toBe("armed");
+      secondWakeCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(child.report_path),
+        ),
+      ),
+    ).toBe(true);
+
+    expect(readWatchRegistry({ registryPath: watchRegistryPath }).watches).toEqual([
+      expect.objectContaining({
+        owner: parent.agent_id,
+        target: child.report_path,
+        change: "content",
+        state: "armed",
+        notification_pending: false,
+      }),
+    ]);
   });
 
   it("does not describe a missing report target as a done marker and preserves the reason-aware notifier", async () => {

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -251,9 +251,7 @@ describe("revive on purpose (#492)", () => {
 
     expect(mockClient.newSplit).not.toHaveBeenCalled();
     expect(mockClient.newSurface).not.toHaveBeenCalled();
-    const state = engine.getAgentState("cmuxlayerCodex-revive");
-    expect(state?.state).toBe("error");
-    expect(state?.error).toContain("disappeared");
+    expect(engine.getAgentState("cmuxlayerCodex-revive")).toBeNull();
   });
 
   it("does not revive an unexpected CLI death; it records the terminal state", async () => {
@@ -279,7 +277,7 @@ describe("revive on purpose (#492)", () => {
     expect(state?.error).toContain("CLI exited");
   });
 
-  it("keeps a CLI death resumable by id after its pane is closed", async () => {
+  it("does not retain an unclosed CLI-death row after its pane is closed", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(makeRecord({ workspace_id: "ws:1" }));
     liveSurfaces = [
@@ -297,9 +295,10 @@ describe("revive on purpose (#492)", () => {
     liveSurfaces = [{ ...makeSurface("surface:other"), workspace_ref: "ws:1" }];
     await runConfirmedSurfaceAbsenceSweep();
 
-    const resumed = await engine.resumeAgent("cmuxlayerCodex-revive");
-    expect(resumed.agent_id).toBe("cmuxlayerCodex-revive");
-    expect(resumed.surface_id).toBe("surface:new");
+    expect(engine.getAgentState("cmuxlayerCodex-revive")).toBeNull();
+    await expect(
+      engine.resumeAgent("cmuxlayerCodex-revive"),
+    ).rejects.toThrow("Agent not found");
   });
 
   it("explicit resume by agent id works when the session artifact exists", async () => {
@@ -753,7 +752,7 @@ describe("revive on purpose (#492)", () => {
     expect(mockClient.send).not.toHaveBeenCalled();
   });
 
-  it("keeps a recoverable terminal row when its stale process is gone", async () => {
+  it("evicts an unclosed terminal row when its stale process is gone", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(
       makeRecord({
@@ -767,12 +766,14 @@ describe("revive on purpose (#492)", () => {
       throw Object.assign(new Error("no such process"), { code: "ESRCH" });
     });
 
-    expect(engine.evictDeadProcessAgents()).toEqual([]);
-    expect(stateMgr.readState("cmuxlayerCodex-revive")).not.toBeNull();
+    expect(engine.evictDeadProcessAgents()).toEqual([
+      "cmuxlayerCodex-revive",
+    ]);
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).toBeNull();
     killSpy.mockRestore();
   });
 
-  it("keeps a recoverable legacy row during startup purge without surface ownership", async () => {
+  it("purges an unclosed legacy row during startup purge", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(
       makeRecord({
@@ -786,7 +787,9 @@ describe("revive on purpose (#492)", () => {
     });
     await registry.reconstitute();
 
-    expect(registry.purgeAllTerminal()).toEqual([]);
-    expect(stateMgr.readState("cmuxlayerCodex-revive")).not.toBeNull();
+    expect(registry.purgeAllTerminal()).toEqual([
+      expect.objectContaining({ agent_id: "cmuxlayerCodex-revive" }),
+    ]);
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).toBeNull();
   });
 });

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -323,6 +323,186 @@ describe("revive on purpose (#492)", () => {
     expect(sends.some((text) => text.includes(CODEX_SESSION))).toBe(true);
   });
 
+  it("retains a resumable tombstone when a terminal agent is force-closed", async () => {
+    writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
+    stateMgr.writeState(
+      makeRecord({
+        state: "done",
+        workspace_id: "ws:1",
+        surface_id: "surface:old",
+      }),
+    );
+    await engine.getRegistry().reconstitute();
+
+    await engine.stopAgent("cmuxlayerCodex-revive", true);
+
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).toMatchObject({
+      agent_id: "cmuxlayerCodex-revive",
+      cli_session_id: CODEX_SESSION,
+      state: "done",
+      user_killed: true,
+    });
+    expect(registry.purgeAllTerminal()).toEqual([]);
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).not.toBeNull();
+    const resumed = await engine.resumeAgent("cmuxlayerCodex-revive");
+    expect(resumed).toMatchObject({
+      agent_id: "cmuxlayerCodex-revive",
+      surface_id: "surface:new",
+    });
+  });
+
+  it("resumes by the raw harness session id and preserves the public agent id", async () => {
+    writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
+    stateMgr.writeState(
+      makeRecord({
+        state: "done",
+        workspace_id: "ws:1",
+        surface_id: "surface:old",
+      }),
+    );
+    await engine.getRegistry().reconstitute();
+
+    const resumed = await engine.resumeAgent(CODEX_SESSION);
+
+    expect(resumed).toMatchObject({
+      agent_id: "cmuxlayerCodex-revive",
+      surface_id: "surface:new",
+    });
+  });
+
+  it("recovers a missing captured id from the session registry before raw-id resume", async () => {
+    writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: (sessionId) =>
+        sessionId === CODEX_SESSION
+          ? {
+              session_id: CODEX_SESSION,
+              surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+              cwd: "/Users/e/Gits/cmuxlayer/.worktrees/run3",
+              pid: null,
+              cli: "codex",
+              launcher: "cmuxlayerCodex",
+              session_path: null,
+              ts: Date.now(),
+            }
+          : null,
+      inboxOpts: { baseDir: TEST_DIR },
+    });
+    stateMgr.writeState(
+      makeRecord({
+        state: "done",
+        workspace_id: "ws:1",
+        surface_id: "surface:old",
+        surface_uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        cli_session_id: null,
+      }),
+    );
+    await registry.reconstitute();
+
+    const resumed = await engine.resumeAgent(CODEX_SESSION);
+
+    expect(resumed.agent_id).toBe("cmuxlayerCodex-revive");
+    expect(stateMgr.readState("cmuxlayerCodex-revive")?.cli_session_id).toBe(
+      CODEX_SESSION,
+    );
+  });
+
+  it("prefers an exact registration surface over same-cwd fallback records", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: () => ({
+        session_id: CODEX_SESSION,
+        surface_uuid: "exact-surface-uuid",
+        cwd: "/shared/worktree",
+        pid: null,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: null,
+        ts: Date.now(),
+      }),
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "exact-agent",
+        cli_session_id: null,
+        surface_uuid: "exact-surface-uuid",
+        launch_cwd: "/shared/worktree",
+      }),
+    );
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "same-cwd-agent",
+        cli_session_id: null,
+        surface_uuid: "different-surface-uuid",
+        launch_cwd: "/shared/worktree",
+      }),
+    );
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)?.agent_id).toBe(
+      "exact-agent",
+    );
+  });
+
+  it("rejects ambiguous same-cwd registration fallback records", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: () => ({
+        session_id: CODEX_SESSION,
+        surface_uuid: "missing-surface-uuid",
+        cwd: "/shared/worktree",
+        pid: null,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: null,
+        ts: Date.now(),
+      }),
+    });
+    for (const agentId of ["first-cwd-agent", "second-cwd-agent"]) {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          cli_session_id: null,
+          surface_uuid: `${agentId}-surface`,
+          launch_cwd: "/shared/worktree",
+        }),
+      );
+    }
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
+  });
+
+  it("captures the full harness session id before spawn returns", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionResolver: (agent) => ({
+        session_id: CODEX_SESSION,
+        path: "/rollout/codex.jsonl",
+        pid: null,
+        pid_registered_at: null,
+      }),
+      inboxOpts: { baseDir: TEST_DIR },
+    });
+
+    const spawned = await engine.spawnAgent({
+      repo: "cmuxlayer",
+      cli: "codex",
+      prompt: "capture my real harness id",
+    });
+
+    expect(stateMgr.readState(spawned.agent_id)?.cli_session_id).toBe(
+      CODEX_SESSION,
+    );
+  });
+
   it("restores the persisted caller title when resuming an agent", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -499,6 +499,35 @@ describe("revive on purpose (#492)", () => {
     expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
   });
 
+  it("rejects a raw-session registration that matches only by cwd", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: () => ({
+        session_id: CODEX_SESSION,
+        surface_uuid: "missing-surface-uuid",
+        cwd: "/shared/worktree",
+        pid: null,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: null,
+        ts: Date.now(),
+      }),
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "cwd-only-agent",
+        state: "done",
+        cli_session_id: null,
+        surface_uuid: "different-surface-uuid",
+        launch_cwd: "/shared/worktree",
+      }),
+    );
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
+  });
+
   it("does not mutate an active fallback match during raw-id resolution", async () => {
     engine.dispose();
     engine = new AgentEngine(stateMgr, registry, mockClient, {

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -333,6 +333,12 @@ describe("revive on purpose (#492)", () => {
       }),
     );
     await engine.getRegistry().reconstitute();
+    liveSurfaces = [
+      {
+        ...makeSurface("surface:witness"),
+        workspace_ref: "ws:witness",
+      },
+    ];
 
     await engine.stopAgent("cmuxlayerCodex-revive", true);
 
@@ -368,6 +374,20 @@ describe("revive on purpose (#492)", () => {
       agent_id: "cmuxlayerCodex-revive",
       surface_id: "surface:new",
     });
+  });
+
+  it("rejects duplicate persisted owners of one raw harness session", async () => {
+    for (const agentId of ["duplicate-session-a", "duplicate-session-b"]) {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "done",
+          cli_session_id: CODEX_SESSION,
+        }),
+      );
+    }
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
   });
 
   it("recovers a missing captured id from the session registry before raw-id resume", async () => {
@@ -429,6 +449,7 @@ describe("revive on purpose (#492)", () => {
     stateMgr.writeState(
       makeRecord({
         agent_id: "exact-agent",
+        state: "done",
         cli_session_id: null,
         surface_uuid: "exact-surface-uuid",
         launch_cwd: "/shared/worktree",
@@ -476,6 +497,41 @@ describe("revive on purpose (#492)", () => {
     }
 
     expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
+  });
+
+  it("does not mutate an active fallback match during raw-id resolution", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: () => ({
+        session_id: CODEX_SESSION,
+        surface_uuid: "active-surface-uuid",
+        cwd: "/shared/worktree",
+        pid: null,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: "/rollout/raw.jsonl",
+        ts: Date.now(),
+      }),
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "active-agent",
+        state: "working",
+        cli_session_id: null,
+        cli_session_path: null,
+        surface_uuid: "active-surface-uuid",
+        launch_cwd: "/shared/worktree",
+      }),
+    );
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
+    expect(stateMgr.readState("active-agent")).toMatchObject({
+      cli_session_id: null,
+      cli_session_path: null,
+      state: "working",
+    });
   });
 
   it("captures the full harness session id before spawn returns", async () => {

--- a/tests/revive-on-purpose.test.ts
+++ b/tests/revive-on-purpose.test.ts
@@ -251,7 +251,9 @@ describe("revive on purpose (#492)", () => {
 
     expect(mockClient.newSplit).not.toHaveBeenCalled();
     expect(mockClient.newSurface).not.toHaveBeenCalled();
-    expect(engine.getAgentState("cmuxlayerCodex-revive")).toBeNull();
+    const state = engine.getAgentState("cmuxlayerCodex-revive");
+    expect(state?.state).toBe("error");
+    expect(state?.error).toContain("disappeared");
   });
 
   it("does not revive an unexpected CLI death; it records the terminal state", async () => {
@@ -277,7 +279,7 @@ describe("revive on purpose (#492)", () => {
     expect(state?.error).toContain("CLI exited");
   });
 
-  it("does not retain an unclosed CLI-death row after its pane is closed", async () => {
+  it("keeps a CLI death resumable by id after its pane is closed", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(makeRecord({ workspace_id: "ws:1" }));
     liveSurfaces = [
@@ -295,10 +297,9 @@ describe("revive on purpose (#492)", () => {
     liveSurfaces = [{ ...makeSurface("surface:other"), workspace_ref: "ws:1" }];
     await runConfirmedSurfaceAbsenceSweep();
 
-    expect(engine.getAgentState("cmuxlayerCodex-revive")).toBeNull();
-    await expect(
-      engine.resumeAgent("cmuxlayerCodex-revive"),
-    ).rejects.toThrow("Agent not found");
+    const resumed = await engine.resumeAgent("cmuxlayerCodex-revive");
+    expect(resumed.agent_id).toBe("cmuxlayerCodex-revive");
+    expect(resumed.surface_id).toBe("surface:new");
   });
 
   it("explicit resume by agent id works when the session artifact exists", async () => {
@@ -527,6 +528,56 @@ describe("revive on purpose (#492)", () => {
     expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
   });
 
+  it("rejects a stale registration that matches a newer record only by reused pid and cwd", async () => {
+    engine.dispose();
+    engine = new AgentEngine(stateMgr, registry, mockClient, {
+      spawnPreflight: async () => {},
+      sessionIdentityResolver: () => null,
+      selfRegistrationSessionLookup: () => ({
+        session_id: CODEX_SESSION,
+        surface_uuid: "long-gone-surface",
+        cwd: "/shared/worktree",
+        pid: 4242,
+        cli: "codex",
+        launcher: "cmuxlayerCodex",
+        session_path: null,
+        ts: 1_700_000_000_000,
+      }),
+    });
+    stateMgr.writeState(
+      makeRecord({
+        agent_id: "newer-unrelated-agent",
+        state: "done",
+        cli_session_id: null,
+        surface_uuid: "new-surface",
+        launch_cwd: "/shared/worktree",
+        pid: 4242,
+        created_at: "2026-08-25T10:00:00.000Z",
+      }),
+    );
+
+    expect(engine.resolveResumeAgent(CODEX_SESSION)).toBeNull();
+    expect(stateMgr.readState("newer-unrelated-agent")?.cli_session_id).toBeNull();
+  });
+
+  it("clears prior-run done and halt evidence when reopening for resume", () => {
+    stateMgr.writeState(
+      makeRecord({
+        state: "done",
+        task_done_candidate_at: "2026-08-24T10:00:00.000Z",
+        task_done_detected_at: "2026-08-24T10:00:05.000Z",
+        halt_last_active_at: "2026-08-24T10:00:06.000Z",
+      }),
+    );
+
+    expect(stateMgr.reopenForResume("cmuxlayerCodex-revive")).toMatchObject({
+      state: "creating",
+      task_done_candidate_at: null,
+      task_done_detected_at: null,
+      halt_last_active_at: null,
+    });
+  });
+
   it("does not mutate an active fallback match during raw-id resolution", async () => {
     engine.dispose();
     engine = new AgentEngine(stateMgr, registry, mockClient, {
@@ -752,7 +803,7 @@ describe("revive on purpose (#492)", () => {
     expect(mockClient.send).not.toHaveBeenCalled();
   });
 
-  it("evicts an unclosed terminal row when its stale process is gone", async () => {
+  it("retains a recoverable crash row when its stale process is gone", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(
       makeRecord({
@@ -766,14 +817,12 @@ describe("revive on purpose (#492)", () => {
       throw Object.assign(new Error("no such process"), { code: "ESRCH" });
     });
 
-    expect(engine.evictDeadProcessAgents()).toEqual([
-      "cmuxlayerCodex-revive",
-    ]);
-    expect(stateMgr.readState("cmuxlayerCodex-revive")).toBeNull();
+    expect(engine.evictDeadProcessAgents()).toEqual([]);
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).not.toBeNull();
     killSpy.mockRestore();
   });
 
-  it("purges an unclosed legacy row during startup purge", async () => {
+  it("retains a recoverable legacy crash row during startup purge", async () => {
     writeCodexSessionArtifact(harnessHome, CODEX_SESSION);
     stateMgr.writeState(
       makeRecord({
@@ -787,9 +836,7 @@ describe("revive on purpose (#492)", () => {
     });
     await registry.reconstitute();
 
-    expect(registry.purgeAllTerminal()).toEqual([
-      expect.objectContaining({ agent_id: "cmuxlayerCodex-revive" }),
-    ]);
-    expect(stateMgr.readState("cmuxlayerCodex-revive")).toBeNull();
+    expect(registry.purgeAllTerminal()).toEqual([]);
+    expect(stateMgr.readState("cmuxlayerCodex-revive")).not.toBeNull();
   });
 });

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -96,7 +96,7 @@ describe("copyBufferTail", () => {
 });
 
 describe("makeSelfRegistrationSessionLookup", () => {
-  it("returns the newest exact raw session-id registration", () => {
+  it("returns the last-written exact raw session-id registration, regardless of ts", () => {
     const lookup = makeSelfRegistrationSessionLookup({
       registryPath: "/fake/registry.jsonl",
       readFile: () =>

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -8,6 +8,7 @@ import {
   boundPendingRegistrationLine,
   copyBufferTail,
   makeSelfRegistrationSessionResolver,
+  makeSelfRegistrationSessionLookup,
   parseSelfRegistrationLines,
   resolveSessionRegistryPath,
   SESSION_REGISTRATION_MAX_CANDIDATES_PER_SURFACE,
@@ -91,6 +92,37 @@ describe("copyBufferTail", () => {
     expect(tail.buffer.byteLength).toBe(tail.byteLength);
     source.fill(0x63);
     expect(tail).toEqual(Buffer.alloc(64, 0x62));
+  });
+});
+
+describe("makeSelfRegistrationSessionLookup", () => {
+  it("returns the newest exact raw session-id registration", () => {
+    const lookup = makeSelfRegistrationSessionLookup({
+      registryPath: "/fake/registry.jsonl",
+      readFile: () =>
+        jsonl(
+          {
+            session_id: "raw-session-id",
+            ts: 10,
+            cwd: "/old",
+          },
+          {
+            session_id: "different-session",
+            ts: 30,
+          },
+          {
+            session_id: "raw-session-id",
+            ts: 20,
+            cwd: "/new",
+          },
+        ),
+    });
+
+    expect(lookup("RAW-SESSION-ID")).toMatchObject({
+      session_id: "raw-session-id",
+      cwd: "/new",
+      ts: 20,
+    });
   });
 });
 

--- a/tests/self-registration.test.ts
+++ b/tests/self-registration.test.ts
@@ -112,7 +112,7 @@ describe("makeSelfRegistrationSessionLookup", () => {
           },
           {
             session_id: "raw-session-id",
-            ts: 20,
+            ts: 5,
             cwd: "/new",
           },
         ),
@@ -121,7 +121,7 @@ describe("makeSelfRegistrationSessionLookup", () => {
     expect(lookup("RAW-SESSION-ID")).toMatchObject({
       session_id: "raw-session-id",
       cwd: "/new",
-      ts: 20,
+      ts: 5,
     });
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -12318,6 +12318,7 @@ codex>
     ["stop_agent", false],
     ["kill", false],
     ["stop_agent", true],
+    ["kill", true],
   ] as const)(
     "%s force=%s refuses manual mode on a freshly moved UUID route before mutation",
     async (toolName, force) => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2447,12 +2447,12 @@ describe("agent lifecycle tool handlers", () => {
       {
         owner: parentId,
         target: expected.report_path,
-        marker: expected.done_marker,
+        change: "content",
         deadline: Number.MAX_SAFE_INTEGER,
       },
       { registryPath: watchRegistryPath },
     );
-    appendFileSync(expected.report_path, `${expected.done_marker}\n`, "utf8");
+    appendFileSync(expected.report_path, "first revision\n", "utf8");
     await sweepWatches({
       registryPath: watchRegistryPath,
       notify: async () => true,
@@ -2461,7 +2461,7 @@ describe("agent lifecycle tool handlers", () => {
       readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
         (watch) => watch.watch_id === oldWatch.watch_id,
       )?.state,
-    ).toBe("fired");
+    ).toBe("armed");
     const exec = makeLifecycleExec();
     const server = createTrackedServer({
       exec,
@@ -2505,22 +2505,18 @@ describe("agent lifecycle tool handlers", () => {
       ) as Record<string, unknown>;
       expect(detail.report_path).toBe(expected.report_path);
       expect(detail.done_marker).toBe(expected.done_marker);
-      expect(
-        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
-      ).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            watch_id: oldWatch.watch_id,
-            state: "fired",
-          }),
-          expect.objectContaining({
-            owner: parentId,
-            target: expected.report_path,
-            change: "content",
-            state: "armed",
-          }),
-        ]),
+      const reportWatches = readWatchRegistry({
+        registryPath: watchRegistryPath,
+      }).watches.filter(
+        (watch) =>
+          watch.owner === parentId && watch.target === expected.report_path,
       );
+      expect(reportWatches).toHaveLength(1);
+      expect(reportWatches[0]).toMatchObject({
+        watch_id: oldWatch.watch_id,
+        change: "content",
+        state: "armed",
+      });
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }
@@ -12318,9 +12314,13 @@ codex>
     },
   );
 
-  it.each(["stop_agent", "kill"] as const)(
-    "%s refuses manual mode on a freshly moved UUID route before mutation",
-    async (toolName) => {
+  it.each([
+    ["stop_agent", false],
+    ["kill", false],
+    ["stop_agent", true],
+  ] as const)(
+    "%s force=%s refuses manual mode on a freshly moved UUID route before mutation",
+    async (toolName, force) => {
       const stableUuid = "11111111-2222-4333-8444-555555555555";
       const routeClient = makeUuidRouteClient([
         {
@@ -12364,8 +12364,8 @@ codex>
 
       const args =
         toolName === "stop_agent"
-          ? { agent_id: record.agent_id, force: false }
-          : { target: record.agent_id, force: false };
+          ? { agent_id: record.agent_id, force }
+          : { target: record.agent_id, force };
       const result = await registeredTestTool(server, toolName).handler(
         args,
         {} as any,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2516,8 +2516,7 @@ describe("agent lifecycle tool handlers", () => {
           expect.objectContaining({
             owner: parentId,
             target: expected.report_path,
-            marker: expected.done_marker,
-            watermark: 1,
+            change: "content",
             state: "armed",
           }),
         ]),

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -88,7 +88,7 @@ function makeExec(opts?: {
   let resumedSurfaceLive = false;
   const exec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
     calls.push(args);
-    if (args.includes("new-split")) {
+    if (args.includes("new-split") || args.includes("new-surface")) {
       resumedSurfaceLive = true;
       return {
         stdout: JSON.stringify({
@@ -115,6 +115,14 @@ function makeExec(opts?: {
             },
           ],
         }),
+        stderr: "",
+      };
+    }
+    if (args.includes("list-status")) {
+      return {
+        stdout: JSON.stringify([
+          { key: "mode.control", value: "autonomous" },
+        ]),
         stderr: "",
       };
     }
@@ -570,6 +578,7 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
         surface_uuid: SURFACE_UUID,
         surface_observer_id: "cmux:test",
         surface_provenance: "cmuxlayer_spawn",
+        role: "orchestrator",
         launch_cwd: "/Users/e/Gits/golems/.worktrees/run3",
         worktree_path: "/Users/e/Gits/golems/.worktrees/run3",
       });

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -242,7 +242,11 @@ afterEach(() => {
   rmSync(stateDir, { recursive: true, force: true });
 });
 
-function makeServer(exec: ExecFn, withStableObserver = false) {
+function makeServer(
+  exec: ExecFn,
+  withStableObserver = false,
+  withProcessEvidence = true,
+) {
   return createServer({
     exec,
     stateDir,
@@ -254,8 +258,12 @@ function makeServer(exec: ExecFn, withStableObserver = false) {
         ? {
             session_id: agent.cli_session_id,
             path: agent.cli_session_path ?? null,
-            pid: process.pid,
-            pid_registered_at: new Date().toISOString(),
+            ...(withProcessEvidence
+              ? {
+                  pid: process.pid,
+                  pid_registered_at: new Date().toISOString(),
+                }
+              : {}),
           }
         : null,
     // Model CI/fresh-clone CLI mode explicitly. Ambient access to a developer's
@@ -547,10 +555,10 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     );
     try {
       const exec = makeExec({
-        screen: () => IDLE_CLAUDE_SCREEN,
+        screen: () => "$ ",
         witnessSurface: true,
       });
-      const server = makeServer(exec, true);
+      const server = makeServer(exec, true, false);
       const record = seedAgent(server, {
         cli: "codex",
         model: "gpt-5.6-sol",
@@ -559,14 +567,15 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
           sessionDir,
           `rollout-2026-08-25T10-00-00-${sessionId}.jsonl`,
         ),
-        surface_uuid: null,
+        surface_uuid: SURFACE_UUID,
+        surface_observer_id: "cmux:test",
         surface_provenance: "cmuxlayer_spawn",
         launch_cwd: "/Users/e/Gits/golems/.worktrees/run3",
         worktree_path: "/Users/e/Gits/golems/.worktrees/run3",
       });
 
       const closed = (await getTool(server, "close_surface").handler(
-        { scope: "agent", agent_id: record.agent_id },
+        { scope: "agent", agent_id: record.agent_id, force: true },
         {},
       )) as ToolCallResult;
       expect(
@@ -594,6 +603,34 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
         process.env.CMUXLAYER_HARNESS_HOME = previousHarnessHome;
       }
     }
+  });
+
+  it("returns a structured refusal when forced agent close lacks stable topology", async () => {
+    const exec = makeExec({
+      screen: () => IDLE_CLAUDE_SCREEN,
+      surfaceEnumerationFails: true,
+    });
+    const server = makeServer(exec, true, false);
+    const record = seedAgent(server, {
+      state: "done",
+      cli_session_id: "019faccc-1111-7222-8333-444455556666",
+      surface_uuid: SURFACE_UUID,
+      surface_observer_id: "cmux:test",
+      pid: null,
+    });
+
+    const result = (await getTool(server, "close_surface").handler(
+      { scope: "agent", agent_id: record.agent_id, force: true },
+      {},
+    )) as ToolCallResult;
+    const data = payload(result);
+
+    expect(data).toMatchObject({
+      agent_stopped: false,
+      surface_closed: false,
+    });
+    expect(String(data.reason)).toMatch(/topology|surface|enumerat/i);
+    expect(String(data.remedy)).toMatch(/refresh|list_agents|retry/i);
   });
 
   it("never reads like a completed close while the pane is still listed", async () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -14,7 +14,7 @@
  * red run.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "../src/server.js";
@@ -85,8 +85,23 @@ function makeExec(opts?: {
 }): ExecFn & { calls: string[][] } {
   const calls: string[][] = [];
   let surfaceLive = true;
+  let resumedSurfaceLive = false;
   const exec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
     calls.push(args);
+    if (args.includes("new-split")) {
+      resumedSurfaceLive = true;
+      return {
+        stdout: JSON.stringify({
+          workspace: "workspace:1",
+          surface: "surface:resumed",
+          surface_id: "BBBBBBBB-CCCC-4DDD-8EEE-FFFFFFFFFFFF",
+          pane: "pane:1",
+          title: "",
+          type: "terminal",
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("list-workspaces")) {
       return {
         stdout: JSON.stringify({
@@ -109,10 +124,14 @@ function makeExec(opts?: {
       }
       const surfaceRefs = [
         ...(surfaceLive ? [SURFACE] : []),
+        ...(resumedSurfaceLive ? ["surface:resumed"] : []),
         ...(opts?.witnessSurface ? [WITNESS_SURFACE] : []),
       ];
       const surfaceIds = [
         ...(surfaceLive ? [SURFACE_UUID] : []),
+        ...(resumedSurfaceLive
+          ? ["BBBBBBBB-CCCC-4DDD-8EEE-FFFFFFFFFFFF"]
+          : []),
         ...(opts?.witnessSurface ? [WITNESS_UUID] : []),
       ];
       return {
@@ -165,6 +184,19 @@ function makeExec(opts?: {
                   },
                 ]
               : []),
+            ...(resumedSurfaceLive
+              ? [
+                  {
+                    id: "BBBBBBBB-CCCC-4DDD-8EEE-FFFFFFFFFFFF",
+                    ref: "surface:resumed",
+                    pane: "pane:1",
+                    workspace: "workspace:1",
+                    title: "resumed worker",
+                    type: "terminal",
+                    selected: true,
+                  },
+                ]
+              : []),
           ],
         }),
         stderr: "",
@@ -210,7 +242,7 @@ afterEach(() => {
   rmSync(stateDir, { recursive: true, force: true });
 });
 
-function makeServer(exec: ExecFn) {
+function makeServer(exec: ExecFn, withStableObserver = false) {
   return createServer({
     exec,
     stateDir,
@@ -228,8 +260,10 @@ function makeServer(exec: ExecFn) {
         : null,
     // Model CI/fresh-clone CLI mode explicitly. Ambient access to a developer's
     // real cmux socket must not decide whether teardown receipts are truthful.
-    surfaceObserverOwnerIdProvider: () => null,
-    surfaceObserverEpochProvider: () => null,
+    surfaceObserverOwnerIdProvider: () =>
+      withStableObserver ? "cmux:test" : null,
+    surfaceObserverEpochProvider: () =>
+      withStableObserver ? "cmux:test@socket:1" : null,
   }) as unknown;
 }
 
@@ -491,6 +525,75 @@ describe("#485 — close_surface(scope:agent) must close the surface or say it d
     expect(result.isError).toBeUndefined();
     expect(await listSurfaceRefs(server)).not.toContain(SURFACE);
     expect(payload(result).surface_closed).toBe(true);
+  });
+
+  it("closes then resumes the same public agent by its raw Codex session id", async () => {
+    const sessionId = "019faccc-1111-7222-8333-444455556666";
+    const harnessHome = mkdtempSync(join(tmpdir(), "cmux-t2b-harness-"));
+    const previousHarnessHome = process.env.CMUXLAYER_HARNESS_HOME;
+    process.env.CMUXLAYER_HARNESS_HOME = harnessHome;
+    const sessionDir = join(
+      harnessHome,
+      ".codex",
+      "sessions",
+      "2026",
+      "08",
+      "25",
+    );
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, `rollout-2026-08-25T10-00-00-${sessionId}.jsonl`),
+      `${JSON.stringify({ type: "session_meta", payload: { id: sessionId } })}\n`,
+    );
+    try {
+      const exec = makeExec({
+        screen: () => IDLE_CLAUDE_SCREEN,
+        witnessSurface: true,
+      });
+      const server = makeServer(exec, true);
+      const record = seedAgent(server, {
+        cli: "codex",
+        model: "gpt-5.6-sol",
+        cli_session_id: sessionId,
+        cli_session_path: join(
+          sessionDir,
+          `rollout-2026-08-25T10-00-00-${sessionId}.jsonl`,
+        ),
+        surface_uuid: null,
+        surface_provenance: "cmuxlayer_spawn",
+        launch_cwd: "/Users/e/Gits/golems/.worktrees/run3",
+        worktree_path: "/Users/e/Gits/golems/.worktrees/run3",
+      });
+
+      const closed = (await getTool(server, "close_surface").handler(
+        { scope: "agent", agent_id: record.agent_id },
+        {},
+      )) as ToolCallResult;
+      expect(
+        payload(closed).surface_closed,
+        JSON.stringify({ payload: payload(closed), calls: exec.calls }),
+      ).toBe(true);
+
+      const resumedResult = (await getTool(server, "spawn_agent").handler(
+        { resume_agent_id: sessionId, workspace: "workspace:1" },
+        {},
+      )) as ToolCallResult;
+      const resumed = payload(resumedResult);
+
+      expect(resumed, JSON.stringify(resumed)).toMatchObject({
+        ok: true,
+        resumed: true,
+        agent_id: record.agent_id,
+        surface_id: "surface:resumed",
+      });
+    } finally {
+      rmSync(harnessHome, { recursive: true, force: true });
+      if (previousHarnessHome === undefined) {
+        delete process.env.CMUXLAYER_HARNESS_HOME;
+      } else {
+        process.env.CMUXLAYER_HARNESS_HOME = previousHarnessHome;
+      }
+    }
   });
 
   it("never reads like a completed close while the pane is still listed", async () => {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -706,5 +706,15 @@ describe("kill — scoped targets", () => {
     expect(
       detailed.agents.map((agent: { agent_id: string }) => agent.agent_id),
     ).toContain("surfaceless-done-agent");
+    const explicitlyRequested = parseResult(
+      await callTool(server, "list_agents", {
+        agent_ids: ["surfaceless-done-agent"],
+      }),
+    );
+    expect(
+      explicitlyRequested.agents.map(
+        (agent: { agent_id: string }) => agent.agent_id,
+      ),
+    ).toContain("surfaceless-done-agent");
   });
 });

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -659,33 +659,33 @@ describe("kill — scoped targets", () => {
     expect(parsed.ok).toBe(true);
   });
 
-  it("kill force retains resumable surfaceless terminal tombstones", async () => {
+  it("kill force retains a tombstone hidden from default list_agents", async () => {
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState(
       makeAgentRecord({
-        agent_id: "surfaceless-error-agent",
+        agent_id: "surfaceless-done-agent",
         surface_id: "surface:ghost",
-        state: "error",
+        state: "done",
         cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
         role: "orchestrator",
-        error: "Surface surface:ghost disappeared",
-        crash_recover: true,
+        error: null,
+        crash_recover: false,
       }),
     );
     await callTool(server, "list_agents", {});
 
     const result = await callTool(server, "kill", {
-      target: "surfaceless-error-agent",
+      target: "surfaceless-done-agent",
       force: true,
     });
     const parsed = parseResult(result);
 
     expect(parsed.ok).toBe(true);
-    expect(parsed.killed).toContain("surfaceless-error-agent");
-    expect(stateMgr.readState("surfaceless-error-agent")).toMatchObject({
-      agent_id: "surfaceless-error-agent",
+    expect(parsed.killed).toContain("surfaceless-done-agent");
+    expect(stateMgr.readState("surfaceless-done-agent")).toMatchObject({
+      agent_id: "surfaceless-done-agent",
       cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
-      state: "error",
+      state: "done",
       user_killed: true,
       pid: null,
     });
@@ -693,6 +693,18 @@ describe("kill — scoped targets", () => {
     const listed = parseResult(await callTool(server, "list_agents", {}));
     expect(
       listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
-    ).toContain("surfaceless-error-agent");
+    ).not.toContain("surfaceless-done-agent");
+    const filtered = parseResult(
+      await callTool(server, "list_agents", { state: "done" }),
+    );
+    expect(
+      filtered.agents.map((agent: { agent_id: string }) => agent.agent_id),
+    ).toContain("surfaceless-done-agent");
+    const detailed = parseResult(
+      await callTool(server, "list_agents", { detail: "full" }),
+    );
+    expect(
+      detailed.agents.map((agent: { agent_id: string }) => agent.agent_id),
+    ).toContain("surfaceless-done-agent");
   });
 });

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -663,6 +663,18 @@ describe("kill — scoped targets", () => {
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState(
       makeAgentRecord({
+        agent_id: "recoverable-crash-agent",
+        surface_id: "surface:crashed",
+        state: "error",
+        cli_session_id: "019ec0e6-aaaa-bbbb-cccc-ddddeeeeffff",
+        role: "worker",
+        error: "Surface surface:crashed disappeared",
+        crash_recover: false,
+        user_killed: false,
+      }),
+    );
+    stateMgr.writeState(
+      makeAgentRecord({
         agent_id: "surfaceless-done-agent",
         surface_id: "surface:ghost",
         state: "done",
@@ -694,6 +706,9 @@ describe("kill — scoped targets", () => {
     expect(
       listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
     ).not.toContain("surfaceless-done-agent");
+    expect(
+      listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
+    ).toContain("recoverable-crash-agent");
     const filtered = parseResult(
       await callTool(server, "list_agents", { state: "done" }),
     );

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -659,7 +659,7 @@ describe("kill — scoped targets", () => {
     expect(parsed.ok).toBe(true);
   });
 
-  it("kill force removes surfaceless terminal registry ghosts", async () => {
+  it("kill force retains resumable surfaceless terminal tombstones", async () => {
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState(
       makeAgentRecord({
@@ -682,11 +682,17 @@ describe("kill — scoped targets", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.killed).toContain("surfaceless-error-agent");
-    expect(stateMgr.readState("surfaceless-error-agent")).toBeNull();
+    expect(stateMgr.readState("surfaceless-error-agent")).toMatchObject({
+      agent_id: "surfaceless-error-agent",
+      cli_session_id: "019ec0e6-1111-2222-3333-444455556666",
+      state: "error",
+      user_killed: true,
+      pid: null,
+    });
 
     const listed = parseResult(await callTool(server, "list_agents", {}));
     expect(
       listed.agents.map((agent: { agent_id: string }) => agent.agent_id),
-    ).not.toContain("surfaceless-error-agent");
+    ).toContain("surfaceless-error-agent");
   });
 });

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -116,6 +116,24 @@ describe("WatchSpec MCP contract", () => {
     expect(armSchema.shape.predicate.description).toContain(
       "thinking, working, idle, done, error",
     );
+    const fileWatch = { ...baseWatch, target: join(TEST_DIR, "report.md") };
+    expect(
+      armSchema.safeParse({ ...fileWatch, change: "content" }).success,
+    ).toBe(true);
+    expect(
+      waitSchema.safeParse({
+        watch: { ...fileWatch, change: "content" },
+      }).success,
+    ).toBe(true);
+    expect(
+      waitSchema.safeParse({
+        watch: {
+          ...fileWatch,
+          marker: "DONE",
+          change: "content",
+        },
+      }).success,
+    ).toBe(false);
   });
 
   it("accepts WatchSpec through wait_for and blocks until marker count increases", async () => {

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -51,6 +51,59 @@ describe("WatchSpec arm contract", () => {
     });
   });
 
+  it("re-reads an interleaved content write and wakes exactly once", async () => {
+    const target = join(TEST_DIR, "interleaved.md");
+    writeFileSync(target, "before", "utf8");
+    let revision = 1n;
+    let interleave = false;
+    const contentFingerprintIo = {
+      stat: () => ({
+        mtimeNs: revision,
+        ctimeNs: revision,
+        ino: 1n,
+        size: revision === 1n ? 6n : 5n,
+      }),
+      read: () => {
+        const content =
+          revision === 1n ? Buffer.from("before") : Buffer.from("after");
+        if (interleave && revision === 1n) revision = 2n;
+        return content;
+      },
+    };
+    const notify = vi.fn().mockResolvedValue(true);
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        change: "content",
+        deadline: 60_000,
+      },
+      {
+        registryPath: registryPath(),
+        now: () => 1_000,
+        contentFingerprintIo,
+      },
+    );
+
+    interleave = true;
+    const changed = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+      contentFingerprintIo,
+    });
+    const unchanged = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 3_000,
+      notify,
+      contentFingerprintIo,
+    });
+
+    expect(changed.fired).toEqual([armed.watch_id]);
+    expect(unchanged.fired).toEqual([]);
+    expect(notify).toHaveBeenCalledOnce();
+  });
+
   it("rejects an agent watch without an independent observation provider", async () => {
     await expect(
       armWatch(


### PR DESCRIPTION
## Summary

- verify the #473 wait gate already landed on main via #478 (the guard bites in 8 regressions here), and make each short-circuit return a reconciled embedded `agent` consistent with its top-level state
- wake parents on every report revision, including a byte-identical rewrite with the same terminal marker
- retain resumable close tombstones, capture self-registered Codex session IDs, and accept either the public label or full raw harness session ID for resume
- prefer exact stable-surface registration matches and reject ambiguous process/cwd fallbacks

## Failing-before evidence

- stale wait regression returned immediately from registry `done` instead of blocking on live screen `working`
- report watch remained marker/watermark based, so a second terminal report with the same marker did not wake the parent
- force-close removed the resumable record; raw session UUID resume returned `Agent not found`
- Codex spawn ignored stable-surface self-registration and could remain `missing_cli_session_id/non_resumable`

## Passing-after evidence

- focused round-2 waiter/report/resume/retention/spawn matrix: 945/945 passing; final polling fail-fast file: 32/32 passing
- full suite, normal environment: 145 files; 3,371 passed; 1 skipped
- full suite, `CMUX_SOCKET_PATH`/`CMUX_DAEMON_SOCKET` unset: 145 files; 3,371 passed; 1 skipped
- typecheck in both environments: pass
- `bun run pre-pr`: 64/64 pass
- final pre-push hook: full suite 3,371 passed / 1 skipped plus contract runners; no bypass
- live built daemon/proxy contract: system ping, `list_surfaces`/`read_screen`, doctor, and graceful retire/autostart pass against real cmux

Backlog: D28 — untokened `wait_for` callers still receive no heartbeat; intentionally out of scope.

Verifies #473; its wait gating landed in #478.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Core agent lifecycle changes (force-stop tombstones, session identity for Codex, resume-by-raw-session matching) and watch/close_surface API semantics can affect orchestration and callers that assumed eviction or success-shaped close responses.
> 
> **Overview**
> Strengthens **explicit resume** and parent coordination: force-close and deliberate stops now keep **resumable tombstones** (session id preserved, capped at 50 in the registry) instead of evicting rows; `spawn_agent` / `resumeAgent` resolve targets via **`resolveResumeAgent`** (public agent id, persisted `cli_session_id`, or **`selfRegistrationSessionLookup`**). **Codex** treats stable-surface self-registration as authoritative (like other CLIs), with a **≤2s post-spawn poll** (`captureCodexSpawnSessionId`) so harness ids land before spawn returns.
> 
> **WatchSpec** gains **`change: "content"`** (SHA256 fingerprint + metadata): report coordination arms persistent content watches so parents wake on **every file revision**, not only new marker counts; `waitForWatch` also honors watches fired in the same sweep. **`list_agents`** hides deliberate-close tombstones unless filtered or `detail=full`; failed agent-scope **`close_surface`** returns a structured **refusal** instead of `ok` with embedded failure. **`waitFor`** embeds agents aligned with live terminal state on short-circuit paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb5980192dc13f577f7f2b4e84a8d5f6dc77171f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve waiter and resume truth across `stopAgent`, `resumeAgent`, and content-change watches
> - Adds persistent content-change file watches (`change: 'content'`) that fire on each distinct content revision, auto-re-arm after delivery, and replace marker-based parent report watches in `armParentReportWatch`
> - Introduces `resolveResumeAgent` so `resumeAgent` accepts a raw harness session id, using `selfRegistrationSessionLookup` to reverse-resolve sessions, with safeguards against ambiguous or stale matches
> - Force-stop now writes a resumable tombstone (`user_killed: true`, `pid: null`) when a `cli_session_id` exists instead of evicting; `shouldRetainForExplicitResume` retains both deliberate-close and recoverable-crash records
> - `AgentRegistry` prunes resumable tombstones to a cap of 50 (`MAX_RESUMABLE_TOMBSTONES`) on reconstitute, reconcile, and set
> - `reopenAgent` clears `task_done_candidate_at`, `task_done_detected_at`, and `halt_last_active_at` to null so resumed agents start clean
> - `waitForAgentState` immediate terminal branches now return a public agent payload that matches the branch state; `waitForWatch` completes when the sweep explicitly reports the watch fired
> - `list_agents` hides deliberate-close tombstones by default unless `detail=full`, a state filter, or explicit `agent_ids` are requested
> - Codex spawns now capture `cli_session_id` via a bounded poll (default 2s, `MAX_SPAWN_SESSION_CAPTURE_MS`) during `spawnAgent` before falling back to lazy capture
> - Behavioral Change: `WatchSpecSchema` now requires exactly one of `predicate`, `marker`, or `change`; existing specs with zero or multiple selectors are rejected. `close_surface` agent-stop failures now return a structured error via `err(...)` instead of embedding the stop receipt in `structuredContent`. Owner watch-notification delivery no longer depends on `externalDelivered`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb59801.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


— cmuxlayerCodex-4af3d56d (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-4af3d56d","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03884","ts":"2026-08-25T11:57:36Z"} -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file content-change watches that detect revisions and notify waiting workflows.
  * Resume operations now accept either an agent ID or matching session ID.
  * Improved session capture and recovery for resumable agents.
* **Bug Fixes**
  * Wait results now consistently reflect live agent state.
  * Improved stop, force-stop, and crash-recovery handling while preserving resumable sessions.
  * Prevented ambiguous or stale session matches during resume.
* **Improvements**
  * Explicitly resumable terminal agents are hidden from default listings but remain available through detailed or filtered views.
  * Retained resumable history is capped at 50 records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->