### PR TITLE
fix: gate daemon respawn by cmux ancestry

### DIFF
--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -159,6 +159,10 @@ export interface ControlHealth {
     ps?: string;
     ps_error?: string;
     script_path?: string | null;
+    spawner_ancestry?: {
+      app_bundle_path: string | null;
+      pid: number | null;
+    };
   };
   selected_transport: {
     client_class: string | null;
@@ -641,6 +645,49 @@ function buildWarnings(health: Omit<ControlHealth, "warnings">): string[] {
   return warnings;
 }
 
+interface ProcessAncestryRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+function parseProcessAncestryRows(output: string): ProcessAncestryRow[] {
+  return output
+    .split("\n")
+    .map((line) => {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/);
+      if (!match) return null;
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        command: match[3],
+      };
+    })
+    .filter((row): row is ProcessAncestryRow => row !== null);
+}
+
+export function resolveSpawnerAncestry(
+  processTable: string,
+  spawnerPid: number,
+): { app_bundle_path: string | null; pid: number | null } {
+  const byPid = new Map(
+    parseProcessAncestryRows(processTable).map((row) => [row.pid, row]),
+  );
+  const visited = new Set<number>();
+  let pid = spawnerPid;
+  while (pid > 0 && !visited.has(pid)) {
+    visited.add(pid);
+    const row = byPid.get(pid);
+    if (!row) break;
+    const bundle = row.command.match(/(\/.*?\.app)(?:\/|$)/)?.[1] ?? null;
+    if (bundle) {
+      return { app_bundle_path: bundle, pid: row.pid };
+    }
+    pid = row.ppid;
+  }
+  return { app_bundle_path: null, pid: null };
+}
+
 export async function collectControlHealth(
   opts: ControlHealthOptions = {},
 ): Promise<ControlHealth> {
@@ -663,17 +710,23 @@ export async function collectControlHealth(
   const nightlyDefaultSocket = join(tmpDir, "cmux-nightly.sock");
   const pathEntries = splitPathEntries(env.PATH);
 
-  const [prodMarkers, nightlyMarkers, cmuxResolution, processList, ps] =
-    await Promise.all([
-      Promise.all([
-        readMarker(
-          "state_last_socket",
-          join(stateDir, "last-socket-path"),
-          deps,
-        ),
-        readMarker(
-          "tmp_last_socket",
-          join(tmpDir, "cmux-last-socket-path"),
+  const [
+    prodMarkers,
+    nightlyMarkers,
+    cmuxResolution,
+    processList,
+    processAncestry,
+    ps,
+  ] = await Promise.all([
+    Promise.all([
+      readMarker(
+        "state_last_socket",
+        join(stateDir, "last-socket-path"),
+        deps,
+      ),
+      readMarker(
+        "tmp_last_socket",
+        join(tmpDir, "cmux-last-socket-path"),
           deps,
         ),
       ]),
@@ -688,12 +741,13 @@ export async function collectControlHealth(
           join(tmpDir, "cmux-nightly-last-socket-path"),
           deps,
         ),
-      ]),
-      resolveExecutables("cmux", pathEntries, deps),
-      runOptional(deps.execFile, "ps", ["ax", "-o", "pid=", "-o", "command="]),
-      runOptional(deps.execFile, "ps", [
-        "-o",
-        "pid=",
+    ]),
+    resolveExecutables("cmux", pathEntries, deps),
+    runOptional(deps.execFile, "ps", ["ax", "-o", "pid=", "-o", "command="]),
+    runOptional(deps.execFile, "ps", ["-ww", "-axo", "pid=,ppid=,command="]),
+    runOptional(deps.execFile, "ps", [
+      "-o",
+      "pid=",
         "-o",
         "ppid=",
         "-o",
@@ -719,6 +773,10 @@ export async function collectControlHealth(
   const envSnapshot = Object.fromEntries(
     ENV_KEYS.map((key) => [key, redactEnvValue(key, env[key])]),
   ) as Record<string, string | null>;
+  const spawnerAncestry = resolveSpawnerAncestry(
+    processAncestry.stdout ?? "",
+    opts.ppid ?? process.ppid,
+  );
 
   const base: Omit<ControlHealth, "warnings"> = {
     generated_at: (opts.now ?? (() => new Date()))().toISOString(),
@@ -732,6 +790,7 @@ export async function collectControlHealth(
       env: envSnapshot,
       path_entries: pathEntries,
       cmux_resolution: cmuxResolution,
+      spawner_ancestry: spawnerAncestry,
       ...(ps.stdout ? { ps: ps.stdout } : {}),
       ...(ps.error ? { ps_error: ps.error } : {}),
     },
@@ -865,6 +924,10 @@ function formatDaemonLifecycle(
 }
 
 export function formatControlHealth(health: ControlHealth): string {
+  const spawnerAncestry = health.current_process.spawner_ancestry ?? {
+    app_bundle_path: null,
+    pid: null,
+  };
   const lines = [
     "cmuxlayer control_health",
     `generated_at: ${health.generated_at}`,
@@ -879,6 +942,9 @@ export function formatControlHealth(health: ControlHealth): string {
           `transport_error: ${health.selected_transport.transport_error ?? "unknown"}`,
         ]
       : []),
+    `daemon spawner ancestry: ${spawnerAncestry.app_bundle_path ?? "none"}${
+      spawnerAncestry.pid === null ? "" : ` (pid=${spawnerAncestry.pid})`
+    }`,
     `env CMUX_SOCKET_PATH: ${health.current_process.env.CMUX_SOCKET_PATH ?? "unset"}`,
     `env CMUX_BUNDLED_CLI_PATH: ${health.current_process.env.CMUX_BUNDLED_CLI_PATH ?? "unset"}`,
     "cmux resolution:",

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -679,7 +679,10 @@ export function resolveSpawnerAncestry(
     visited.add(pid);
     const row = byPid.get(pid);
     if (!row) break;
-    const bundle = row.command.match(/(\/.*?\.app)(?:\/|$)/)?.[1] ?? null;
+    const bundle =
+      row.command.match(
+        /(?:^|\s)(\/(?:(?!\s(?:-|\/)).)*?\.app)(?:\/|\s|$)/,
+      )?.[1] ?? null;
     if (bundle) {
       return { app_bundle_path: bundle, pid: row.pid };
     }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -513,6 +513,7 @@ export async function runDaemonFirstEntry(
       output: opts.output,
       logger,
       env,
+      probeCmuxSocket,
       spawnDaemonForVersionBump: spawnDaemon,
     });
     bindProxyStdioLifecycle({ input, proxy, logger, exit });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,6 +28,11 @@ import {
   resolveInstalledEntryScript,
 } from "./version.js";
 import { canonicalPath, isMainModule } from "./is-main.js";
+import {
+  candidateSocketPathsForOpts,
+  probeSocketHealth,
+  type SocketProbeResult,
+} from "./cmux-socket-probe.js";
 
 const DEFAULT_INITIAL_BACKOFF_MS = 100;
 const DEFAULT_MAX_BACKOFF_MS = 5_000;
@@ -140,6 +145,7 @@ export interface CmuxLayerProxyOptions {
   spawnDaemonForVersionBump?: (
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
+  probeCmuxSocket?: () => Promise<SocketProbeResult>;
   versionBumpReconnectGuard?: VersionBumpReconnectGuard;
   selfReexecGuard?: VersionBumpReconnectGuard;
   reconnectDaemonSpawnGuard?: VersionBumpReconnectGuard;
@@ -288,6 +294,7 @@ export class CmuxLayerProxy {
   private readonly spawnDaemonForVersionBump?: (
     opts: SpawnDaemonOptions,
   ) => Promise<unknown> | unknown;
+  private readonly probeCmuxSocket: () => Promise<SocketProbeResult>;
   private readonly versionBumpReconnectGuard: VersionBumpReconnectGuard;
   private readonly selfReexecGuard: VersionBumpReconnectGuard;
   private readonly reconnectDaemonSpawnGuard: VersionBumpReconnectGuard;
@@ -324,6 +331,8 @@ export class CmuxLayerProxy {
   private readonly agentOutputWrites = new Set<Promise<void>>();
   private bufferedRequestTimer: NodeJS.Timeout | null = null;
   private readonly reconnectLogTimes = new Map<string, number>();
+  private lastCmuxProbe: SocketProbeResult | null = null;
+  private readonly loggedSpawnSuppressions = new Set<string>();
   private readonly queue: QueuedMessage[] = [];
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly expiredRequestKeys = new Set<string>();
@@ -361,6 +370,8 @@ export class CmuxLayerProxy {
     this.installedDaemonScriptPath =
       opts.installedDaemonScriptPath ?? resolveInstalledDaemonScript;
     this.spawnDaemonForVersionBump = opts.spawnDaemonForVersionBump;
+    this.probeCmuxSocket =
+      opts.probeCmuxSocket ?? (() => probeProxyCmuxSocket(this.env));
     this.versionBumpReconnectGuard =
       opts.versionBumpReconnectGuard ?? new VersionBumpReconnectGuard();
     this.selfReexecGuard =
@@ -648,6 +659,9 @@ export class CmuxLayerProxy {
         );
         return;
       }
+      if (!(await this.canSpawnSharedDaemon("reconnect-failure"))) {
+        return;
+      }
       const spawnStartedAt = Date.now();
       const spawned = await this.spawnDaemonForVersionBump({
         socketPath: this.socketPath,
@@ -673,6 +687,47 @@ export class CmuxLayerProxy {
         error,
       );
     }
+  }
+
+  private async canSpawnSharedDaemon(
+    trigger: "reconnect-failure" | "version-bump",
+  ): Promise<boolean> {
+    if (isEnabled(this.env.CMUXLAYER_FORCE_INPROCESS)) {
+      this.logSpawnSuppression("force-inprocess", "none", trigger);
+      return false;
+    }
+    const probe =
+      this.lastCmuxProbe?.denied_reason === "access-control"
+        ? this.lastCmuxProbe
+        : await this.probeCmuxSocket();
+    this.lastCmuxProbe = probe;
+    if (probe.usable) {
+      return true;
+    }
+    this.logSpawnSuppression(
+      probe.denied_reason === "access-control"
+        ? "cmux-access-control"
+        : "cmux-ancestry-unproven",
+      probe.socketPath,
+      trigger,
+    );
+    return false;
+  }
+
+  private logSpawnSuppression(
+    reason:
+      "cmux-access-control" | "cmux-ancestry-unproven" | "force-inprocess",
+    path: string,
+    trigger: "reconnect-failure" | "version-bump",
+  ): void {
+    const key = `${reason}:${path}:${trigger}`;
+    if (this.loggedSpawnSuppressions.has(key)) {
+      return;
+    }
+    this.loggedSpawnSuppressions.add(key);
+    this.logger.error(
+      `[cmuxlayer-proxy] daemon spawn suppressed (reason=${reason}, path=${path}, trigger=${trigger})`,
+    );
   }
 
   private attachDaemonSocket(socket: net.Socket): void {
@@ -1361,9 +1416,10 @@ export class CmuxLayerProxy {
       const daemonScriptPath = this.installedDaemonScriptPath();
       if (daemonScriptPath && this.spawnDaemonForVersionBump) {
         try {
-          const spawnStartedAt = Date.now();
-          const spawned = await this.spawnDaemonForVersionBump({
-            socketPath: this.socketPath,
+          if (await this.canSpawnSharedDaemon("version-bump")) {
+            const spawnStartedAt = Date.now();
+            const spawned = await this.spawnDaemonForVersionBump({
+              socketPath: this.socketPath,
             env: process.env,
             logger: this.logger,
             daemonScriptPath,
@@ -1377,9 +1433,10 @@ export class CmuxLayerProxy {
               ? spawned.pid
               : "unknown";
           this.logReconnect(
-            "spawn-fired-version-bump",
-            `[cmuxlayer-proxy] daemon spawn fired (script=${daemonScriptPath}, pid=${pid})`,
-          );
+              "spawn-fired-version-bump",
+              `[cmuxlayer-proxy] daemon spawn fired (script=${daemonScriptPath}, pid=${pid})`,
+            );
+          }
         } catch (error) {
           this.logger.error(
             "[cmuxlayer-proxy] failed to spawn installed daemon for version bump",
@@ -1407,6 +1464,30 @@ export class CmuxLayerProxy {
       this.versionBumpReconnecting = false;
     }
   }
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+async function probeProxyCmuxSocket(
+  env: NodeJS.ProcessEnv,
+): Promise<SocketProbeResult> {
+  const candidates = candidateSocketPathsForOpts({
+    socketPath: env.CMUX_SOCKET_PATH?.trim() || undefined,
+  });
+  let lastResult: SocketProbeResult = {
+    usable: false,
+    socketPath: candidates[0] ?? "unknown",
+  };
+  for (const socketPath of candidates) {
+    const result = await probeSocketHealth(socketPath);
+    if (result.usable || result.denied_reason === "access-control") {
+      return result;
+    }
+    lastResult = result;
+  }
+  return lastResult;
 }
 
 export async function runProxy(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -112,12 +112,16 @@ export class VersionBumpReconnectGuard {
     this.now = opts.now ?? Date.now;
   }
 
-  allow(): boolean {
+  canAttempt(): boolean {
     const cutoff = this.now() - this.windowMs;
     while (this.attempts.length > 0 && this.attempts[0] < cutoff) {
       this.attempts.shift();
     }
-    if (this.attempts.length >= this.maxAttempts) {
+    return this.attempts.length < this.maxAttempts;
+  }
+
+  allow(): boolean {
+    if (!this.canAttempt()) {
       return false;
     }
     this.attempts.push(this.now());
@@ -652,7 +656,7 @@ export class CmuxLayerProxy {
         );
         return;
       }
-      if (!this.reconnectDaemonSpawnGuard.allow()) {
+      if (!this.reconnectDaemonSpawnGuard.canAttempt()) {
         this.logReconnect(
           "spawn-guard",
           `[cmuxlayer-proxy] daemon spawn skipped (reason=guard, attempt=${attempt})`,
@@ -660,6 +664,9 @@ export class CmuxLayerProxy {
         return;
       }
       if (!(await this.canSpawnSharedDaemon("reconnect-failure"))) {
+        return;
+      }
+      if (!this.reconnectDaemonSpawnGuard.allow()) {
         return;
       }
       const spawnStartedAt = Date.now();

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -209,7 +209,7 @@ describe("control health", () => {
             stdout: [
               "900 800 /opt/homebrew/bin/node /opt/cmuxlayer/dist/daemon.js",
               "800 700 /opt/homebrew/bin/node /opt/cmuxlayer/dist/proxy.js",
-              "700 1 /Applications/Zed.app/Contents/MacOS/Zed",
+              "700 1 /usr/bin/open -a /Applications/Zed.app",
               "1 0 /sbin/launchd",
             ].join("\n"),
           };

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -191,6 +191,45 @@ describe("control health", () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
   });
 
+  it("reports the daemon spawner's real app ancestry instead of inherited cmux env", async () => {
+    const health = await collectControlHealth({
+      homeDir: join(TEST_ROOT, "ancestry-home"),
+      tmpDir: join(TEST_ROOT, "ancestry-tmp"),
+      pid: 900,
+      ppid: 800,
+      cwd: TEST_ROOT,
+      env: {
+        PATH: "/usr/bin:/bin",
+        CMUX_SURFACE_ID: "inherited-pane-id",
+      },
+      execFile: async (file, args) => {
+        if (file !== "ps") return { stdout: "" };
+        if (args.join(" ") === "-ww -axo pid=,ppid=,command=") {
+          return {
+            stdout: [
+              "900 800 /opt/homebrew/bin/node /opt/cmuxlayer/dist/daemon.js",
+              "800 700 /opt/homebrew/bin/node /opt/cmuxlayer/dist/proxy.js",
+              "700 1 /Applications/Zed.app/Contents/MacOS/Zed",
+              "1 0 /sbin/launchd",
+            ].join("\n"),
+          };
+        }
+        if (args.join(" ") === "ax -o pid= -o command=") {
+          return { stdout: "" };
+        }
+        return { stdout: "900 800 900 900 S+ ?? node daemon.js" };
+      },
+    });
+
+    expect(health.current_process.spawner_ancestry).toEqual({
+      app_bundle_path: "/Applications/Zed.app",
+      pid: 700,
+    });
+    expect(formatControlHealth(health)).toContain(
+      "daemon spawner ancestry: /Applications/Zed.app (pid=700)",
+    );
+  });
+
   it("reports pane_pty_dead surfaces and monitor recovery state", async () => {
     rmSync(TEST_ROOT, { recursive: true, force: true });
     const home = join(TEST_ROOT, "home-observability");

--- a/tests/proxy-version-bump.test.ts
+++ b/tests/proxy-version-bump.test.ts
@@ -146,6 +146,8 @@ class FakeDaemon {
 describe("proxy version-bump auto-reconnect", () => {
   const daemons: FakeDaemon[] = [];
   const proxies: CmuxLayerProxy[] = [];
+  const insideCmuxProbe = () =>
+    Promise.resolve({ usable: true, socketPath: "/tmp/cmux.sock" });
 
   afterEach(async () => {
     vi.useRealTimers();
@@ -183,12 +185,14 @@ describe("proxy version-bump auto-reconnect", () => {
       input,
       output,
       logger,
+      env: {},
       initialBackoffMs: 5,
       maxBackoffMs: 20,
       reconnectJitterRatio: 0,
       requestTimeoutMs: 500,
       staleRecheckIntervalMs: 20,
       detectStaleBuild,
+      probeCmuxSocket: insideCmuxProbe,
       spawnDaemonForVersionBump,
       installedDaemonScriptPath: () =>
         "/opt/homebrew/opt/cmuxlayer/dist/daemon.js",
@@ -228,6 +232,52 @@ describe("proxy version-bump auto-reconnect", () => {
     );
   });
 
+  it("does not spawn the installed daemon for a version bump after cmux denial", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("bump-denied");
+    const daemon = new FakeDaemon(path);
+    daemons.push(daemon);
+    await daemon.start();
+
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue({ pid: 4242 });
+    const logger = { error: vi.fn() };
+    const proxy = new CmuxLayerProxy({
+      socketPath: path,
+      input: new PassThrough(),
+      output: new PassThrough(),
+      logger,
+      env: {},
+      staleRecheckIntervalMs: 60_000,
+      detectStaleBuild: () => ({
+        stale: true,
+        running: "0.4.58",
+        installed: "0.4.59",
+      }),
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      probeCmuxSocket: () =>
+        Promise.resolve({
+          usable: false,
+          socketPath: "/tmp/cmux.sock",
+          denied_reason: "access-control" as const,
+          error:
+            "Access denied - only processes started inside cmux can connect",
+        }),
+      spawnDaemonForVersionBump,
+    });
+    proxies.push(proxy);
+    proxy.start();
+    await waitFor(() => daemon.connections.length > 0);
+
+    await (
+      proxy as unknown as { checkVersionBumpReconnect(): Promise<void> }
+    ).checkVersionBumpReconnect();
+
+    expect(spawnDaemonForVersionBump).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon spawn suppressed (reason=cmux-access-control, path=/tmp/cmux.sock, trigger=version-bump)",
+    );
+  });
+
   it("requeues an in-flight request across a version-bump reconnect", async () => {
     mkdirSync(TEST_ROOT, { recursive: true });
     const path = socketPath("in-flight-bump");
@@ -244,6 +294,7 @@ describe("proxy version-bump auto-reconnect", () => {
       socketPath: path,
       input,
       output,
+      env: {},
       initialBackoffMs: 5,
       maxBackoffMs: 20,
       reconnectJitterRatio: 0,
@@ -264,6 +315,7 @@ describe("proxy version-bump auto-reconnect", () => {
       spawnDaemonForVersionBump: vi.fn().mockImplementation(async () => {
         runningVersion = installedVersion;
       }),
+      probeCmuxSocket: insideCmuxProbe,
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
       logger: { error: vi.fn() },
     });
@@ -334,8 +386,10 @@ describe("proxy version-bump auto-reconnect", () => {
       socketPath: path,
       input: new PassThrough(),
       output: new PassThrough(),
+      env: {},
       staleRecheckIntervalMs: 60_000,
       detectStaleBuild,
+      probeCmuxSocket: insideCmuxProbe,
       spawnDaemonForVersionBump,
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
     });
@@ -363,6 +417,7 @@ describe("proxy version-bump auto-reconnect", () => {
       input: new PassThrough(),
       output: new PassThrough(),
       logger,
+      env: {},
       initialBackoffMs: 1_000,
       maxBackoffMs: 1_000,
       reconnectJitterRatio: 0,
@@ -373,6 +428,7 @@ describe("proxy version-bump auto-reconnect", () => {
           ? { stale: true, running: "0.3.33", installed: "0.3.34" }
           : { stale: false, running: "0.3.33", installed: "0.3.33" },
       spawnDaemonForVersionBump: vi.fn().mockResolvedValue({ pid: 4242 }),
+      probeCmuxSocket: insideCmuxProbe,
       installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
     });
     proxies.push(proxy);

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -400,6 +400,11 @@ describe("CmuxLayerProxy", () => {
       reconnectJitterRatio: 0,
       requestTimeoutMs: 500,
       maxBufferedRequests: 8,
+      env: {},
+      probeCmuxSocket: vi.fn().mockResolvedValue({
+        usable: true,
+        socketPath: "/tmp/cmux.sock",
+      }),
       ...opts,
     });
     proxies.push(proxy);
@@ -873,6 +878,37 @@ describe("CmuxLayerProxy", () => {
     );
   });
 
+  it("does not spawn the installed daemon after reconnect denial by cmux", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-spawn-denied");
+    const logger = { error: vi.fn() };
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue({ pid: 4242 });
+    const attempts: number[] = [];
+    const { proxy } = createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      logger,
+      onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+      probeCmuxSocket: vi.fn().mockResolvedValue({
+        usable: false,
+        socketPath: "/tmp/cmux.sock",
+        denied_reason: "access-control",
+        error: "Access denied - only processes started inside cmux can connect",
+      }),
+      reconnectLogIntervalMs: 0,
+      spawnDaemonForVersionBump,
+    });
+
+    await waitFor(() => attempts.length >= 3);
+    await proxy.stop();
+
+    expect(spawnDaemonForVersionBump).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cmuxlayer-proxy] daemon spawn suppressed (reason=cmux-access-control, path=/tmp/cmux.sock, trigger=reconnect-failure)",
+    );
+  });
+
   it(
     "logs a successful daemon spawn that exits suspiciously quickly",
     async () => {
@@ -899,7 +935,7 @@ describe("CmuxLayerProxy", () => {
             "daemon spawn suspicious quick-exit (isMain/symlink mismatch?)",
           ),
         ),
-      );
+      ),
       await proxy.stop();
     },
   );

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -935,7 +935,7 @@ describe("CmuxLayerProxy", () => {
             "daemon spawn suspicious quick-exit (isMain/symlink mismatch?)",
           ),
         ),
-      ),
+      );
       await proxy.stop();
     },
   );
@@ -960,6 +960,35 @@ describe("CmuxLayerProxy", () => {
     await waitFor(() => attempts.length >= 6);
 
     expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not consume reconnect spawn guard capacity on transient probe failures", async () => {
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const path = socketPath("reconnect-probe-guard");
+    const spawnDaemonForVersionBump = vi.fn().mockResolvedValue(undefined);
+    const attempts: number[] = [];
+    const probeCmuxSocket = vi
+      .fn()
+      .mockResolvedValueOnce({ usable: false, socketPath: "/tmp/cmux.sock" })
+      .mockResolvedValueOnce({ usable: false, socketPath: "/tmp/cmux.sock" })
+      .mockResolvedValue({ usable: true, socketPath: "/tmp/cmux.sock" });
+    createProxy(path, {
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      installedDaemonScriptPath: () => "/opt/cmuxlayer/dist/daemon.js",
+      onReconnectDelay: (_delayMs, attempt) => attempts.push(attempt),
+      probeCmuxSocket,
+      reconnectDaemonSpawnGuard: new VersionBumpReconnectGuard({
+        maxAttempts: 1,
+        windowMs: 60_000,
+      }),
+      spawnDaemonForVersionBump,
+    });
+
+    await waitFor(() => attempts.length >= 5);
+
+    expect(probeCmuxSocket).toHaveBeenCalledTimes(3);
+    expect(spawnDaemonForVersionBump).toHaveBeenCalledTimes(1);
   });
 
   it("replays queued requests after reconnect autostart brings up the daemon", async () => {


### PR DESCRIPTION
## Summary

- gate both reconnect-failure and version-bump daemon respawn paths on a successful cmux socket/access probe
- latch cmux access-control denial and emit one structured suppression log per path/trigger
- report the daemon spawner's real `.app` ancestry in `control_health` instead of trusting inherited cmux environment variables

## Verification

- RED: the new denied reconnect test spawned twice, the denied version-bump test spawned once, and health omitted spawner ancestry before implementation
- focused Vitest: 58/58 under both unset and set `CMUXLAYER_FORCE_INPROCESS`
- typecheck: clean under both unset and set `CMUXLAYER_FORCE_INPROCESS`
- build: clean
- full default suite / push hook: 145 files, 3382 passed, 1 skipped
- full forced-inprocess suite: 144 files passed, 1 known pre-existing `tests/live-topology-restart.test.ts` failure; 3381 passed, 1 failed, 1 skipped (same exact-main failure, outside D86)
- isolated launchd proof from a non-cmux process: access-control denial was logged and `/tmp/cmuxlayer-d86-proof-b0271b27/daemon.sock` was never created
- live health probe inside cmux: `/Applications/cmux.app (pid=28146)`

— cmuxlayerCodex-b0271b27 (worker) · codex/gpt-5.6-sol

<!-- golem-signature:v1:{"agent":"cmuxlayerCodex-b0271b27","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03934","timestamp":"2026-08-25T14:18:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when shared daemon respawn runs during reconnect and version bumps; a wrong socket probe result could block recovery outside cmux (by design) or delay it if probes flap before the guard allows spawn.
> 
> **Overview**
> **Daemon respawn is gated on cmux socket health** before the proxy spawns an installed daemon on reconnect failure or version bump. `canSpawnSharedDaemon` probes candidate sockets (via injectable `probeCmuxSocket` / default `probeProxyCmuxSocket`), allows spawn when the probe is **usable**, and suppresses spawn on **access-control denial**, unproven ancestry, or `CMUXLAYER_FORCE_IN_PROCESS`—with one structured `daemon spawn suppressed` log per reason/path/trigger. Reconnect spawn guard capacity is only consumed after the probe passes (`canAttempt` vs `allow`), so transient probe failures do not eat retry budget.
> 
> **Control health** now walks `ps` ancestry from the current process parent to find the real macOS `.app` spawner (`resolveSpawnerAncestry`, extra `ps -ww -axo pid=,ppid=,command=`), exposes `spawner_ancestry` on the health payload, and prints a `daemon spawner ancestry` line in formatted output.
> 
> Entry startup wires the same cmux probe into `runProxy` so proxy behavior matches entry autostart gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 034dde2d063771d50705022727e8c3ed788a8ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate daemon respawn by cmux ancestry and socket health
> - Adds `canSpawnSharedDaemon` to `CmuxLayerProxy` in [proxy.ts](https://github.com/EtanHey/cmuxlayer/pull/543/files#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2), which blocks daemon spawns when `CMUXLAYER_FORCE_INPROCESS` is set, when cmux socket probe reports access-control denial, or when spawner ancestry cannot be proven to be an app bundle.
> - Reconnect-driven and version-bump spawns now check `canSpawnSharedDaemon` before consuming `VersionBumpReconnectGuard` capacity; suppressed spawns log once per reason/path/trigger tuple via `logSpawnSuppression`.
> - `VersionBumpReconnectGuard.canAttempt` peeks at capacity without recording an attempt, so transient probe failures do not waste limited spawn slots.
> - `collectControlHealth` in [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/543/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d) runs `ps -ww -axo pid=,ppid=,command=` and walks the parent chain via `resolveSpawnerAncestry` to find the app bundle ancestor, surfacing it as `current_process.spawner_ancestry` in health output.
> - Risk: health collection now issues one extra `ps` invocation; proxies constructed without a `probeCmuxSocket` option fall back to `probeProxyCmuxSocket(env)` which probes candidate socket paths and may return access-control-denied, blocking otherwise-valid spawns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 034dde2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Control health reports the application ancestry of the daemon spawner, including its bundle path and process ID.
  - Proxy startup now checks cmux socket availability before spawning a shared daemon.

- **Bug Fixes**
  - Prevented unnecessary daemon launches when the cmux socket is unavailable or access is denied.
  - Applied socket checks consistently during reconnect failures and version changes.
  - Added clearer suppression logging for blocked daemon spawns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->