### PR TITLE
fix: enumerate topology across cmux windows

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -223,10 +223,12 @@ import {
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
   collectSurfaceTopology,
+  enumerateAllWindowWorkspaces,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
   isSurfaceObserverEpochCurrent,
   resolveAgentSurfaceBinding,
+  type AllWindowWorkspaceEnumeration,
   type SurfaceObserverEpoch,
   type SurfaceObserverIdProvider,
   type SurfaceTopologySnapshot,
@@ -1106,6 +1108,7 @@ interface AgentEngineClient {
   /** Native and CLI clients accept a stable UUID as the read-screen target. */
   supportsStableSurfaceReads?: boolean;
   listWindows?(): Promise<{ windows: CmuxWindow[] }>;
+  listAllWorkspaces?(): Promise<AllWindowWorkspaceEnumeration>;
   listWorkspaces(opts?: {
     window?: string;
   }): Promise<{ workspaces: CmuxWorkspace[] }>;
@@ -3035,7 +3038,7 @@ export class AgentEngine {
   ): Promise<string | undefined> {
     if (workspace || !repo) return workspace;
 
-    return resolveWorkspaceRefForRepo(repo, () => this.client.listWorkspaces());
+    return resolveWorkspaceRefForRepo(repo, () => this.listAllWorkspaces());
   }
 
   private async sendLaunchCommand(
@@ -5320,6 +5323,19 @@ export class AgentEngine {
 
   private captureSurfaceObserverEpoch(): SurfaceObserverEpoch {
     return captureObserverEpoch(this.surfaceObserverEpochProvider());
+  }
+
+  private async listAllWorkspaces(): Promise<AllWindowWorkspaceEnumeration> {
+    const listed = this.client.listAllWorkspaces
+      ? await this.client.listAllWorkspaces()
+      : await enumerateAllWindowWorkspaces(
+          this.client,
+          this.surfaceObserverEpochProvider(),
+        );
+    if (!listed.complete) {
+      throw new Error("Incomplete cmux all-window workspace enumeration");
+    }
+    return listed;
   }
 
   private isSurfaceObserverEpochCurrent(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -84,6 +84,7 @@ import type {
   CmuxReadScreenResult,
   CmuxSendOptions,
   CmuxStatusUpdate,
+  CmuxWindow,
   CmuxWorkspace,
   ParsedScreenResult,
   ParsedScreenStatus,
@@ -1104,7 +1105,10 @@ interface AgentEngineClient {
   getTransportHealth?(): TransportHealthSignal | null;
   /** Native and CLI clients accept a stable UUID as the read-screen target. */
   supportsStableSurfaceReads?: boolean;
-  listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }>;
+  listWindows?(): Promise<{ windows: CmuxWindow[] }>;
+  listWorkspaces(opts?: {
+    window?: string;
+  }): Promise<{ workspaces: CmuxWorkspace[] }>;
   log(
     message: string,
     opts?: {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -223,7 +223,7 @@ import {
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
   collectSurfaceTopology,
-  enumerateAllWindowWorkspaces,
+  enumerateAllWindowWorkspacesWithRetry,
   EMPTY_SURFACE_TOPOLOGY,
   healthTopologyOverrides,
   isSurfaceObserverEpochCurrent,
@@ -5328,7 +5328,7 @@ export class AgentEngine {
   private async listAllWorkspaces(): Promise<AllWindowWorkspaceEnumeration> {
     const listed = this.client.listAllWorkspaces
       ? await this.client.listAllWorkspaces()
-      : await enumerateAllWindowWorkspaces(
+      : await enumerateAllWindowWorkspacesWithRetry(
           this.client,
           this.surfaceObserverEpochProvider(),
         );

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -37,7 +37,7 @@ import { findWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
   captureSurfaceObserverEpoch,
-  enumerateAllWindowWorkspaces,
+  enumerateAllWindowWorkspacesWithRetry,
   enrichSurfaceIdsFromPanes,
   isSurfaceObserverEpochCurrent,
   type SurfaceObserverEpoch,
@@ -286,6 +286,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         supportsStableSurfaceReads: true,
         log: async () => {},
         listAllWorkspaces: () => this.listAllWorkspaces(),
+        listWindows: () => this.client.listWindows(),
         listWorkspaces: (workspaceOpts) =>
           this.client.listWorkspaces(workspaceOpts),
         setStatus: async () => {},
@@ -675,11 +676,10 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
     return captureSurfaceObserverEpoch(() => this.getSurfaceObserverEpoch());
   }
 
-  private async listAllWorkspaces(cache = true) {
-    const listed = await enumerateAllWindowWorkspaces(
+  private async listAllWorkspaces() {
+    const listed = await enumerateAllWindowWorkspacesWithRetry(
       this.client,
       () => this.getSurfaceObserverEpoch(),
-      { cache },
     );
     if (!listed.complete) {
       throw new Error("Incomplete cmux all-window workspace enumeration");

--- a/src/app-server-runtime.ts
+++ b/src/app-server-runtime.ts
@@ -37,6 +37,7 @@ import { findWorkspaceRefForRepo } from "./repo-workspace.js";
 import { partitionPaneSurfacesByMembership } from "./pane-surfaces.js";
 import {
   captureSurfaceObserverEpoch,
+  enumerateAllWindowWorkspaces,
   enrichSurfaceIdsFromPanes,
   isSurfaceObserverEpochCurrent,
   type SurfaceObserverEpoch,
@@ -227,7 +228,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         observerEpoch,
         "app-server surface enumeration",
       );
-      const workspaces = await this.client.listWorkspaces();
+      const workspaces = await this.listAllWorkspaces();
       const panesByWorkspace = await Promise.all(
         workspaces.workspaces.map(async (ws) => ({
           ref: ws.ref,
@@ -284,7 +285,9 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
         getTransportHealth: () => getTransportHealth(this.client),
         supportsStableSurfaceReads: true,
         log: async () => {},
-        listWorkspaces: () => this.client.listWorkspaces(),
+        listAllWorkspaces: () => this.listAllWorkspaces(),
+        listWorkspaces: (workspaceOpts) =>
+          this.client.listWorkspaces(workspaceOpts),
         setStatus: async () => {},
         setStatuses: async () => {},
         clearStatus: async () => {},
@@ -448,7 +451,7 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
       observerEpoch,
       "app-server thread start",
     );
-    const workspaces = await this.client.listWorkspaces();
+    const workspaces = await this.listAllWorkspaces();
     this.assertSurfaceObserverEpochCurrent(
       observerEpoch,
       "app-server thread start",
@@ -670,6 +673,18 @@ export class CmuxAppServerRuntime implements AppServerBridgeRuntime {
 
   private captureSurfaceObserverEpoch(): SurfaceObserverEpoch {
     return captureSurfaceObserverEpoch(() => this.getSurfaceObserverEpoch());
+  }
+
+  private async listAllWorkspaces(cache = true) {
+    const listed = await enumerateAllWindowWorkspaces(
+      this.client,
+      () => this.getSurfaceObserverEpoch(),
+      { cache },
+    );
+    if (!listed.complete) {
+      throw new Error("Incomplete cmux all-window workspace enumeration");
+    }
+    return listed;
   }
 
   private assertSurfaceObserverEpochCurrent(

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -10,6 +10,7 @@ import { delimiter, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import type {
   CmuxPane,
+  CmuxWindow,
   CmuxWorkspace,
   CmuxPaneSurfaces,
   CmuxNewSplitResult,
@@ -337,8 +338,17 @@ export class CmuxClient {
     return workspace;
   }
 
-  async listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }> {
-    const raw = await this.run(["list-workspaces"]);
+  async listWindows(): Promise<{ windows: CmuxWindow[] }> {
+    const raw = await this.run(["list-windows"]);
+    return this.parse(raw, "list-windows");
+  }
+
+  async listWorkspaces(opts?: {
+    window?: string;
+  }): Promise<{ workspaces: CmuxWorkspace[] }> {
+    const args = ["list-workspaces"];
+    if (opts?.window) args.push("--window", opts.window);
+    const raw = await this.run(args);
     return this.parse(raw, "list-workspaces");
   }
 

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -340,7 +340,10 @@ export class CmuxClient {
 
   async listWindows(): Promise<{ windows: CmuxWindow[] }> {
     const raw = await this.run(["list-windows"]);
-    return this.parse(raw, "list-windows");
+    const parsed = this.parse<unknown>(raw, "list-windows");
+    return Array.isArray(parsed)
+      ? { windows: parsed as CmuxWindow[] }
+      : (parsed as { windows: CmuxWindow[] });
   }
 
   async listWorkspaces(opts?: {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -254,7 +254,14 @@ export class CmuxSocketClient {
   }
 
   async listWindows(): Promise<{ windows: CmuxWindow[] }> {
-    return this.call("window.list");
+    try {
+      return await this.call("window.list");
+    } catch (e) {
+      if (this.isMethodNotFound(e) && this.cliFallback) {
+        return this.cliFallbackPinned()!.listWindows();
+      }
+      throw e;
+    }
   }
 
   async listWorkspaces(opts?: {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -29,6 +29,7 @@ import { CmuxPersistentSocket } from "./cmux-persistent-socket.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 import { parseCmuxStatusFrame } from "./cmux-status-frame.js";
+import { listAllWindowWorkspaces } from "./surface-topology.js";
 export { CmuxSocketError } from "./cmux-socket-error.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
@@ -835,7 +836,10 @@ export class CmuxSocketClient {
   ): Promise<string> {
     if (workspace) return workspace;
 
-    const { workspaces } = await this.listWorkspaces();
+    const { workspaces } = await listAllWindowWorkspaces(
+      this,
+      () => this.currentObserverTransportEpoch(),
+    );
     for (const ws of workspaces) {
       const surfaces = await this.listPaneSurfaces({ workspace: ws.ref });
       if (surfaces.surfaces.some((s) => s.ref === surface)) {

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -10,6 +10,7 @@
 
 import type {
   CmuxWorkspace,
+  CmuxWindow,
   CmuxPaneSurfaces,
   CmuxPane,
   CmuxNewSplitResult,
@@ -252,8 +253,16 @@ export class CmuxSocketClient {
     return result.pong === true;
   }
 
-  async listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }> {
-    return this.call("workspace.list");
+  async listWindows(): Promise<{ windows: CmuxWindow[] }> {
+    return this.call("window.list");
+  }
+
+  async listWorkspaces(opts?: {
+    window?: string;
+  }): Promise<{ workspaces: CmuxWorkspace[] }> {
+    return this.call("workspace.list", {
+      ...(opts?.window ? { window_id: opts.window } : {}),
+    });
   }
 
   async selectWorkspace(workspace: string): Promise<void> {

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -81,6 +81,7 @@ export interface CmuxSelfHealingClientOptions {
 }
 
 const FORWARDED_ASYNC_METHODS = [
+  "listWindows",
   "listWorkspaces",
   "listPaneSurfaces",
   "listPanes",
@@ -127,6 +128,7 @@ interface QueuedFailedPayload {
 }
 
 const READ_ONLY_METHODS = new Set<ForwardedAsyncMethod>([
+  "listWindows",
   "listWorkspaces",
   "listPaneSurfaces",
   "listPanes",

--- a/src/cmux-transport-self-heal.ts
+++ b/src/cmux-transport-self-heal.ts
@@ -9,6 +9,7 @@ import { CmuxClient } from "./cmux-client.js";
 import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
 import { CmuxSocketClient } from "./cmux-socket-client.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
+import { SURFACE_TOPOLOGY_CLIENT_METHODS } from "./surface-topology.js";
 import type { CreateCmuxClientOptions } from "./cmux-client-factory.js";
 import {
   candidateSocketPathsForOpts,
@@ -81,10 +82,7 @@ export interface CmuxSelfHealingClientOptions {
 }
 
 const FORWARDED_ASYNC_METHODS = [
-  "listWindows",
-  "listWorkspaces",
-  "listPaneSurfaces",
-  "listPanes",
+  ...SURFACE_TOPOLOGY_CLIENT_METHODS,
   "listTerminalMetadata",
   "newSplit",
   "newSurface",

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -218,14 +218,14 @@ export function findWorkspaceRefForRepo(
 
 export async function resolveWorkspaceRefForRepo(
   repo: string | null | undefined,
-  listWorkspaces: () => Promise<{
+  listAllWorkspaces: () => Promise<{
     workspaces: Array<WorkspaceCandidate>;
   }>,
   opts: FindWorkspaceForRepoOptions = {},
 ): Promise<string | undefined> {
   if (!repo) return undefined;
   try {
-    const { workspaces } = await listWorkspaces();
+    const { workspaces } = await listAllWorkspaces();
     return findWorkspaceRefForRepo(workspaces, repo, opts);
   } catch {
     return undefined;

--- a/src/repo-workspace.ts
+++ b/src/repo-workspace.ts
@@ -224,10 +224,6 @@ export async function resolveWorkspaceRefForRepo(
   opts: FindWorkspaceForRepoOptions = {},
 ): Promise<string | undefined> {
   if (!repo) return undefined;
-  try {
-    const { workspaces } = await listAllWorkspaces();
-    return findWorkspaceRefForRepo(workspaces, repo, opts);
-  } catch {
-    return undefined;
-  }
+  const { workspaces } = await listAllWorkspaces();
+  return findWorkspaceRefForRepo(workspaces, repo, opts);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7714,31 +7714,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             remapped_to: route.surface,
           }
         : route;
-    const throwStaleSurfaceRef = (
-      snapshot: SurfaceTopologySnapshot | null,
-      diagnostic?: string,
-    ): never => {
-      const liveAgents: Array<{ agent_id: string; surface_id: string }> = [];
+    const throwStaleSurfaceRef = (diagnostic?: string): never => {
+      const expectedUuidKey = expectedUuid?.trim().toLowerCase() ?? null;
+      const owners: AgentRecord[] = [];
       const seen = new Set<string>();
       for (const record of stateMgr.listStates()) {
-        const uuid = record.surface_uuid?.trim();
-        const currentRef =
-          uuid && snapshot ? findSurfaceRefByUuid(snapshot, uuid) : null;
-        const liveRef =
-          currentRef ??
-          (snapshot?.workspaceBySurface.has(record.surface_id)
-            ? record.surface_id
-            : null);
-        if (!liveRef || seen.has(record.agent_id)) continue;
+        const recordUuidKey = record.surface_uuid?.trim().toLowerCase() ?? null;
+        const ownsRequestedRef = record.surface_id === requestedSurface;
+        const ownsExpectedUuid = Boolean(
+          expectedUuidKey && recordUuidKey === expectedUuidKey,
+        );
+        if (
+          (!ownsRequestedRef && !ownsExpectedUuid) ||
+          seen.has(record.agent_id)
+        ) {
+          continue;
+        }
         seen.add(record.agent_id);
-        liveAgents.push({ agent_id: record.agent_id, surface_id: liveRef });
+        owners.push(record);
       }
       const occupancy =
-        liveAgents.length === 1
-          ? `${requestedSurface} is stale; agent ${liveAgents[0].agent_id} is alive at ${liveAgents[0].surface_id} — use agent_id`
-          : liveAgents.length > 1
-            ? `${requestedSurface} is stale; live managed agents: ${liveAgents
-                .map((agent) => `${agent.agent_id} at ${agent.surface_id}`)
+        owners.length === 1
+          ? `${requestedSurface} is stale; agent ${owners[0].agent_id} owns this ref but no live route was proven — use agent_id`
+          : owners.length > 1
+            ? `${requestedSurface} is stale; managed agents recorded on this ref: ${owners
+                .map((agent) => agent.agent_id)
                 .join(", ")} — use agent_id`
             : `${requestedSurface} is stale; no live managed agent maps this ref`;
       throw new Error(diagnostic ? `${occupancy} (${diagnostic})` : occupancy);
@@ -7771,7 +7771,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const currentRef = findSurfaceRefByUuid(topology, stableUuid);
         if (!currentRef) {
           return throwStaleSurfaceRef(
-            topology,
             `Stable surface UUID ${stableUuid} captured for ${requestedSurface} ` +
               `is no longer live; refusing ${operation} rather than using a recycled ref.`,
           );
@@ -7813,11 +7812,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         topology.surfaceIdByRef.size > 0 ||
         topology.surfaceRefById.size > 0
       ) {
-        throwStaleSurfaceRef(topology);
+        throwStaleSurfaceRef();
       }
 
       if (!topology.workspaceBySurface.has(requestedSurface)) {
-        throwStaleSurfaceRef(topology);
+        throwStaleSurfaceRef();
       }
 
       const workspace =
@@ -11502,7 +11501,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           getTransportHealth: () => getTransportHealth(client),
           supportsStableSurfaceReads: true,
           log: (message, eventOpts) => client.log(message, eventOpts),
-          listWorkspaces: () => client.listWorkspaces(),
+          ...(typeof client.listWindows === "function"
+            ? { listWindows: () => client.listWindows() }
+            : {}),
+          listWorkspaces: (workspaceOpts) =>
+            client.listWorkspaces(workspaceOpts),
           setStatus: (key, value, statusOpts) =>
             client.setStatus(key, value, statusOpts),
           setStatuses: async (updates) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -249,6 +249,7 @@ import {
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
   collectSurfaceTopology as collectCmuxSurfaceTopology,
+  enumerateAllWindowWorkspaces,
   EMPTY_SURFACE_TOPOLOGY,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
@@ -3824,6 +3825,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const ownsContext = !opts?.context;
   const context = opts?.context ?? createServerContext(opts);
   const client = context.client;
+  const listAllWorkspaces = async (cache = true) => {
+    const listed = await enumerateAllWindowWorkspaces(
+      client,
+      () => context.surfaceObserverEpoch,
+      { cache },
+    );
+    if (!listed.complete) {
+      throw new SurfaceEnumerationError(
+        "Malformed cmux surface enumeration: incomplete all-window workspace enumeration",
+      );
+    }
+    return listed;
+  };
   const stateMgr = context.stateMgr;
   const roleSurfaceOverrides = context.roleSurfaceOverrides;
   const explicitRoleForDiscoveredSurface = (
@@ -4642,7 +4656,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const resolveWorkspaceForRepo = async (
     repo: string | null | undefined,
   ): Promise<string | undefined> => {
-    return resolveWorkspaceRefForRepo(repo, () => client.listWorkspaces());
+    return resolveWorkspaceRefForRepo(repo, listAllWorkspaces);
   };
 
   const getSurfaceDelivery = (surface: string) => {
@@ -7128,7 +7142,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   ): Promise<string | undefined> => {
     if (!candidate) return undefined;
     try {
-      const { workspaces } = await client.listWorkspaces();
+      const { workspaces } = await listAllWorkspaces();
       const normalized = candidate.trim();
       return (
         workspaces.find(
@@ -7150,7 +7164,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         typeof value === "string" && value.trim().length > 0,
     );
     try {
-      const { workspaces } = await client.listWorkspaces();
+      const { workspaces } = await listAllWorkspaces();
       for (const candidate of candidates) {
         const match = workspaces.find((workspace) =>
           envWorkspaceMatches(workspace, candidate),
@@ -7191,7 +7205,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   /** Currently-focused workspace ref, or undefined if it can't be read. */
   const currentFocusedWorkspace = async (): Promise<string | undefined> => {
     try {
-      const { workspaces } = await client.listWorkspaces();
+      const { workspaces } = await listAllWorkspaces();
       return workspaces.find((w) => w.selected)?.ref;
     } catch {
       return undefined;
@@ -7241,12 +7255,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (!repo) return;
     let workspace: CmuxWorkspace | undefined;
     try {
-      const listed = await client.listWorkspaces();
+      const listed = await listAllWorkspaces();
       workspace = listed.workspaces.find((candidate) =>
         envWorkspaceMatches(candidate, workspaceRef),
       );
-    } catch {
-      return;
+    } catch (error) {
+      throw new PlacementWorkspaceError(
+        `Cannot verify whether workspace ${workspaceRef} belongs to repo ${repo}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
     }
     const cwd = workspace?.current_directory?.trim();
     if (!cwd || workspaceDirectoryRepoMatchScore(repo, cwd) > 0) return;
@@ -7321,7 +7338,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
 
     try {
-      const { workspaces } = await client.listWorkspaces();
+      const { workspaces } = await listAllWorkspaces();
       const paneLists = await Promise.all(
         workspaces.map(async (workspace) => ({
           workspace: workspace.ref,
@@ -7546,7 +7563,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     try {
       const workspaceRefs = workspace
         ? [workspace]
-        : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+        : (await listAllWorkspaces()).workspaces.map((ws) => ws.ref);
 
       for (const workspaceRef of workspaceRefs) {
         const panes = await client.listPanes({ workspace: workspaceRef });
@@ -8269,7 +8286,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     async (args) => {
       try {
         const listingObserverEpoch = context.surfaceObserverEpoch;
-        const workspaces = await client.listWorkspaces();
+        const workspaces = await listAllWorkspaces();
         const targetWorkspaceRefs = args.workspace
           ? [args.workspace]
           : workspaces.workspaces.map((workspace) => workspace.ref);
@@ -8680,7 +8697,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         );
 
         const [{ workspaces }, panes] = await Promise.all([
-          client.listWorkspaces(),
+          listAllWorkspaces(),
           client.listPanes({ workspace: targetWorkspace }),
         ]);
         const paneGroups = await Promise.all(
@@ -11245,7 +11262,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let lastLifecycleSurfaces: CmuxSurface[] | null = null;
     let lastLifecycleSurfaceObserverEpoch: string | null = null;
     const readLifecycleSurfaces = async () => {
-      const workspaces = await client.listWorkspaces();
+      const workspaces = await listAllWorkspaces();
       const workspaceList = requireSurfaceEnumerationArray<CmuxWorkspace>(
         workspaces.workspaces,
         "workspaces.workspaces",
@@ -11504,6 +11521,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ...(typeof client.listWindows === "function"
             ? { listWindows: () => client.listWindows() }
             : {}),
+          listAllWorkspaces,
           listWorkspaces: (workspaceOpts) =>
             client.listWorkspaces(workspaceOpts),
           setStatus: (key, value, statusOpts) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -249,7 +249,7 @@ import {
 import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
   collectSurfaceTopology as collectCmuxSurfaceTopology,
-  enumerateAllWindowWorkspaces,
+  enumerateAllWindowWorkspacesWithRetry,
   EMPTY_SURFACE_TOPOLOGY,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
@@ -3825,11 +3825,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const ownsContext = !opts?.context;
   const context = opts?.context ?? createServerContext(opts);
   const client = context.client;
-  const listAllWorkspaces = async (cache = true) => {
-    const listed = await enumerateAllWindowWorkspaces(
+  const listAllWorkspaces = async () => {
+    const listed = await enumerateAllWindowWorkspacesWithRetry(
       client,
       () => context.surfaceObserverEpoch,
-      { cache },
     );
     if (!listed.complete) {
       throw new SurfaceEnumerationError(
@@ -7206,7 +7205,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const currentFocusedWorkspace = async (): Promise<string | undefined> => {
     try {
       const { workspaces } = await listAllWorkspaces();
-      return workspaces.find((w) => w.selected)?.ref;
+      const callerContext = currentCallerContext();
+      const callerCandidates = [
+        callerContext?.workspaceId,
+        callerContext?.tabId,
+      ].filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      );
+      const callerWorkspace = callerCandidates
+        .map((candidate) =>
+          workspaces.find((workspace) =>
+            envWorkspaceMatches(workspace, candidate),
+          ),
+        )
+        .find((workspace) => workspace !== undefined);
+      if (callerWorkspace?.window_ref) {
+        return workspaces.find(
+          (workspace) =>
+            workspace.selected &&
+            workspace.window_ref === callerWorkspace.window_ref,
+        )?.ref;
+      }
+      const connectorWorkspaces = await client.listWorkspaces();
+      return connectorWorkspaces.workspaces.find((workspace) => workspace.selected)
+        ?.ref;
     } catch {
       return undefined;
     }
@@ -9922,7 +9945,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.workspace,
             "read_screen",
           );
-          if (route.surface === args.surface) throw readError;
+          if (
+            route.surface === args.surface &&
+            (route.workspace ?? null) === (args.workspace ?? null)
+          ) {
+            throw readError;
+          }
           screenRemap = remapFields(route);
           ({ result, topology } = await readScreenSnapshot({
             ...snapshotOpts,

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -7,6 +7,7 @@ import type {
   CmuxPane,
   CmuxPaneSurfaces,
   CmuxSurface,
+  CmuxWindow,
   CmuxWorkspace,
 } from "./types.js";
 
@@ -40,7 +41,10 @@ export interface ResolvedAgentSurfaceBinding {
 }
 
 export interface SurfaceTopologyClient {
-  listWorkspaces(): Promise<{ workspaces: CmuxWorkspace[] }>;
+  listWindows?(): Promise<{ windows: CmuxWindow[] }>;
+  listWorkspaces(opts?: {
+    window?: string;
+  }): Promise<{ workspaces: CmuxWorkspace[] }>;
   listPanes(opts?: { workspace?: string }): Promise<{
     workspace_ref?: string;
     window_ref?: string;
@@ -295,10 +299,37 @@ export async function collectSurfaceTopology(
   }
 
   let workspaceRefs: string[];
+  let workspaceEnumerationComplete = true;
   try {
-    workspaceRefs = workspace
-      ? [workspace]
-      : (await client.listWorkspaces()).workspaces.map((ws) => ws.ref);
+    if (workspace) {
+      workspaceRefs = [workspace];
+    } else if (client.listWindows) {
+      const listedWindows = await client.listWindows();
+      if (!Array.isArray(listedWindows.windows)) return null;
+      const refs = new Set<string>();
+      for (const window of listedWindows.windows) {
+        const windowTarget = window.ref ?? window.id;
+        if (!windowTarget) return null;
+        const listedWorkspaces = await client.listWorkspaces({
+          window: windowTarget,
+        });
+        if (!Array.isArray(listedWorkspaces.workspaces)) return null;
+        if (
+          typeof window.workspace_count === "number" &&
+          listedWorkspaces.workspaces.length !== window.workspace_count
+        ) {
+          workspaceEnumerationComplete = false;
+        }
+        for (const listedWorkspace of listedWorkspaces.workspaces) {
+          refs.add(listedWorkspace.ref);
+        }
+      }
+      workspaceRefs = [...refs];
+    } else {
+      workspaceRefs = (await client.listWorkspaces()).workspaces.map(
+        (ws) => ws.ref,
+      );
+    }
   } catch {
     return null;
   }
@@ -306,7 +337,7 @@ export async function collectSurfaceTopology(
   const snapshot: SurfaceTopologySnapshot = {
     observerId,
     observerEpoch,
-    complete: true,
+    complete: workspaceEnumerationComplete,
     surfaces: [],
     workspaceBySurface: new Map(),
     titleBySurface: new Map(),

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -65,6 +65,22 @@ export type SurfaceObserverIdProvider = () => string | null | undefined;
  */
 export type SurfaceObserverEpoch = string | null | undefined;
 
+export interface AllWindowWorkspaceEnumeration {
+  workspaces: CmuxWorkspace[];
+  complete: boolean;
+  window_count: number | null;
+}
+
+interface CachedWorkspaceEnumeration {
+  observerEpoch: string;
+  pending: Promise<AllWindowWorkspaceEnumeration>;
+}
+
+const workspaceEnumerationCache = new WeakMap<
+  object,
+  CachedWorkspaceEnumeration
+>();
+
 export function captureSurfaceObserverEpoch(
   observerIdProvider?: SurfaceObserverIdProvider,
 ): SurfaceObserverEpoch {
@@ -83,6 +99,112 @@ export function isSurfaceObserverEpochCurrent(
   if (observerEpoch === undefined) return true;
   if (!observerEpoch || !observerIdProvider) return false;
   return captureSurfaceObserverEpoch(observerIdProvider) === observerEpoch;
+}
+
+export async function enumerateAllWindowWorkspaces(
+  client: Pick<SurfaceTopologyClient, "listWindows" | "listWorkspaces">,
+  observerEpochProvider?: SurfaceObserverIdProvider,
+  opts: { cache?: boolean } = {},
+): Promise<AllWindowWorkspaceEnumeration> {
+  const observerEpoch = captureSurfaceObserverEpoch(observerEpochProvider);
+  const cacheKey = client as object;
+  if (observerEpoch && opts.cache !== false) {
+    const cached = workspaceEnumerationCache.get(cacheKey);
+    if (cached?.observerEpoch === observerEpoch) return cached.pending;
+  }
+
+  const enumerate = async (): Promise<AllWindowWorkspaceEnumeration> => {
+    if (!client.listWindows) {
+      const listed = await client.listWorkspaces();
+      return {
+        workspaces: listed.workspaces,
+        complete: Array.isArray(listed.workspaces),
+        window_count: null,
+      };
+    }
+
+    const listedWindows = await client.listWindows();
+    if (
+      listedWindows == null ||
+      !Object.prototype.hasOwnProperty.call(listedWindows, "windows")
+    ) {
+      // Legacy/test doubles may expose the optional method without supporting
+      // it. Production socket clients convert method_not_found to CLI first.
+      const listed = await client.listWorkspaces();
+      return {
+        workspaces: listed.workspaces,
+        complete: Array.isArray(listed.workspaces),
+        window_count: null,
+      };
+    }
+    if (!Array.isArray(listedWindows.windows)) {
+      throw new Error("Malformed cmux window enumeration");
+    }
+    let complete = listedWindows.windows.length > 0;
+    const workspaceLists = await Promise.all(
+      listedWindows.windows.map(async (window) => {
+        const windowTarget = window.ref ?? window.id;
+        if (!windowTarget) {
+          complete = false;
+          return [] as CmuxWorkspace[];
+        }
+        const listed = await client.listWorkspaces({ window: windowTarget });
+        if (!Array.isArray(listed.workspaces)) {
+          throw new Error(
+            `Malformed cmux workspace enumeration for ${windowTarget}`,
+          );
+        }
+        if (
+          typeof window.workspace_count === "number"
+            ? listed.workspaces.length !== window.workspace_count
+            : listed.workspaces.length === 0
+        ) {
+          complete = false;
+        }
+        return listed.workspaces;
+      }),
+    );
+    const byRef = new Map<string, CmuxWorkspace>();
+    for (const workspace of workspaceLists.flat()) {
+      byRef.set(workspace.ref, workspace);
+    }
+    return {
+      workspaces: [...byRef.values()],
+      complete,
+      window_count: listedWindows.windows.length,
+    };
+  };
+
+  const pending = enumerate();
+  if (observerEpoch && opts.cache !== false) {
+    // Coalesce the N callers in one observer epoch that arrive together, but
+    // do not retain a completed map: windows/workspaces can change without an
+    // observer reconnect, and route-proof callers must see that same-epoch
+    // topology change on their next observation.
+    workspaceEnumerationCache.set(cacheKey, { observerEpoch, pending });
+    const clearPending = () => {
+      const cached = workspaceEnumerationCache.get(cacheKey);
+      if (cached?.pending === pending) {
+        workspaceEnumerationCache.delete(cacheKey);
+      }
+    };
+    void pending.then(clearPending, clearPending);
+  }
+  return pending;
+}
+
+export async function listAllWindowWorkspaces(
+  client: Pick<SurfaceTopologyClient, "listWindows" | "listWorkspaces">,
+  observerEpochProvider?: SurfaceObserverIdProvider,
+): Promise<{ workspaces: CmuxWorkspace[] }> {
+  const result = await enumerateAllWindowWorkspaces(
+    client,
+    observerEpochProvider,
+  );
+  if (!result.complete) {
+    throw new Error("Incomplete cmux all-window workspace enumeration");
+  }
+  return { workspaces: result.workspaces };
 }
 
 export const EMPTY_SURFACE_TOPOLOGY: SurfaceTopology = {
@@ -303,32 +425,13 @@ export async function collectSurfaceTopology(
   try {
     if (workspace) {
       workspaceRefs = [workspace];
-    } else if (client.listWindows) {
-      const listedWindows = await client.listWindows();
-      if (!Array.isArray(listedWindows.windows)) return null;
-      const refs = new Set<string>();
-      for (const window of listedWindows.windows) {
-        const windowTarget = window.ref ?? window.id;
-        if (!windowTarget) return null;
-        const listedWorkspaces = await client.listWorkspaces({
-          window: windowTarget,
-        });
-        if (!Array.isArray(listedWorkspaces.workspaces)) return null;
-        if (
-          typeof window.workspace_count === "number" &&
-          listedWorkspaces.workspaces.length !== window.workspace_count
-        ) {
-          workspaceEnumerationComplete = false;
-        }
-        for (const listedWorkspace of listedWorkspaces.workspaces) {
-          refs.add(listedWorkspace.ref);
-        }
-      }
-      workspaceRefs = [...refs];
     } else {
-      workspaceRefs = (await client.listWorkspaces()).workspaces.map(
-        (ws) => ws.ref,
+      const listed = await enumerateAllWindowWorkspaces(
+        client,
+        observerEpochProvider,
       );
+      workspaceEnumerationComplete = listed.complete;
+      workspaceRefs = listed.workspaces.map((ws) => ws.ref);
     }
   } catch {
     return null;

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -56,6 +56,19 @@ export interface SurfaceTopologyClient {
   }): Promise<CmuxPaneSurfaces>;
 }
 
+const SURFACE_TOPOLOGY_CLIENT_METHOD_MAP = {
+  listWindows: true,
+  listWorkspaces: true,
+  listPanes: true,
+  listPaneSurfaces: true,
+} satisfies Record<keyof SurfaceTopologyClient, true>;
+
+export const SURFACE_TOPOLOGY_CLIENT_METHODS = Object.freeze(
+  Object.keys(SURFACE_TOPOLOGY_CLIENT_METHOD_MAP) as Array<
+    keyof SurfaceTopologyClient
+  >,
+);
+
 export type SurfaceObserverIdProvider = () => string | null | undefined;
 
 /**
@@ -161,7 +174,10 @@ export async function enumerateAllWindowWorkspaces(
         ) {
           complete = false;
         }
-        return listed.workspaces;
+        return listed.workspaces.map((workspace) => ({
+          ...workspace,
+          window_ref: workspace.window_ref ?? windowTarget,
+        }));
       }),
     );
     const byRef = new Map<string, CmuxWorkspace>();
@@ -193,11 +209,25 @@ export async function enumerateAllWindowWorkspaces(
   return pending;
 }
 
+export async function enumerateAllWindowWorkspacesWithRetry(
+  client: Pick<SurfaceTopologyClient, "listWindows" | "listWorkspaces">,
+  observerEpochProvider?: SurfaceObserverIdProvider,
+): Promise<AllWindowWorkspaceEnumeration> {
+  const first = await enumerateAllWindowWorkspaces(
+    client,
+    observerEpochProvider,
+  );
+  if (first.complete) return first;
+  return enumerateAllWindowWorkspaces(client, observerEpochProvider, {
+    cache: false,
+  });
+}
+
 export async function listAllWindowWorkspaces(
   client: Pick<SurfaceTopologyClient, "listWindows" | "listWorkspaces">,
   observerEpochProvider?: SurfaceObserverIdProvider,
 ): Promise<{ workspaces: CmuxWorkspace[] }> {
-  const result = await enumerateAllWindowWorkspaces(
+  const result = await enumerateAllWindowWorkspacesWithRetry(
     client,
     observerEpochProvider,
   );
@@ -426,7 +456,7 @@ export async function collectSurfaceTopology(
     if (workspace) {
       workspaceRefs = [workspace];
     } else {
-      const listed = await enumerateAllWindowWorkspaces(
+      const listed = await enumerateAllWindowWorkspacesWithRetry(
         client,
         observerEpochProvider,
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,17 @@ export interface CmuxWorkspace {
   current_directory?: string | null;
 }
 
+export interface CmuxWindow {
+  id?: string;
+  ref?: string;
+  index?: number;
+  key?: boolean;
+  visible?: boolean;
+  workspace_count?: number;
+  selected_workspace_id?: string | null;
+  selected_workspace_ref?: string | null;
+}
+
 export type SurfaceWorkingDirectorySource =
   | "terminal_metadata"
   | "surface"

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface SurfaceMode {
 export interface CmuxWorkspace {
   id?: string;
   ref: string;
+  /** Owning window, attached by all-window topology enumeration. */
+  window_ref?: string;
   title: string;
   index: number;
   selected: boolean;

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -848,6 +848,78 @@ describe("CmuxAppServerRuntime", () => {
     }
   });
 
+  it("starts a thread in a repo workspace belonging to another window", async () => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const client = makeClient();
+    client.listWindows = vi.fn().mockResolvedValue({
+      windows: [
+        { ref: "window:A", workspace_count: 1 },
+        { ref: "window:B", workspace_count: 1 },
+      ],
+    });
+    client.listWorkspaces.mockImplementation(
+      async (opts?: { window?: string }) => ({
+        workspaces:
+          opts?.window === "window:B"
+            ? [
+                {
+                  ref: "workspace:B",
+                  title: "brainlayer",
+                  current_directory: "/Users/test/Gits/brainlayer",
+                },
+              ]
+            : [
+                {
+                  ref: "workspace:A",
+                  title: "cmuxlayer",
+                  current_directory: "/Users/test/Gits/cmuxlayer",
+                },
+              ],
+      }),
+    );
+    client.identify.mockResolvedValue({
+      focused: {
+        workspace_ref: "workspace:B",
+        surface_ref: "surface:new",
+      },
+    });
+    const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    const record = makeRecord();
+    const spawnAgent = vi
+      .spyOn((runtime as any).engine, "spawnAgent")
+      .mockResolvedValue({
+        agent_id: record.agent_id,
+        surface_id: "surface:new",
+        workspace_id: "workspace:B",
+        state: "booting",
+      });
+    vi.spyOn(runtime as any, "waitForCodexPrompt").mockResolvedValue(undefined);
+    vi.spyOn((runtime as any).engine, "getAgentState").mockReturnValue({
+      ...record,
+      surface_id: "surface:new",
+      workspace_id: "workspace:B",
+    });
+
+    try {
+      await expect(
+        runtime.startThread({ cwd: "/Users/test/Gits/brainlayer" }),
+      ).resolves.toMatchObject({ threadId: record.agent_id });
+      expect(spawnAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ workspace: "workspace:B" }),
+      );
+      expect(client.listWorkspaces).toHaveBeenCalledWith({
+        window: "window:A",
+      });
+      expect(client.listWorkspaces).toHaveBeenCalledWith({
+        window: "window:B",
+      });
+    } finally {
+      runtime.dispose();
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
   it("refuses to start a thread when no workspace belongs to its repo instead of using the selected workspace", async () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     mkdirSync(TEST_DIR, { recursive: true });

--- a/tests/app-server-runtime.test.ts
+++ b/tests/app-server-runtime.test.ts
@@ -48,6 +48,7 @@ function makeClient() {
   return {
     getTransportHealth: () => ({ mode: "socket", degraded: false }),
     currentSocketPath: vi.fn(() => "/tmp/cmux-app-test.sock"),
+    listWindows: vi.fn().mockResolvedValue(undefined),
     listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
     listPanes: vi.fn().mockResolvedValue({ panes: [] }),
     listPaneSurfaces: vi.fn().mockResolvedValue({ surfaces: [] }),
@@ -885,6 +886,9 @@ describe("CmuxAppServerRuntime", () => {
       },
     });
     const runtime = new CmuxAppServerRuntime({ client, stateDir: TEST_DIR });
+    expect((runtime as any).engine.client.listWindows).toEqual(
+      expect.any(Function),
+    );
     const record = makeRecord();
     const spawnAgent = vi
       .spyOn((runtime as any).engine, "spawnAgent")

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -67,26 +67,33 @@ describe("CmuxClient.listWorkspaces", () => {
 });
 
 describe("CmuxClient.listWindows", () => {
-  it("calls cmux --json list-windows", async () => {
-    const { client, exec } = mockClient({
-      windows: [
-        {
-          ref: "window:2",
-          id: "11111111-2222-4333-8444-555555555555",
-          index: 0,
-          key: true,
-          visible: true,
-          workspace_count: 1,
-        },
-      ],
-    });
+  it("normalizes the captured bare-array CLI envelope", async () => {
+    const { client, exec } = mockClient([
+      {
+        id: "22C79E1B-0D28-44F1-A9A1-EA2B232A31F1",
+        index: 0,
+        key: false,
+        selected_workspace_id: "A00EB8D5-5383-4711-9671-07F58E8CB868",
+        workspace_count: 1,
+      },
+      {
+        id: "514AF6DA-3510-4DD0-9531-3607E386B6CC",
+        index: 1,
+        key: true,
+        selected_workspace_id: "DD9FC08A-BF20-45FD-A7AC-C1166DA802B8",
+        workspace_count: 1,
+      },
+    ]);
 
     const result = await client.listWindows();
 
     expect(exec).toHaveBeenCalledWith("cmux", [
       "--json", "--id-format", "both", "list-windows",
     ]);
-    expect(result.windows[0]?.ref).toBe("window:2");
+    expect(result.windows).toHaveLength(2);
+    expect(result.windows[0]?.id).toBe(
+      "22C79E1B-0D28-44F1-A9A1-EA2B232A31F1",
+    );
   });
 });
 

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -51,6 +51,43 @@ describe("CmuxClient.listWorkspaces", () => {
     expect(result.workspaces).toHaveLength(1);
     expect(result.workspaces[0].ref).toBe("workspace:1");
   });
+
+  it("scopes workspace enumeration to an explicit window", async () => {
+    const { client, exec } = mockClient({ workspaces: [] });
+
+    await client.listWorkspaces({ window: "window:2" });
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json", "--id-format", "both",
+      "list-workspaces",
+      "--window",
+      "window:2",
+    ]);
+  });
+});
+
+describe("CmuxClient.listWindows", () => {
+  it("calls cmux --json list-windows", async () => {
+    const { client, exec } = mockClient({
+      windows: [
+        {
+          ref: "window:2",
+          id: "11111111-2222-4333-8444-555555555555",
+          index: 0,
+          key: true,
+          visible: true,
+          workspace_count: 1,
+        },
+      ],
+    });
+
+    const result = await client.listWindows();
+
+    expect(exec).toHaveBeenCalledWith("cmux", [
+      "--json", "--id-format", "both", "list-windows",
+    ]);
+    expect(result.windows[0]?.ref).toBe("window:2");
+  });
 });
 
 describe("CmuxClient observer transport identity", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -47,6 +47,18 @@ type MockResponseHandler = (req: MockV2Request) => unknown;
 
 const MOCK_RESPONSES: Record<string, unknown> = {
   "system.ping": { pong: true },
+  "window.list": {
+    windows: [
+      {
+        id: "11111111-2222-4333-8444-555555555555",
+        ref: "window:2",
+        index: 0,
+        key: true,
+        visible: true,
+        workspace_count: 1,
+      },
+    ],
+  },
   "workspace.list": {
     workspaces: [
       {
@@ -479,6 +491,26 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(result.workspaces[0]).toHaveProperty("title");
     expect(result.workspaces[0]).toHaveProperty("index");
     expect(result.workspaces[0]).toHaveProperty("selected");
+  });
+
+  it("listWindows sends a window.list request", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    const result = await client.listWindows();
+
+    expect(result.windows[0]?.ref).toBe("window:2");
+    expect(lastV2Request).toEqual({ method: "window.list", params: {} });
+  });
+
+  it("scopes workspace.list to an explicit window", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await client.listWorkspaces({ window: "window:2" });
+
+    expect(lastV2Request).toEqual({
+      method: "workspace.list",
+      params: { window_id: "window:2" },
+    });
   });
 
   it("selectWorkspace sends a workspace.select request", async () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -1119,6 +1119,12 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
   function createMockCli(): CmuxClient {
     cliCalls = [];
     return {
+      listWindows: async () => {
+        cliCalls.push({ method: "listWindows", args: [] });
+        return {
+          windows: [{ id: "cli-window", workspace_count: 1 }],
+        };
+      },
       newSplit: async (direction: string, opts?: unknown) => {
         cliCalls.push({ method: "newSplit", args: [direction, opts] });
         return {
@@ -1163,6 +1169,24 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
       },
     } as unknown as CmuxClient;
   }
+
+  it("listWindows falls back to CLI when window.list returns method_not_found", async () => {
+    const saved = MOCK_RESPONSES["window.list"];
+    delete MOCK_RESPONSES["window.list"];
+    try {
+      const client = new CmuxSocketClient({
+        socketPath: MOCK_SOCKET_PATH,
+        cliFallback: createMockCli(),
+      });
+
+      await expect(client.listWindows()).resolves.toEqual({
+        windows: [{ id: "cli-window", workspace_count: 1 }],
+      });
+      expect(cliCalls).toEqual([{ method: "listWindows", args: [] }]);
+    } finally {
+      MOCK_RESPONSES["window.list"] = saved;
+    }
+  });
 
   it("newSplit routes an explicit focus preference through the verified CLI contract", async () => {
     const client = new CmuxSocketClient({

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -604,6 +604,79 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     expect(result.text).toContain("hello");
   });
 
+  it("resolves read, send, and close targets across windows without a workspace", async () => {
+    const savedWindows = MOCK_RESPONSES["window.list"];
+    const savedWorkspaces = MOCK_RESPONSES["workspace.list"];
+    const savedSurfaces = MOCK_RESPONSES["surface.list"];
+    MOCK_RESPONSES["window.list"] = {
+      windows: [
+        { ref: "window:A", workspace_count: 1 },
+        { ref: "window:B", workspace_count: 1 },
+      ],
+    };
+    MOCK_RESPONSES["workspace.list"] = (req) => ({
+      workspaces: [
+        {
+          ref:
+            req.params.window_id === "window:B"
+              ? "workspace:B"
+              : "workspace:A",
+          title: String(req.params.window_id ?? "window:A"),
+          index: 0,
+          selected: true,
+          pinned: false,
+        },
+      ],
+    });
+    MOCK_RESPONSES["surface.list"] = (req) => ({
+      workspace_ref: req.params.workspace_id,
+      window_ref:
+        req.params.workspace_id === "workspace:B" ? "window:B" : "window:A",
+      pane_ref: "pane:1",
+      surfaces:
+        req.params.workspace_id === "workspace:B"
+          ? [
+              {
+                ref: "surface:B",
+                title: "other window",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ]
+          : [],
+    });
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await expect(client.readScreen("surface:B")).resolves.toHaveProperty(
+        "surface",
+      );
+      await expect(client.send("surface:B", "hello")).resolves.toBeUndefined();
+      await expect(client.closeSurface("surface:B")).resolves.toBeUndefined();
+
+      for (const method of [
+        "surface.read_text",
+        "surface.send_text",
+        "surface.close",
+      ]) {
+        expect(mockEvents).toContainEqual({
+          type: "v2",
+          method,
+          params: expect.objectContaining({
+            surface_id: "surface:B",
+            workspace_id: "workspace:B",
+          }),
+        });
+      }
+    } finally {
+      MOCK_RESPONSES["window.list"] = savedWindows;
+      MOCK_RESPONSES["workspace.list"] = savedWorkspaces;
+      MOCK_RESPONSES["surface.list"] = savedSurfaces;
+    }
+  });
+
   it("newSplit creates a surface and returns refs", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
     const result = await client.newSplit("right", { workspace: "workspace:1" });
@@ -905,10 +978,14 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
   });
 
   it("resolves surface-targeted sidebar commands to the target surface workspace", async () => {
+    const savedWindowList = MOCK_RESPONSES["window.list"];
     const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
     const savedSurfaceList = MOCK_RESPONSES["surface.list"];
     const savedIdentify = MOCK_RESPONSES["system.identify"];
 
+    MOCK_RESPONSES["window.list"] = {
+      windows: [{ ref: "window:1", workspace_count: 2 }],
+    };
     MOCK_RESPONSES["workspace.list"] = {
       workspaces: [
         {
@@ -991,6 +1068,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
         "notify --title Done --workspace workspace:2 --surface surface:target",
       );
     } finally {
+      MOCK_RESPONSES["window.list"] = savedWindowList;
       MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
       MOCK_RESPONSES["surface.list"] = savedSurfaceList;
       MOCK_RESPONSES["system.identify"] = savedIdentify;
@@ -998,10 +1076,14 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
   });
 
   it("falls back to the focused workspace for tab commands when a surface cannot be mapped", async () => {
+    const savedWindowList = MOCK_RESPONSES["window.list"];
     const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
     const savedSurfaceList = MOCK_RESPONSES["surface.list"];
     const savedIdentify = MOCK_RESPONSES["system.identify"];
 
+    MOCK_RESPONSES["window.list"] = {
+      windows: [{ ref: "window:1", workspace_count: 2 }],
+    };
     MOCK_RESPONSES["workspace.list"] = {
       workspaces: [
         {
@@ -1055,6 +1137,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
         "notify --title Done --surface surface:unmapped",
       );
     } finally {
+      MOCK_RESPONSES["window.list"] = savedWindowList;
       MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
       MOCK_RESPONSES["surface.list"] = savedSurfaceList;
       MOCK_RESPONSES["system.identify"] = savedIdentify;

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -140,6 +140,38 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
     }
   });
 
+  it("preserves every SurfaceTopologyClient method through the wrapper", () => {
+    const socketPath = join(tmpdir(), `cmux-topology-parity-${process.pid}.sock`);
+    const cli = new CmuxClient({
+      exec: vi.fn().mockResolvedValue({ stdout: "{}", stderr: "" }),
+      bin: "cmux",
+    });
+    const socket = {
+      currentSocketPath: () => socketPath,
+      disconnect: vi.fn(),
+      listWindows: vi.fn(),
+      listWorkspaces: vi.fn(),
+      listPanes: vi.fn(),
+      listPaneSurfaces: vi.fn(),
+    } as unknown as CmuxSocketClient;
+    const client = wrapSocketWithSelfHeal(socket, cli, {
+      socketPath,
+      reprobeIntervalMs: 60_000,
+    });
+
+    for (const method of [
+      "listWindows",
+      "listWorkspaces",
+      "listPanes",
+      "listPaneSurfaces",
+    ]) {
+      expect(typeof (client as unknown as Record<string, unknown>)[method]).toBe(
+        "function",
+      );
+    }
+    client.stop();
+  });
+
   function track(server: net.Server, path: string): void {
     servers.push({ server, path });
   }

--- a/tests/cmux-transport-self-heal.test.ts
+++ b/tests/cmux-transport-self-heal.test.ts
@@ -18,6 +18,7 @@ import {
   wrapCliWithSelfHeal,
   wrapSocketWithSelfHeal,
 } from "../src/cmux-transport-self-heal.js";
+import { SURFACE_TOPOLOGY_CLIENT_METHODS } from "../src/surface-topology.js";
 
 const CAN_BIND_MOCK_SOCKET = process.env.CODEX_SANDBOX !== "seatbelt";
 const ACCESS_CONTROL_DENIED_TEXT =
@@ -159,12 +160,7 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("transport self-healing", () => {
       reprobeIntervalMs: 60_000,
     });
 
-    for (const method of [
-      "listWindows",
-      "listWorkspaces",
-      "listPanes",
-      "listPaneSurfaces",
-    ]) {
+    for (const method of SURFACE_TOPOLOGY_CLIENT_METHODS) {
       expect(typeof (client as unknown as Record<string, unknown>)[method]).toBe(
         "function",
       );

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -59,6 +59,14 @@ async function spawnReadyAgent(
 
 function makeLifecycleExec(readScreenText: () => string): ExecFn {
   return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("read-screen")) {
       return {
         stdout: JSON.stringify({

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -81,6 +81,14 @@ function makeExec(
     if (mutableScreen) mutableScreen.text = text;
   };
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("list-workspaces")) {
       return {
         stdout: JSON.stringify({
@@ -1010,6 +1018,14 @@ describe("dispatch_to_agent nudge (state-independent inbox wake)", () => {
     // Recycle the surface: it now hosts a Codex agent.
     (exec as ReturnType<typeof vi.fn>).mockImplementation(
       async (_cmd: string, args: string[]) => {
+        if (args.includes("list-windows")) {
+          return {
+            stdout: JSON.stringify({
+              windows: [{ ref: "window:1", workspace_count: 1 }],
+            }),
+            stderr: "",
+          };
+        }
         if (args.includes("read-screen")) {
           return {
             stdout: JSON.stringify({

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -74,6 +74,14 @@ function makeExec(
     }
   };
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("list-workspaces")) {
       return {
         stdout: JSON.stringify({

--- a/tests/painpoint-e2e.test.ts
+++ b/tests/painpoint-e2e.test.ts
@@ -148,6 +148,14 @@ function makeLifecycleExec(surfaceRefs: string[], opts?: {
   const screenBySurface = opts?.screenBySurface ?? new Map<string, string>();
   const exec: ExecFn = async (_cmd, args) => {
     const { command, index: commandIndex } = commandArg(args);
+    if (command === "list-windows") {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (command === "list-workspaces") {
       return {
         stdout: JSON.stringify({

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -75,6 +75,14 @@ function makeLifecycleExec(initialReadyText: string | (() => string) = "codex> "
   let submissionObservationPending = false;
 
   return vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
         readyText =

--- a/tests/repo-workspace.test.ts
+++ b/tests/repo-workspace.test.ts
@@ -163,11 +163,12 @@ describe("resolveWorkspaceRefForRepo", () => {
     expect(ref).toBe("ws:root");
   });
 
-  it("swallows listWorkspaces errors and returns undefined", async () => {
-    const ref = await resolveWorkspaceRefForRepo("brainlayer", async () => {
-      throw new Error("socket down");
-    });
-    expect(ref).toBeUndefined();
+  it("propagates enumeration errors so placement fails closed", async () => {
+    await expect(
+      resolveWorkspaceRefForRepo("brainlayer", async () => {
+        throw new Error("socket down");
+      }),
+    ).rejects.toThrow("socket down");
   });
 });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -239,6 +239,15 @@ function makeLifecycleExec(opts?: {
       };
     }
 
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
+
     if (args.includes("list-panes")) {
       const listed = listedSurface();
       return {
@@ -1573,6 +1582,7 @@ type UuidRouteSurface = {
   ref: string;
   id?: string;
   workspace_ref: string;
+  window_ref?: string;
   title?: string;
 };
 
@@ -1699,6 +1709,42 @@ function makeUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
       screenText = next;
     },
   };
+}
+
+function makeCrossWindowUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
+  const routeClient = makeUuidRouteClient(initialSurfaces);
+  const windows = ["window:A", "window:B"];
+  const workspaceForWindow = new Map([
+    ["window:A", "workspace:A"],
+    ["window:B", "workspace:B"],
+  ]);
+  (routeClient.client as any).listWindows = vi.fn().mockResolvedValue({
+    windows: windows.map((ref) => ({ ref, workspace_count: 1 })),
+  });
+  routeClient.client.listWorkspaces.mockImplementation(
+    async (opts?: { window?: string }) => {
+      // Reproduce D89: the daemon belongs to window A, so an unscoped call
+      // sees only A even though window B is live.
+      const workspaceRef = opts?.window
+        ? workspaceForWindow.get(opts.window)
+        : "workspace:A";
+      return {
+        workspaces: workspaceRef
+          ? [
+              {
+                ref: workspaceRef,
+                title: workspaceRef,
+                index: 0,
+                selected: workspaceRef === "workspace:A",
+                pinned: false,
+              },
+            ]
+          : [],
+      };
+    },
+  );
+  (routeClient.client as any).focusSurface = vi.fn().mockResolvedValue(undefined);
+  return routeClient;
 }
 
 function moveUuidRouteAfterNextSurfaceSnapshot(
@@ -6844,6 +6890,14 @@ describe("agent lifecycle tool handlers", () => {
     let launchSent = false;
     let readCountAfterLaunch = 0;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("send")) {
         launchSent = true;
       }
@@ -10637,6 +10691,185 @@ codex>
     });
   });
 
+  it.each(["read_screen", "update_surface", "close_surface"] as const)(
+    "%s routes a live surface in another window without a workspace argument",
+    async (toolName) => {
+      const routeClient = makeCrossWindowUuidRouteClient([
+        {
+          ref: "surface:A",
+          id: "11111111-2222-4333-8444-555555555555",
+          workspace_ref: "workspace:A",
+          window_ref: "window:A",
+          title: "daemon-window-agent",
+        },
+        {
+          ref: "surface:B",
+          id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+          workspace_ref: "workspace:B",
+          window_ref: "window:B",
+          title: "caller-window-agent",
+        },
+      ]);
+      const server = createTrackedServer({
+        client: routeClient.client as any,
+        stateDir: TEST_DIR,
+        skipAgentLifecycle: true,
+      });
+      const args =
+        toolName === "read_screen"
+          ? { surface: "surface:B", parsed_only: true }
+          : toolName === "update_surface"
+            ? {
+                action: "move",
+                surface: "surface:B",
+                pane: "pane:destination",
+              }
+            : { surface: "surface:B" };
+
+      const result = await registeredTestTool(server, toolName).handler(
+        args,
+        {} as any,
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(parseToolResult(result)).toMatchObject({ ok: true });
+      expect(routeClient.client.listWorkspaces).toHaveBeenCalledWith({
+        window: "window:B",
+      });
+      if (toolName === "update_surface") {
+        expect(routeClient.client.moveSurface).toHaveBeenCalledWith(
+          expect.objectContaining({
+            surface: "surface:B",
+          }),
+        );
+      }
+      if (toolName === "close_surface") {
+        expect(routeClient.client.closeSurface).toHaveBeenCalledWith(
+          "surface:B",
+          expect.objectContaining({ workspace: "workspace:B" }),
+        );
+      }
+    },
+  );
+
+  it("agent-mode send_to routes a live agent in another window", async () => {
+    const surfaceUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+    const routeClient = makeCrossWindowUuidRouteClient([
+      {
+        ref: "surface:A",
+        id: "11111111-2222-4333-8444-555555555555",
+        workspace_ref: "workspace:A",
+        window_ref: "window:A",
+      },
+      {
+        ref: "surface:B",
+        id: surfaceUuid,
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+        title: "crossWindowCodex",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "crossWindowCodex",
+      surface_id: "surface:B",
+      surface_uuid: surfaceUuid,
+      workspace_id: "workspace:B",
+      state: "ready",
+      repo: "cmuxlayer",
+      cli: "codex",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+    routeClient.client.send.mockClear();
+    routeClient.sendCalls.length = 0;
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        agent_id: record.agent_id,
+        text: "cross-window delivery",
+        press_enter: false,
+      },
+      {} as any,
+    );
+
+    expect(parseToolResult(result).error).toBeUndefined();
+    expect(result.isError).not.toBe(true);
+    expect(routeClient.sendCalls).toEqual([
+      { surface: "surface:B", text: "cross-window delivery" },
+    ]);
+  });
+
+  it("spawn_agent creates a worker in an explicit workspace in another window", async () => {
+    const spawnedUuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+    const initialSurfaces: UuidRouteSurface[] = [
+      {
+        ref: "surface:A",
+        id: "11111111-2222-4333-8444-555555555555",
+        workspace_ref: "workspace:A",
+        window_ref: "window:A",
+      },
+      {
+        ref: "surface:B",
+        id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+      },
+    ];
+    const routeClient = makeCrossWindowUuidRouteClient(initialSurfaces);
+    routeClient.client.newSplit.mockImplementation(
+      async (_direction: string, opts?: { workspace?: string }) => {
+        routeClient.setLiveSurfaces([
+          ...initialSurfaces,
+          {
+            ref: "surface:spawned",
+            id: spawnedUuid,
+            workspace_ref: opts?.workspace ?? "workspace:B",
+            window_ref: "window:B",
+            title: "cross-window spawn",
+          },
+        ]);
+        return {
+          workspace: opts?.workspace ?? "workspace:B",
+          surface: "surface:spawned",
+          surface_id: spawnedUuid,
+          pane: "pane:spawned",
+          title: "cross-window spawn",
+          type: "terminal" as const,
+        };
+      },
+    );
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      lifecycleInitializer: async () => {},
+      sessionIdentityResolver: () => null,
+    });
+
+    const result = await registeredTestTool(server, "spawn_agent").handler(
+      {
+        repo: "cmuxlayer",
+        model: "gpt-5.5",
+        cli: "codex",
+        role: "implementor",
+        workspace: "workspace:B",
+        force_new: true,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      workspace_id: "workspace:B",
+      surface_id: "surface:spawned",
+    });
+    expect(routeClient.client.newSplit).toHaveBeenCalledWith(
+      "right",
+      expect.objectContaining({ workspace: "workspace:B" }),
+    );
+  });
+
   it("raw send_to on a stale ref with no mapped agent names that no live agent occupies it", async () => {
     const routeClient = makeUuidRouteClient([
       {
@@ -10671,7 +10904,7 @@ codex>
     expect(routeClient.sendCalls).toEqual([]);
   });
 
-  it("raw send_to on a stale ref names a live agent that already moved off that ref", async () => {
+  it("raw send_to on a stale ref does not name an unrelated live agent", async () => {
     const surfaceUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([
       {
@@ -10705,8 +10938,9 @@ codex>
 
     expect(result.isError).toBe(true);
     expect(parsed.error).toMatch(
-      /surface:524 is stale; agent skillcreatorClaude is alive at surface:89 — use agent_id/i,
+      /surface:524 is stale; no live managed agent maps this ref/i,
     );
+    expect(parsed.error).not.toMatch(/skillcreatorClaude/i);
     expect(parsed.error).not.toMatch(
       /Fresh topology did not provide a stable surface UUID/i,
     );
@@ -10749,7 +10983,7 @@ codex>
     ]);
   });
 
-  it("raw send_to names a live agent when a captured UUID is no longer live", async () => {
+  it("raw send_to does not name an unrelated agent when a captured UUID is no longer live", async () => {
     const deadUuid = "11111111-2222-4333-8444-555555555555";
     const liveUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
     const routeClient = makeUuidRouteClient([
@@ -10794,11 +11028,51 @@ codex>
 
     expect(result.isError).toBe(true);
     expect(parsed.error).toMatch(
-      /surface:524 is stale; agent skillcreatorClaude is alive at surface:89 — use agent_id/i,
+      /surface:524 is stale; no live managed agent maps this ref/i,
     );
+    expect(parsed.error).not.toMatch(/skillcreatorClaude/i);
     expect(parsed.error).not.toMatch(
       /^Stable surface UUID .* is no longer live; refusing/i,
     );
+    expect(routeClient.sendCalls).toEqual([]);
+  });
+
+  it("raw send_to names only the managed agent that owns a stale ref", async () => {
+    const deadUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:other",
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const owner = makeServerAgentRecord({
+      agent_id: "staleRefOwner",
+      surface_id: "surface:524",
+      surface_uuid: deadUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      repo: "cmuxlayer",
+      cli: "codex",
+    });
+    const server = await createUuidRouteServer(routeClient, owner);
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        mode: "surface",
+        target: "surface:524",
+        text: "owner diagnostic",
+        press_enter: false,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(
+      /surface:524 is stale; agent staleRefOwner owns this ref but no live route was proven — use agent_id/i,
+    );
+    expect(parsed.error).not.toMatch(/surface:other/i);
     expect(routeClient.sendCalls).toEqual([]);
   });
 
@@ -14467,6 +14741,14 @@ codex>
   it("my_agents marks a row when screen data is unavailable", async () => {
     const readError = new Error("screen read timed out");
     mockExec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("list-workspaces")) {
         return {
           stdout: JSON.stringify({

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1718,6 +1718,10 @@ function makeCrossWindowUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
     ["window:A", "workspace:A"],
     ["window:B", "workspace:B"],
   ]);
+  const workspaceIdForRef = new Map([
+    ["workspace:A", "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"],
+    ["workspace:B", "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"],
+  ]);
   (routeClient.client as any).listWindows = vi.fn().mockResolvedValue({
     windows: windows.map((ref) => ({ ref, workspace_count: 1 })),
   });
@@ -1733,6 +1737,7 @@ function makeCrossWindowUuidRouteClient(initialSurfaces: UuidRouteSurface[]) {
           ? [
               {
                 ref: workspaceRef,
+                id: workspaceIdForRef.get(workspaceRef),
                 title: workspaceRef,
                 index: 0,
                 selected: workspaceRef === "workspace:A",
@@ -10870,6 +10875,81 @@ codex>
     );
   });
 
+  it("spawn_agent resolves an unscoped caller workspace in another window", async () => {
+    const callerWorkspaceId = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb";
+    const spawnedUuid = "cccccccc-dddd-4eee-8fff-000000000000";
+    const initialSurfaces: UuidRouteSurface[] = [
+      {
+        ref: "surface:A",
+        id: "11111111-2222-4333-8444-555555555555",
+        workspace_ref: "workspace:A",
+        window_ref: "window:A",
+      },
+      {
+        ref: "surface:B",
+        id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+      },
+    ];
+    const routeClient = makeCrossWindowUuidRouteClient(initialSurfaces);
+    routeClient.client.newSplit.mockImplementation(
+      async (_direction: string, opts?: { workspace?: string }) => {
+        routeClient.setLiveSurfaces([
+          ...initialSurfaces,
+          {
+            ref: "surface:spawned",
+            id: spawnedUuid,
+            workspace_ref: opts?.workspace ?? "workspace:A",
+            window_ref: opts?.workspace === "workspace:B" ? "window:B" : "window:A",
+          },
+        ]);
+        return {
+          workspace: opts?.workspace ?? "workspace:A",
+          surface: "surface:spawned",
+          surface_id: spawnedUuid,
+          pane: "pane:spawned",
+          title: "caller workspace spawn",
+          type: "terminal" as const,
+        };
+      },
+    );
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      lifecycleInitializer: async () => {},
+      sessionIdentityResolver: () => null,
+    });
+
+    const result = await runWithCallerContext(
+      { workspaceId: callerWorkspaceId },
+      () =>
+        registeredTestTool(server, "spawn_agent").handler(
+          {
+            repo: "cmuxlayer",
+            model: "gpt-5.5",
+            cli: "codex",
+            role: "implementor",
+            force_new: true,
+          },
+          {} as any,
+        ),
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      workspace_id: "workspace:B",
+      surface_id: "surface:spawned",
+    });
+    expect(routeClient.client.newSplit).toHaveBeenCalledWith(
+      "right",
+      expect.objectContaining({ workspace: "workspace:B" }),
+    );
+  });
+
   it("raw send_to on a stale ref with no mapped agent names that no live agent occupies it", async () => {
     const routeClient = makeUuidRouteClient([
       {
@@ -13913,10 +13993,7 @@ codex>
       { surface: "surface:path-race", parsed_only: true },
       {},
     );
-    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
-      await Promise.resolve();
-    }
-    expect(get).toHaveBeenCalledWith(oldPath);
+    await vi.waitFor(() => expect(get).toHaveBeenCalledWith(oldPath));
     const updated = {
       ...record,
       cli_session_path: "/fixtures/codex/session-after-read.jsonl",
@@ -14058,10 +14135,7 @@ codex>
       { agent_id: record.agent_id },
       {},
     );
-    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
-      await Promise.resolve();
-    }
-    expect(get).toHaveBeenCalledWith(oldPath);
+    await vi.waitFor(() => expect(get).toHaveBeenCalledWith(oldPath));
     const updated = {
       ...record,
       cli_session_path: "/fixtures/codex/state-session-after.jsonl",
@@ -14112,10 +14186,7 @@ codex>
       { agent_id: record.agent_id },
       {},
     );
-    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
-      await Promise.resolve();
-    }
-    expect(get).toHaveBeenCalledWith(path);
+    await vi.waitFor(() => expect(get).toHaveBeenCalledWith(path));
     const updated = {
       ...record,
       cli: "claude" as const,
@@ -15037,6 +15108,37 @@ describe("auto-focus discipline (focus target before split, restore after render
     let createdSurfaceReadStarted = false;
     const exec = vi.fn(async (cmd: string, args: string[]) => {
       calls.push(args);
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 2 }],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "Main",
+                index: 0,
+                selected: focusedWorkspace === "workspace:1",
+                pinned: false,
+              },
+              {
+                ref: "workspace:2",
+                title: "Review team",
+                index: 1,
+                selected: focusedWorkspace === "workspace:2",
+                pinned: false,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("identify")) {
         if (
           opts?.failFocusObservationAfterCreation &&

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10950,6 +10950,111 @@ codex>
     );
   });
 
+  it("read_screen retries the same cross-window surface with its resolved workspace", async () => {
+    const routeClient = makeCrossWindowUuidRouteClient([
+      {
+        ref: "surface:A",
+        id: "11111111-2222-4333-8444-555555555555",
+        workspace_ref: "workspace:A",
+        window_ref: "window:A",
+      },
+      {
+        ref: "surface:B",
+        id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+      },
+    ]);
+    routeClient.client.readScreen.mockImplementation(
+      async (surface: string, opts?: { workspace?: string }) => {
+        if (surface === "surface:B" && opts?.workspace !== "workspace:B") {
+          throw new Error("Unable to resolve workspace for surface surface:B");
+        }
+        return {
+          surface,
+          text: "gpt-5.6-sol medium - 80% left\ncodex> ",
+          lines: 20,
+          scrollback_used: false,
+        };
+      },
+    );
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      lifecycleInitializer: async () => {},
+    });
+
+    const result = await registeredTestTool(server, "read_screen").handler(
+      { surface: "surface:B" },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(routeClient.client.readScreen).toHaveBeenLastCalledWith(
+      "surface:B",
+      expect.objectContaining({ workspace: "workspace:B" }),
+    );
+  });
+
+  it("uses the selected workspace from the caller's window when two windows are selected", async () => {
+    const routeClient = makeCrossWindowUuidRouteClient([
+      {
+        ref: "surface:A",
+        workspace_ref: "workspace:A",
+        window_ref: "window:A",
+      },
+      {
+        ref: "surface:B",
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+      },
+    ]);
+    routeClient.client.listWorkspaces.mockImplementation(
+      async (opts?: { window?: string }) => ({
+        workspaces: [
+          {
+            ref: opts?.window === "window:B" ? "workspace:B" : "workspace:A",
+            id:
+              opts?.window === "window:B"
+                ? "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"
+                : "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+            title: opts?.window ?? "window:A",
+            index: 0,
+            selected: true,
+            pinned: false,
+          },
+        ],
+      }),
+    );
+    routeClient.client.newSplit.mockResolvedValue({
+      workspace: "workspace:A",
+      surface: "surface:new",
+      pane: "pane:new",
+      title: "",
+      type: "terminal" as const,
+    });
+
+    const server = createTrackedServer({
+      client: routeClient.client as any,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      lifecycleInitializer: async () => {},
+    });
+    const result = await runWithCallerContext(
+      { workspaceId: "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb" },
+      () =>
+        registeredTestTool(server, "new_split").handler(
+          { direction: "right", workspace: "workspace:A" },
+          {} as any,
+        ),
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(routeClient.client.selectWorkspace).toHaveBeenCalledWith(
+      "workspace:A",
+    );
+  });
+
   it("raw send_to on a stale ref with no mapped agent names that no live agent occupies it", async () => {
     const routeClient = makeUuidRouteClient([
       {
@@ -14369,7 +14474,7 @@ codex>
       const pending = registeredTestTool(server, "my_agents").handler({}, {});
       for (
         let index = 0;
-        index < 50 && get.mock.calls.length === 0;
+        index < 250 && get.mock.calls.length === 0;
         index += 1
       ) {
         await Promise.resolve();
@@ -14419,7 +14524,11 @@ codex>
     });
 
     const pending = registeredTestTool(server, "my_agents").handler({}, {});
-    for (let index = 0; index < 50 && get.mock.calls.length === 0; index += 1) {
+    for (
+      let index = 0;
+      index < 250 && get.mock.calls.length === 0;
+      index += 1
+    ) {
       await Promise.resolve();
     }
     expect(get).toHaveBeenCalledWith(path);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1119,6 +1119,14 @@ describe("tool handler integration", () => {
   let mockExec: ExecFn;
 
   const defaultPanePlacementResult = (args: string[]) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("list-workspaces")) {
       return {
         stdout: JSON.stringify({
@@ -2877,12 +2885,12 @@ describe("tool handler integration", () => {
     );
 
     // Stable identity resolution runs first, then mode scope, screen preflight,
-    // text delivery, and Return. Legacy topology has no UUID to retain.
+    // text delivery, and Return. This minimal mock has no topology to retain.
     expect(mockExec).toHaveBeenCalledTimes(5);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
-      expect.arrayContaining(["list-workspaces"]),
+      expect.arrayContaining(["list-windows"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
@@ -3029,7 +3037,7 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
-      expect.arrayContaining(["list-workspaces"]),
+      expect.arrayContaining(["list-windows"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
@@ -3183,6 +3191,14 @@ describe("tool handler integration", () => {
     });
 
     const mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("list-workspaces")) {
         return {
           stdout: JSON.stringify({
@@ -3373,6 +3389,14 @@ describe("tool handler integration", () => {
     });
 
     const mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("list-workspaces")) {
         return {
           stdout: JSON.stringify({
@@ -8522,6 +8546,14 @@ describe("tool handler integration", () => {
       const sentTexts: string[] = [];
 
       mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+        if (args.includes("list-windows")) {
+          return {
+            stdout: JSON.stringify({
+              windows: [{ ref: "window:1", workspace_count: 1 }],
+            }),
+            stderr: "",
+          };
+        }
         if (args.includes("list-workspaces")) {
           return {
             stdout: JSON.stringify({
@@ -8841,6 +8873,14 @@ describe("tool handler integration", () => {
     const submittedCommands: string[] = [];
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("list-workspaces")) {
         return {
           stdout: JSON.stringify({
@@ -9192,6 +9232,14 @@ describe("tool handler integration", () => {
     const updateMenuKeys: string[] = [];
 
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
       if (args.includes("list-workspaces")) {
         return {
           stdout: JSON.stringify({

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2902,9 +2902,10 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Stable identity resolution first enumerates windows and workspaces, then
-    // checks mode scope and screen readiness before delivery and Return.
-    expect(mockExec).toHaveBeenCalledTimes(6);
+    // Stable identity resolution retries the deliberately incomplete `{}`
+    // topology fixture once, then checks mode scope and screen readiness
+    // before delivery and Return.
+    expect(mockExec).toHaveBeenCalledTimes(8);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -2918,20 +2919,30 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
-      expect.arrayContaining(["identify", "--surface", "surface:1"]),
+      expect.arrayContaining(["list-windows"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       4,
       "cmux",
-      expect.arrayContaining(["read-screen"]),
+      expect.arrayContaining(["list-workspaces"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       5,
       "cmux",
-      expect.arrayContaining(["send"]),
+      expect.arrayContaining(["identify", "--surface", "surface:1"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       6,
+      "cmux",
+      expect.arrayContaining(["read-screen"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      7,
+      "cmux",
+      expect.arrayContaining(["send"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      8,
       "cmux",
       expect.arrayContaining(["send-key"]),
     );
@@ -3056,7 +3067,7 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(6);
+    expect(mockExec).toHaveBeenCalledTimes(8);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -3070,20 +3081,30 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
-      expect.arrayContaining(["identify", "--surface", "surface:6"]),
+      expect.arrayContaining(["list-windows"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       4,
       "cmux",
-      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
+      expect.arrayContaining(["list-workspaces"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       5,
       "cmux",
-      expect.arrayContaining(["send", "--surface", "surface:6"]),
+      expect.arrayContaining(["identify", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       6,
+      "cmux",
+      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      7,
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      8,
       "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
     );

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1501,6 +1501,12 @@ describe("tool handler integration", () => {
       .fn()
       .mockResolvedValueOnce({
         stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 2 }],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
           workspaces: [
             {
               ref: "workspace:1",
@@ -1938,6 +1944,12 @@ describe("tool handler integration", () => {
       .fn()
       .mockResolvedValueOnce({
         stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
           workspaces: [
             {
               ref: "workspace:1",
@@ -2010,6 +2022,12 @@ describe("tool handler integration", () => {
   it("list_surfaces preserves the current full schema behind verbose=true while still deduping", async () => {
     mockExec = vi
       .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      })
       .mockResolvedValueOnce({
         stdout: JSON.stringify({
           workspaces: [
@@ -2884,9 +2902,9 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    // Stable identity resolution runs first, then mode scope, screen preflight,
-    // text delivery, and Return. This minimal mock has no topology to retain.
-    expect(mockExec).toHaveBeenCalledTimes(5);
+    // Stable identity resolution first enumerates windows and workspaces, then
+    // checks mode scope and screen readiness before delivery and Return.
+    expect(mockExec).toHaveBeenCalledTimes(6);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -2895,20 +2913,25 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       "cmux",
-      expect.arrayContaining(["identify", "--surface", "surface:1"]),
+      expect.arrayContaining(["list-workspaces"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
-      expect.arrayContaining(["read-screen"]),
+      expect.arrayContaining(["identify", "--surface", "surface:1"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       4,
       "cmux",
-      expect.arrayContaining(["send"]),
+      expect.arrayContaining(["read-screen"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       5,
+      "cmux",
+      expect.arrayContaining(["send"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      6,
       "cmux",
       expect.arrayContaining(["send-key"]),
     );
@@ -3033,7 +3056,7 @@ describe("tool handler integration", () => {
       {} as any,
     );
 
-    expect(mockExec).toHaveBeenCalledTimes(5);
+    expect(mockExec).toHaveBeenCalledTimes(6);
     expect(mockExec).toHaveBeenNthCalledWith(
       1,
       "cmux",
@@ -3042,20 +3065,25 @@ describe("tool handler integration", () => {
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       "cmux",
-      expect.arrayContaining(["identify", "--surface", "surface:6"]),
+      expect.arrayContaining(["list-workspaces"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       3,
       "cmux",
-      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
+      expect.arrayContaining(["identify", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       4,
       "cmux",
-      expect.arrayContaining(["send", "--surface", "surface:6"]),
+      expect.arrayContaining(["read-screen", "--surface", "surface:6"]),
     );
     expect(mockExec).toHaveBeenNthCalledWith(
       5,
+      "cmux",
+      expect.arrayContaining(["send", "--surface", "surface:6"]),
+    );
+    expect(mockExec).toHaveBeenNthCalledWith(
+      6,
       "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:6", "return"]),
     );
@@ -8157,6 +8185,18 @@ describe("tool handler integration", () => {
         stdout: JSON.stringify({ ok: true }),
         stderr: "",
       });
+    const queuedExec = mockExec;
+    mockExec = vi.fn(async (cmd: string, args: string[]) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify({
+            windows: [{ ref: "window:1", workspace_count: 1 }],
+          }),
+          stderr: "",
+        };
+      }
+      return queuedExec(cmd, args);
+    }) as typeof mockExec;
     const server = createServer({
       exec: mockExec,
       skipAgentLifecycle: true,

--- a/tests/spawn-monitor-boot.test.ts
+++ b/tests/spawn-monitor-boot.test.ts
@@ -21,6 +21,14 @@ function makeExec(): ExecFn {
   let bootTextSent = false;
   let activeCli: "claude" | "codex" = "claude";
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("send-key") && args.includes("return")) {
       submitted = bootTextSent;
       return { stdout: "{}", stderr: "" };

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -3,6 +3,7 @@ import { evaluateAgentHealth } from "../src/agent-health.js";
 import type { AgentRecord } from "../src/agent-types.js";
 import {
   collectSurfaceTopology,
+  enumerateAllWindowWorkspaces,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   resolveAgentSurfaceBinding,
@@ -279,6 +280,65 @@ describe("collectSurfaceTopology", () => {
     expect(client.listWorkspaces).toHaveBeenCalledWith({
       window: "window-uuid-B",
     });
+  });
+
+  it("does not mark a zero-window topology complete", async () => {
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({ windows: [] }),
+      listWorkspaces: vi.fn(),
+      listPanes: vi.fn(),
+      listPaneSurfaces: vi.fn(),
+    };
+
+    const snapshot = await collectSurfaceTopology(client);
+
+    expect(snapshot).toMatchObject({ complete: false, surfaces: [] });
+  });
+
+  it("does not mark an uncounted empty window complete", async () => {
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [{ id: "window-uuid" }],
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+      listPanes: vi.fn(),
+      listPaneSurfaces: vi.fn(),
+    };
+
+    const snapshot = await collectSurfaceTopology(client);
+
+    expect(snapshot).toMatchObject({ complete: false, surfaces: [] });
+  });
+
+  it("coalesces concurrent window-to-workspace enumeration within one observer epoch", async () => {
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [
+          { ref: "window:A", workspace_count: 1 },
+          { ref: "window:B", workspace_count: 1 },
+        ],
+      }),
+      listWorkspaces: vi.fn(async (opts?: { window?: string }) => ({
+        workspaces: [
+          workspace(opts?.window === "window:B" ? "workspace:B" : "workspace:A"),
+        ],
+      })),
+      listPanes: vi.fn(async (opts?: { workspace?: string }) => ({
+        workspace_ref: opts?.workspace,
+        panes: [],
+      })),
+      listPaneSurfaces: vi.fn(),
+    };
+    const observerEpoch = () => "observer:epoch:1";
+
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        enumerateAllWindowWorkspaces(client, observerEpoch),
+      ),
+    );
+
+    expect(client.listWindows).toHaveBeenCalledTimes(1);
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(2);
   });
 
   it("marks malformed pane enumeration incomplete", async () => {

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -4,6 +4,7 @@ import type { AgentRecord } from "../src/agent-types.js";
 import {
   collectSurfaceTopology,
   enumerateAllWindowWorkspaces,
+  listAllWindowWorkspaces,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   resolveAgentSurfaceBinding,
@@ -338,6 +339,28 @@ describe("collectSurfaceTopology", () => {
     );
 
     expect(client.listWindows).toHaveBeenCalledTimes(1);
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries one incomplete window snapshot before refusing it", async () => {
+    const client = {
+      listWindows: vi
+        .fn()
+        .mockResolvedValueOnce({
+          windows: [{ ref: "window:A", workspace_count: 2 }],
+        })
+        .mockResolvedValueOnce({
+          windows: [{ ref: "window:A", workspace_count: 1 }],
+        }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [workspace("workspace:A")],
+      }),
+    };
+
+    await expect(listAllWindowWorkspaces(client)).resolves.toEqual({
+      workspaces: [expect.objectContaining({ ref: "workspace:A" })],
+    });
+    expect(client.listWindows).toHaveBeenCalledTimes(2);
     expect(client.listWorkspaces).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -191,6 +191,96 @@ describe("enrichSurfaceIdsFromPanes", () => {
 });
 
 describe("collectSurfaceTopology", () => {
+  it("enumerates workspaces in every cmux window before marking topology complete", async () => {
+    const surfaceAUuid = "11111111-2222-4333-8444-555555555555";
+    const surfaceBUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [
+          { ref: "window:A", workspace_count: 1 },
+          { ref: "window:B", workspace_count: 1 },
+        ],
+      }),
+      listWorkspaces: vi.fn(
+        async (opts?: { window?: string }) => ({
+          workspaces:
+            opts?.window === "window:B"
+              ? [workspace("workspace:B")]
+              : [workspace("workspace:A")],
+        }),
+      ),
+      listPanes: vi.fn(async (opts?: { workspace?: string }) => {
+        const inWindowB = opts?.workspace === "workspace:B";
+        const ref = inWindowB ? "surface:B" : "surface:A";
+        return {
+          workspace_ref: opts?.workspace,
+          window_ref: inWindowB ? "window:B" : "window:A",
+          panes: [
+            {
+              ...pane(inWindowB ? "pane:B" : "pane:A", 0, [ref]),
+              surface_ids: [inWindowB ? surfaceBUuid : surfaceAUuid],
+            },
+          ],
+        };
+      }),
+      listPaneSurfaces: vi.fn(
+        async (opts?: { workspace?: string; pane?: string }) => {
+          const inWindowB = opts?.workspace === "workspace:B";
+          const ref = inWindowB ? "surface:B" : "surface:A";
+          return {
+            workspace_ref: opts?.workspace ?? "workspace:A",
+            window_ref: inWindowB ? "window:B" : "window:A",
+            pane_ref: opts?.pane ?? (inWindowB ? "pane:B" : "pane:A"),
+            surfaces: [
+              {
+                ...surface(ref),
+                id: inWindowB ? surfaceBUuid : surfaceAUuid,
+              },
+            ],
+          };
+        },
+      ),
+    };
+
+    const snapshot = await collectSurfaceTopology(client);
+
+    expect(client.listWindows).toHaveBeenCalledTimes(1);
+    expect(client.listWorkspaces).toHaveBeenCalledWith({ window: "window:A" });
+    expect(client.listWorkspaces).toHaveBeenCalledWith({ window: "window:B" });
+    expect(snapshot?.complete).toBe(true);
+    expect(snapshot?.workspaceBySurface).toEqual(
+      new Map([
+        ["surface:A", "workspace:A"],
+        ["surface:B", "workspace:B"],
+      ]),
+    );
+    expect(snapshot?.surfaceRefById.get(surfaceBUuid)).toBe("surface:B");
+  });
+
+  it("uses the stable window id when the CLI omits a window ref", async () => {
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [{ id: "window-uuid-B", workspace_count: 1 }],
+      }),
+      listWorkspaces: vi.fn().mockResolvedValue({
+        workspaces: [workspace("workspace:B")],
+      }),
+      listPanes: vi.fn().mockResolvedValue({
+        workspace_ref: "workspace:B",
+        window_ref: "window:B",
+        panes: [],
+      }),
+      listPaneSurfaces: vi.fn(),
+    };
+
+    const snapshot = await collectSurfaceTopology(client);
+
+    expect(snapshot?.complete).toBe(true);
+    expect(client.listWorkspaces).toHaveBeenCalledWith({
+      window: "window-uuid-B",
+    });
+  });
+
   it("marks malformed pane enumeration incomplete", async () => {
     const client = makeTopologyClient([], []);
     client.listPanes.mockResolvedValueOnce({

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -88,6 +88,14 @@ function makeExec(opts?: {
   let resumedSurfaceLive = false;
   const exec = vi.fn().mockImplementation(async (_cmd, args: string[]) => {
     calls.push(args);
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("new-split") || args.includes("new-surface")) {
       resumedSurfaceLive = true;
       return {

--- a/tests/v2-interact-kill.test.ts
+++ b/tests/v2-interact-kill.test.ts
@@ -51,6 +51,14 @@ function makeSpawnReadyExec(opts?: { closeKeepsSurface?: boolean }): ExecFn {
           title: "witness-pane",
         };
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("new-split") || args.includes("new-surface")) {
       surfaceLive = true;
     }
@@ -165,6 +173,14 @@ function makeSharedPaneExec(): ExecFn {
           title: "witness-pane",
         };
   return vi.fn().mockImplementation(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout: JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        stderr: "",
+      };
+    }
     if (args.includes("close-surface")) {
       const surface = String(args[args.indexOf("--surface") + 1] ?? "");
       liveSurfaces.delete(surface);


### PR DESCRIPTION
## Summary

- resolve surface operations across every live cmux window, including same-surface `read_screen` retries when only the resolved workspace changes
- bind flattened `selected:true` state to the caller's window, with connector-window fallback when the caller window is unknown
- retry one incomplete all-window enumeration, then fail closed consistently; repo placement no longer swallows enumeration failure
- derive self-healing topology forwarding from an exhaustive shared method constant and forward `listWindows` through the app runtime adapter

## D89 symptom reproduced

The initial proof terminal was created without an explicit workspace and landed as `surface:99` in COACH's `workspace:5` instead of the caller's `workspace:2`. This caller-workspace placement mis-route is a D89 symptom covered by the `callerWorkspaceStrict` fix and the double-selected/caller-window regression. `surface:99` was closed immediately after that proof and remains absent.

## Final-gate evidence at `f106603ae02ad33de3afcb20f47043ede413a560`

1. Cross-window surface routing: failing-first tests cover socket `readScreen`/`send`/`closeSurface` without a workspace and server `read_screen` retry when the surface ref is unchanged but the resolved workspace differs.
2. Double-selected topology: two selected workspaces resolve to the selected workspace in the caller's owning window, never the first flattened row.
3. Retry then refuse: a stale `workspace_count` snapshot is retried once; a second incomplete snapshot throws. Repo resolution propagates the refusal.
4. Wrapper parity: the parity test iterates `SURFACE_TOPOLOGY_CLIENT_METHODS`, which is compile-time exhaustive over `SurfaceTopologyClient`.
5. App runtime: its engine adapter forwards `listWindows`.

## Built-dist live proof

No launchd and no new terminal/surface. An isolated daemon was started from the existing workspace-2 caller, using socket/state under `docs.local/scratch/hotfix-d89-final-6dcf43c6`, and stopped after the read. The MCP server enumerated both windows and read COACH's `surface:29` in workspace 5/window 2 without a workspace argument:

```json
{
  "listed_workspace_refs": ["workspace:2", "workspace:5"],
  "target": {
    "window_ref": "window:2",
    "workspace_ref": "workspace:5",
    "surface_ref": "surface:29"
  },
  "read_screen_without_workspace": {
    "ok": true,
    "surface": "surface:29"
  }
}
```

Proof receipt: `docs.local/scratch/hotfix-d89-final-6dcf43c6/proof.json`. The isolated daemon is stopped; workspace 5 still contains `surface:29` and no `surface:99`.

## Verification

- failing-first focused regressions: observed all six required failures before implementation
- `bun run typecheck`: passed
- `bun run build`: passed
- full local suite: 145 files passed; 3,402 passed, 1 skipped
- push hook: contract fixtures passed; 145 files passed; 3,402 passed, 1 skipped
- exact-head GitHub CI rerun 32869524232: build-site, both launcher-parity jobs, typecheck, and full test job passed
- all current PR checks: green; Cursor Bugbot neutral because its usage limit was reached
- bounded local CodeRabbit run: invoked; reached the three-minute cutoff without returning findings

STATUS: REVIEW_NEEDED

— cmuxlayerCodex (implementor) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"implementor","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03934","ts":"2026-08-25T16:04:35Z"} -->
