### PR TITLE
fix: publish cross-window sweep statuses

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -5261,23 +5261,39 @@ export class AgentEngine {
   private async publishSweepStatus(
     ctx: SweepAgentContext,
     statusUpdates: CmuxStatusUpdate[],
-  ): Promise<boolean> {
-    if (!this.assertSweepInputCurrent(ctx)) return false;
-    if (statusUpdates.length === 1) {
-      const [update] = statusUpdates;
-      await this.client.setStatus(update.key, update.value, update);
-      return true;
-    }
+  ): Promise<ReadonlySet<string>> {
+    if (!this.assertSweepInputCurrent(ctx)) return new Set();
     if (statusUpdates.length > 1) {
       if (this.client.setStatuses) {
-        return (await this.client.setStatuses(statusUpdates)) !== false;
-      }
-      for (const update of statusUpdates) {
-        if (!this.assertSweepInputCurrent(ctx)) return false;
-        await this.client.setStatus(update.key, update.value, update);
+        try {
+          const batchApplied = await this.client.setStatuses(statusUpdates);
+          if (batchApplied !== false) {
+            return new Set(statusUpdates.map(({ key }) => key));
+          }
+          return new Set();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.sweepDebugLog(
+            `[cmuxlayer] sidebar status batch failed; retrying entries independently: ${message}`,
+          );
+        }
       }
     }
-    return true;
+
+    const applied = new Set<string>();
+    for (const update of statusUpdates) {
+      if (!this.assertSweepInputCurrent(ctx)) return new Set();
+      try {
+        await this.client.setStatus(update.key, update.value, update);
+        applied.add(update.key);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.sweepDebugLog(
+          `[cmuxlayer] sidebar status skipped for ${update.key}: ${message}`,
+        );
+      }
+    }
+    return applied;
   }
 
   private shouldNotifyDone(harvestability: WorkerHarvestability): boolean {
@@ -5983,7 +5999,7 @@ export class AgentEngine {
       return;
     }
 
-    const statusBatchApplied = await this.publishSweepStatus(
+    const appliedStatusKeys = await this.publishSweepStatus(
       sweepContext,
       statusUpdates,
     );
@@ -5993,8 +6009,8 @@ export class AgentEngine {
     ) {
       return;
     }
-    if (statusBatchApplied) {
-      for (const pending of pendingStatusSnapshots) {
+    for (const pending of pendingStatusSnapshots) {
+      if (appliedStatusKeys.has(pending.agentId)) {
         this.sidebarSnapshot.set(pending.agentId, pending.snapshot);
       }
     }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -900,7 +900,10 @@ export class CmuxSocketClient {
   }
 
   private async resolveWorkspaceTabId(workspace: string): Promise<string> {
-    const { workspaces } = await this.listWorkspaces();
+    const { workspaces } = await listAllWindowWorkspaces(
+      this,
+      () => this.currentObserverTransportEpoch(),
+    );
     const match = workspaces.find(
       (candidate) => candidate.ref === workspace || candidate.id === workspace,
     );

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -862,6 +862,60 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     // No throw = success
   });
 
+  it("resolves a status tab id from a workspace in another window", async () => {
+    const savedWindowList = MOCK_RESPONSES["window.list"];
+    const savedWorkspaceList = MOCK_RESPONSES["workspace.list"];
+
+    MOCK_RESPONSES["window.list"] = {
+      windows: [
+        { ref: "window:1", workspace_count: 1 },
+        { ref: "window:2", workspace_count: 1 },
+      ],
+    };
+    MOCK_RESPONSES["workspace.list"] = (req) => {
+      const windowRef = String(req.params.window_id ?? "");
+      return {
+        workspaces:
+          windowRef === "window:2"
+            ? [
+                {
+                  id: MOCK_SECOND_WORKSPACE_ID,
+                  ref: "workspace:2",
+                  title: "Other Window",
+                  index: 0,
+                  selected: true,
+                  pinned: false,
+                },
+              ]
+            : [
+                {
+                  id: MOCK_WORKSPACE_ID,
+                  ref: "workspace:1",
+                  title: "Caller Window",
+                  index: 0,
+                  selected: true,
+                  pinned: false,
+                },
+              ],
+      };
+    };
+
+    try {
+      const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+      await client.setStatus("agent", "active", {
+        workspace: "workspace:2",
+      });
+
+      expect(lastV1Command).toBe(
+        `set_status agent active --tab=${MOCK_SECOND_WORKSPACE_ID}`,
+      );
+    } finally {
+      MOCK_RESPONSES["window.list"] = savedWindowList;
+      MOCK_RESPONSES["workspace.list"] = savedWorkspaceList;
+    }
+  });
+
   it("sends a 12-entry status batch through one persistent connection", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -4008,6 +4008,64 @@ describe("Sidebar Sync", () => {
     );
   });
 
+  it("publishes the rest of a sweep when one agent status cannot resolve", async () => {
+    useActiveCodexScreen(mockClient);
+    for (const [agentId, workspace, surface] of [
+      ["status-good", "workspace:alpha", "surface:good"],
+      ["status-missing", "workspace:missing", "surface:missing"],
+    ] as const) {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: agentId,
+          state: "working",
+          surface_id: surface,
+          workspace_id: workspace,
+          cli_session_id: `session-${agentId}`,
+        }),
+      );
+      liveSurfaces.push({ ...makeSurface(surface), workspace_ref: workspace });
+      writeHeartbeat(agentId, inboxOpts);
+    }
+    mockClient.setStatuses.mockRejectedValueOnce(
+      new Error(
+        "cmux set-status failed for keys [status-missing]: Unable to resolve tab id",
+      ),
+    );
+    mockClient.setStatus.mockImplementation(async (key: string) => {
+      if (key === "status-missing") {
+        throw new Error("Unable to resolve tab id for workspace workspace:missing");
+      }
+    });
+    await engine.getRegistry().reconstitute();
+
+    await expect(engine.runSweep()).resolves.toBeUndefined();
+
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "status-good",
+      expect.stringContaining("state=working"),
+      expect.objectContaining({ workspace: "workspace:alpha" }),
+    );
+    expect(mockClient.setStatus).toHaveBeenCalledWith(
+      "status-missing",
+      expect.stringContaining("state=working"),
+      expect.objectContaining({ workspace: "workspace:missing" }),
+    );
+    expect(sweepDebugLogs).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "status-missing: Unable to resolve tab id for workspace workspace:missing",
+        ),
+      ]),
+    );
+    expect(publishedFleetPublications.at(-1)?.snapshot.seatCount).toBe(2);
+
+    mockClient.setStatus.mockClear();
+    await expect(engine.runSweep()).resolves.toBeUndefined();
+    expect(
+      mockClient.setStatus.mock.calls.map(([key]) => key),
+    ).toEqual(["status-missing"]);
+  });
+
   it("logs spawned event on first sweep for each new agent", async () => {
     stateMgr.writeState(
       makeRecord({


### PR DESCRIPTION
## Summary

- resolve sidebar workspace tab IDs through the shared all-window enumerator, including its one retry and fail-closed behavior
- keep the successful status-batch fast path, but retry rejected batches per agent so one unresolvable tab does not abort the sweep
- log individual misses, record only successful sidebar status snapshots, and keep publishing the fleet snapshot

Lead row: D100. The older-socket `window.list` fallback remains deferred to D99.

## Failing-first evidence

- cross-window `setStatus`: failed with `CmuxSocketError: Unable to resolve tab id for workspace workspace:2`
- partial sweep publication: `runSweep()` rejected when one status tab could not resolve
- both regressions pass after the implementation

## Verification

- focused D100 regressions: 3 passed, including the existing false-batch dirty-row contract
- `bun run typecheck`: pass
- `bun run build`: pass
- canonical full suite: 145 files passed; 3,412 passed, 1 skipped
- push hook: contract receipts passed; 145 files passed; 3,412 passed, 1 skipped
- `git diff --check`: pass
- local CodeRabbit review reached the three-minute bound without returning findings

## Real-client proof

Built artifacts, isolated daemon/state under `docs.local/scratch`, no launchd and no new pane:

```json
{
  "caller": {
    "workspace_ref": "workspace:2"
  },
  "listed_workspace_refs": ["workspace:2", "workspace:5"],
  "target": {
    "window_ref": "window:2",
    "workspace_ref": "workspace:5",
    "surface_ref": "surface:29"
  },
  "built_socket_set_status_other_window": {
    "ok": true,
    "key": "d100-cross-window-proof",
    "value": "cross-window-ok",
    "read_back": true,
    "cleaned_up": true
  }
}
```

The isolated daemon's MCP `list_surfaces` returned both live workspaces. Its current MCP profile does not expose `set_status` (`-32602`), so the changed method was exercised through the built `CmuxSocketClient` against the real cmux socket, then read back and cleaned up.

— cmuxlayerCodex (implementor) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"implementor","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03934","ts":"2026-08-25T16:31:36Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sweep sidebar sync and cmux socket workspace resolution; behavior changes when batch or per-agent status fails, but failures are isolated rather than aborting the sweep.
> 
> **Overview**
> Fixes sidebar status publishing when the target workspace lives in another cmux window, and stops a single bad tab from failing the whole sweep.
> 
> **Cross-window tab resolution:** `CmuxSocketClient.resolveWorkspaceTabId` now uses `listAllWindowWorkspaces` instead of the caller-window `listWorkspaces`, so `setStatus` can map a workspace ref to the correct tab UUID across windows.
> 
> **Partial sweep publication:** `publishSweepStatus` returns the set of status keys that actually applied (not a single boolean). Batch `setStatuses` failures are caught and retried per agent; per-key `setStatus` errors are logged and skipped. Sidebar snapshots are updated only for agents whose status keys succeeded, while the sweep and fleet snapshot still complete for the rest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d69dbdbbf701ddf115c0830482036ce8b10a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cross-window sweep status publishing in `AgentEngine`
> - `publishSweepStatus` now returns a `ReadonlySet<string>` of successfully applied status keys instead of a `boolean`, falling back from batch `setStatuses` to per-key `setStatus` on failure and logging per-key failures.
> - The sweep application block updates `sidebarSnapshot` only for agent IDs whose status was successfully applied, replacing the previous all-or-nothing boolean check.
> - `resolveWorkspaceTabId` now uses `listAllWindowWorkspaces` to resolve workspace tab IDs across all windows, not just the current one.
> - Tests cover cross-window workspace resolution and partial sweep failure where one agent's status cannot resolve.
> - Behavioral Change: stale sweep inputs now return an empty `Set` instead of `false`; callers that checked the return value as a boolean are updated in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/546/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 19d69db. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/agent-engine.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 5273](https://github.com/EtanHey/cmuxlayer/blob/19d69dbdbbf701ddf115c0830482036ce8b10a0a/src/agent-engine.ts#L5273): When `setStatuses(statusUpdates)` returns `false`, `publishSweepStatus` immediately returns an empty set instead of falling through to the per-entry `setStatus` loop. If a batch is rejected because one workspace/tab is unresolvable, every otherwise-valid sidebar update is skipped on every sweep, defeating the partial-publication fallback that only runs when the batch throws. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar status updates now continue for other agents when one update fails.
  - Only unresolved sidebar entries are retried, reducing duplicate updates and preserving accurate status information.
  - Status commands now correctly target workspaces located in other application windows.
  - Sidebar snapshots are saved only after the corresponding status update succeeds.

- **Tests**
  - Added coverage for cross-window workspace status commands and partial sidebar update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->