### PR TITLE
fix: ignore app bundle paths in ancestry arguments

### DIFF
--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -679,10 +679,8 @@ export function resolveSpawnerAncestry(
     visited.add(pid);
     const row = byPid.get(pid);
     if (!row) break;
-    const bundle =
-      row.command.match(
-        /(?:^|\s)(\/(?:(?!\s(?:-|\/)).)*?\.app)(?:\/|\s|$)/,
-      )?.[1] ?? null;
+    const executable = row.command.split(" ")[0] ?? "";
+    const bundle = executable.match(/^(\/[^\s]*?\.app)(?:\/|$)/)?.[1] ?? null;
     if (bundle) {
       return { app_bundle_path: bundle, pid: row.pid };
     }

--- a/src/control-health.ts
+++ b/src/control-health.ts
@@ -679,8 +679,8 @@ export function resolveSpawnerAncestry(
     visited.add(pid);
     const row = byPid.get(pid);
     if (!row) break;
-    const executable = row.command.split(" ")[0] ?? "";
-    const bundle = executable.match(/^(\/[^\s]*?\.app)(?:\/|$)/)?.[1] ?? null;
+    const bundle =
+      row.command.match(/^(\/(?:(?!\s[-\/]).)*?\.app)(?:\/|$)/)?.[1] ?? null;
     if (bundle) {
       return { app_bundle_path: bundle, pid: row.pid };
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1427,19 +1427,19 @@ export class CmuxLayerProxy {
             const spawnStartedAt = Date.now();
             const spawned = await this.spawnDaemonForVersionBump({
               socketPath: this.socketPath,
-            env: process.env,
-            logger: this.logger,
-            daemonScriptPath,
-          });
-          instrumentSpawnedDaemon(spawned, spawnStartedAt, this.logger);
-          const pid =
-            spawned &&
-            typeof spawned === "object" &&
-            "pid" in spawned &&
-            typeof spawned.pid === "number"
-              ? spawned.pid
-              : "unknown";
-          this.logReconnect(
+              env: process.env,
+              logger: this.logger,
+              daemonScriptPath,
+            });
+            instrumentSpawnedDaemon(spawned, spawnStartedAt, this.logger);
+            const pid =
+              spawned &&
+              typeof spawned === "object" &&
+              "pid" in spawned &&
+              typeof spawned.pid === "number"
+                ? spawned.pid
+                : "unknown";
+            this.logReconnect(
               "spawn-fired-version-bump",
               `[cmuxlayer-proxy] daemon spawn fired (script=${daemonScriptPath}, pid=${pid})`,
             );

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -83,6 +83,27 @@ describe("control health", () => {
     });
   });
 
+  it("handles spaces in bundle executable names without accepting bundle arguments", () => {
+    expect(
+      resolveSpawnerAncestry(
+        "700 1 /Applications/Google Drive.app/Contents/MacOS/Google Drive\n1 0 /sbin/launchd",
+        700,
+      ),
+    ).toEqual({
+      app_bundle_path: "/Applications/Google Drive.app",
+      pid: 700,
+    });
+    expect(
+      resolveSpawnerAncestry(
+        "700 1 /opt/homebrew/bin/node /Users/x/dist/daemon.js --cli /Applications/Google Drive.app/Contents/MacOS/Google Drive\n1 0 /sbin/launchd",
+        700,
+      ),
+    ).toEqual({
+      app_bundle_path: null,
+      pid: null,
+    });
+  });
+
   it("only notifies on blocking health and records code severity in signatures", () => {
     const { engine, stateDir } = createHealthNotificationEngine();
     try {

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import {
   collectControlHealth,
   formatControlHealth,
+  resolveSpawnerAncestry,
 } from "../src/control-health.js";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ControlHealth } from "../src/control-health.js";
@@ -55,6 +56,33 @@ afterEach(() => {
 });
 
 describe("control health", () => {
+  it.each([
+    "/opt/homebrew/bin/node /Users/x/dist/daemon.js --cli /Applications/cmux.app/Contents/MacOS/cmux",
+    "/opt/homebrew/bin/node /Users/x/dist/daemon.js /Applications/cmux.app/Contents/MacOS/cmux",
+  ])("ignores app bundle paths passed only as ancestor arguments", (command) => {
+    expect(resolveSpawnerAncestry(`700 1 ${command}\n1 0 /sbin/launchd`, 700)).toEqual({
+      app_bundle_path: null,
+      pid: null,
+    });
+  });
+
+  it("reports an app bundle when the ancestor executable is bundle-resident", () => {
+    expect(
+      resolveSpawnerAncestry(
+        [
+          "900 800 /opt/homebrew/bin/node /opt/cmuxlayer/dist/daemon.js",
+          "800 700 /opt/homebrew/bin/node /opt/cmuxlayer/dist/proxy.js",
+          "700 1 /Applications/cmux.app/Contents/MacOS/cmux",
+          "1 0 /sbin/launchd",
+        ].join("\n"),
+        900,
+      ),
+    ).toEqual({
+      app_bundle_path: "/Applications/cmux.app",
+      pid: 700,
+    });
+  });
+
   it("only notifies on blocking health and records code severity in signatures", () => {
     const { engine, stateDir } = createHealthNotificationEngine();
     try {
@@ -209,7 +237,7 @@ describe("control health", () => {
             stdout: [
               "900 800 /opt/homebrew/bin/node /opt/cmuxlayer/dist/daemon.js",
               "800 700 /opt/homebrew/bin/node /opt/cmuxlayer/dist/proxy.js",
-              "700 1 /usr/bin/open -a /Applications/Zed.app",
+              "700 1 /Applications/Zed.app/Contents/MacOS/Zed",
               "1 0 /sbin/launchd",
             ].join("\n"),
           };


### PR DESCRIPTION
STATUS: REVIEW_NEEDED

## Summary

- restrict spawner ancestry bundle detection to the ancestor executable (`argv[0]`)
- reject `.app` paths that appear only in ancestor arguments
- restore the real bundle-resident Zed process fixture
- clean up the existing version-bump spawn block indentation without changing behavior

## Verification

- RED: both false-positive fixtures returned `/Applications/cmux.app` before the fix
- targeted Vitest: 37/37 under both unset and set `CMUXLAYER_FORCE_INPROCESS`
- typecheck: clean under both environment modes
- build: clean
- default full suite and final push hook: 145 files, 3386 passed, 1 skipped
- forced full suite: known out-of-scope `tests/live-topology-restart.test.ts` failure only; 3385 passed, 1 failed, 1 skipped
- detached plain-shell proof, reparented at `ppid=1`: argv false-positive returned `null`; real executable chain returned `/Applications/cmux.app`
- no launchd or launchctl used

## Review boundary

Do not merge until the lead sends `VERIFIED — MERGE`; the lead owns reviewer routing for this follow-up.

— cmuxlayerCodex-b0271b27 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-b0271b27","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03934","ts":"2026-08-25T14:45:51Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only ancestry parsing change with targeted tests; the only regression risk is missing bundles when `ps` puts the executable after the first token.
> 
> **Overview**
> **`resolveSpawnerAncestry`** now treats only the **first token** of each ancestor’s `ps` command as the executable when looking for a `*.app` bundle path, instead of scanning the full command line. That stops false positives when a `.app` path appears only in arguments (e.g. `node daemon.js --cli /Applications/cmux.app/...` or `open -a /Applications/Zed.app`).
> 
> Tests cover ignored-argument cases, real bundle-resident executables (including names with spaces), and the integration mock now uses **`/Applications/Zed.app/Contents/MacOS/Zed`** instead of an `open -a` line. **`proxy.ts`** only re-indents the version-bump daemon spawn block with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0374abe35175cc54e5d28a84a83c20b41ef5529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore `.app` bundle paths in arguments in `resolveSpawnerAncestry`
> Tightens the app-bundle detection regex in [control-health.ts](https://github.com/EtanHey/cmuxlayer/pull/545/files#diff-f964334f4a4d28481598c8c25ceec394cc5f7665b7e068d0806b6b2759d63d9d) so the match anchors at the start of the ancestor command. An app bundle is now reported only when the ancestor executable path itself resides within a `.app` bundle; `.app` paths appearing solely as command arguments are ignored. Adds test cases in [control-health.test.ts](https://github.com/EtanHey/cmuxlayer/pull/545/files#diff-cd2c4a14aaeab7a84abd13403d539d6ff6b908c81f6b87721fbe1f02a55cb7c3) covering argument-only `.app` paths, bundle-resident executables, and spaces in bundle names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0374ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->