### PR TITLE
fix: make boot prompt delivery truthful

### DIFF
--- a/docs/plans/2026-08-25-d82-boot-delivery-design.md
+++ b/docs/plans/2026-08-25-d82-boot-delivery-design.md
@@ -1,0 +1,23 @@
+# D82 Boot Delivery Design
+
+## Goal
+
+Make boot-prompt delivery wait for a real idle agent turn, report a bounded banner-independent queue honestly, reject interrupt-rescued transcript echoes as verified submission, and preserve the live agent binding when delivery does not complete.
+
+## Chosen approach
+
+`waitForBootPromptReady` remains the single pre-delivery gate, but a working or thinking agent is no longer writable merely because its composer chrome and identity are visible. The gate waits until the same agent route has an idle/done composer. If its deadline expires while the agent is still working with an empty composer and no prompt echo, it returns an observed queued result instead of throwing or typing into the running turn.
+
+`deliverBootPrompt` converts that result into an explicit `delivery_state: "queued"` receipt with no typing or Return attempt. Managed spawn handlers retain `boot_prompt_pending` for this state, so the live pane stays registered and inspectable. Lifecycle reconciliation is not allowed to infer `prompt_delivered` or `submit_verified` from a ready/active screen when the server has recorded that the prompt was not delivered.
+
+Post-Return verification compares interrupt markers against the pre-Return screen. A new `Conversation interrupted` marker followed by transcript echo produces terminal `delivery_state: "rescued"`, `delivered: false`, and `submit_verified: false`; it can never produce a verified receipt.
+
+## Rejected approaches
+
+- Send while the front-matter turn is running and infer the hidden queue later: this repeats the defect and depends on Codex queue rendering.
+- Press Escape before sending: the live probe showed that Escape kills the active turn and can create a false-green transcript receipt.
+- Treat a working/status frame as submission evidence: it is not attributable to the boot prompt.
+
+## Verification
+
+Tests must fail first for idle-wait delivery, bounded bannerless queueing, interrupt rescue, and registry retention. Focused tests cover receipt vocabulary and lifecycle reconciliation. Completion additionally requires the full suite, typecheck with and without inherited environment, local review, exact-head CI, and the lead-owned front-matter live probe plus AFTER recording.

--- a/docs/plans/2026-08-25-d82-boot-delivery.md
+++ b/docs/plans/2026-08-25-d82-boot-delivery.md
@@ -1,0 +1,52 @@
+# D82 Boot Delivery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver boot prompts only after the launcher front-matter turn is idle, with truthful queued/rescued receipts and retained live-agent state.
+
+**Architecture:** Extend the existing boot-readiness and delivery-receipt pipeline rather than adding a parallel sender. Keep the server as the only authority that can mark a managed boot prompt delivered; lifecycle screen reconciliation may preserve or fail pending state but may not invent successful delivery.
+
+**Tech Stack:** TypeScript, Vitest, cmux screen parsing and lifecycle registry.
+
+---
+
+### Task 1: Add failing receipt and readiness regressions
+
+**Files:**
+
+- Modify: `tests/delivery-truth-t2.test.ts`
+- Modify: `tests/server-agent-tools.test.ts`
+
+1. Add a test where Codex renders a working front-matter turn with an empty composer, later becomes idle, and the boot prompt is typed only after idle.
+2. Add a test where that working frame persists through `boot_prompt_timeout_ms`; assert bounded return with `delivery_state: "queued"`, `typed: false`, and no Return.
+3. Add a test where a new interrupt marker precedes transcript echo; assert `delivery_state: "rescued"` and `submit_verified: false`.
+4. Add a managed-spawn test proving a queued timeout leaves `boot_prompt_pending: true` and the agent retrievable by id.
+5. Run the focused tests and record the expected failures.
+
+### Task 2: Implement idle-wait and receipt truth
+
+**Files:**
+
+- Modify: `src/server.ts`
+- Modify: `src/agent-engine.ts`
+
+1. Make boot readiness reject working/thinking frames as send-ready.
+2. On deadline, recognize working agent identity plus empty composer plus absent prompt echo as the banner-independent queued observation.
+3. Return a queued boot receipt without typing or pressing Return.
+4. Add `rescued` to the public and engine delivery-state vocabulary and classify new-interrupt transcript evidence as rescued.
+5. Preserve pending managed records for queued delivery and prevent lifecycle reconciliation from manufacturing successful boot delivery.
+6. Run the focused tests until green.
+
+### Task 3: Verify and publish through the run gates
+
+**Files:**
+
+- Modify only files required by review findings.
+
+1. Run all affected suites, then the full suite.
+2. Run typecheck both with the inherited environment and with the documented clean-environment form.
+3. Run `git diff --check` and bounded local CodeRabbit review.
+4. Commit with the required agent trailer, push, and open a signed ready-for-review PR.
+5. Process no more than two review rounds; the lead owns the independent reviewer and live front-matter probe.
+6. Before merge, separately assert checks green, zero unanswered P1 findings, and both `before`/`after` evidence links in the PR body.
+7. Merge with a merge commit, verify origin/main contains the final head, and write the contract report ending with the required sentinel.

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -262,6 +262,7 @@ export type AgentDeliveryState =
   | "submitted"
   | "queued"
   | "queued_followup"
+  | "rescued"
   | "failed"
   | "pending_verify"
   | "failed_confirmed";
@@ -352,7 +353,12 @@ export class RetryableDeliveryError extends Error {
 type DeliverySubmitter = (receipt: AgentDeliveryReceipt) => Promise<{
   retry_count: number;
   submit_verified: boolean | null;
-  delivery?: "submitted" | "queued" | "queued_followup" | "pending_verify";
+  delivery?:
+    | "submitted"
+    | "queued"
+    | "queued_followup"
+    | "rescued"
+    | "pending_verify";
 }>;
 
 export interface SpawnAgentParams {
@@ -2711,8 +2717,7 @@ export class AgentEngine {
       const awaitingManagedBootPrompt =
         targetState === "ready" &&
         agent.boot_prompt_pending === true &&
-        agent.prompt_delivered === false &&
-        !evidence.activeCodex;
+        agent.prompt_delivered === false;
       if (
         !hasTargetEvidence ||
         awaitingManagedBootPrompt ||
@@ -2744,7 +2749,8 @@ export class AgentEngine {
             transitionAgent.model,
             parsedModel,
           ),
-          ...(transitionAgent.boot_prompt_pending
+          ...(transitionAgent.boot_prompt_pending &&
+          transitionAgent.prompt_delivered !== false
             ? {
                 boot_prompt_pending: false,
                 prompt_delivered: true,
@@ -3911,12 +3917,10 @@ export class AgentEngine {
       const evidence = this.readReadyEvidence(agent, screen.text);
       const promptStillPending =
         agent.boot_prompt_pending === true &&
-        !evidence.activeCodex &&
         this.screenShowsPendingBootPrompt(agent, screen.text);
       const awaitingManagedBootPrompt =
         agent.boot_prompt_pending === true &&
-        agent.prompt_delivered === false &&
-        !evidence.activeCodex;
+        agent.prompt_delivered === false;
 
       if (promptStillPending || awaitingManagedBootPrompt) {
         this.readyPatternMatches.delete(agent.agent_id);
@@ -3994,7 +3998,7 @@ export class AgentEngine {
 
       const settled = this.stateMgr.updateRecord(agent.agent_id, {
         ...settlement,
-        ...(agent.boot_prompt_pending
+        ...(agent.boot_prompt_pending && agent.prompt_delivered !== false
           ? {
               boot_prompt_pending: false,
               prompt_delivered: true,
@@ -7380,6 +7384,13 @@ export class AgentEngine {
             receipt.verify_deadline_at ??= new Date(
               Date.now() + this.deliveryVerifyDeadlineMs,
             ).toISOString();
+          } else if (result.delivery === "rescued") {
+            receipt.delivery_state = "rescued";
+            receipt.terminal = true;
+            receipt.resolved_at = new Date().toISOString();
+            receipt.submit_verified = false;
+            receipt.error = "Prompt appeared only after an external interrupt";
+            receipt.verify_deadline_at = null;
           } else {
             receipt.delivery_state = "submitted";
             receipt.terminal = true;

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -299,6 +299,7 @@ export interface DeliveryTelemetryEvent {
     | "submitted"
     | "queued"
     | "queued_followup"
+    | "rescued"
     | "failed"
     | "pending_verify"
     | "failed_confirmed";

--- a/src/server.ts
+++ b/src/server.ts
@@ -5392,6 +5392,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const preReturnInterruptMarkers = interruptMarkerCount(
       opts.pre_return_screen,
     );
+    let sawNewInterrupt = false;
     const screenIncludesSubmittedText = (screenText: string): boolean =>
       screenContainsCompleteSubmittedText(screenText, opts.text);
 
@@ -5411,6 +5412,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         continue;
       }
       sawReadableScreen = true;
+      sawNewInterrupt ||=
+        interruptMarkerCount(snapshot.text) > preReturnInterruptMarkers;
 
       const hasPendingInput =
         opts.require_attributable_submit_evidence === true
@@ -5513,10 +5516,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         bootFrameAdvanced &&
         !hasPendingSubmitEvidence &&
         screenIncludesSubmittedText(snapshot.text);
-      const newInterruptObserved =
-        interruptMarkerCount(snapshot.text) > preReturnInterruptMarkers;
       if (
-        newInterruptObserved &&
+        sawNewInterrupt &&
         !hasPendingSubmitEvidence &&
         (bootHasTranscriptEcho || bootHasTokenOrCostDelta)
       ) {
@@ -16488,7 +16489,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               (receipt) => receipt.delivery_state === "queued",
             ).length;
             const failedCount = receipts.filter(
-              (receipt) => receipt.delivery_state === "failed",
+              (receipt) =>
+                receipt.delivery_state === "failed" ||
+                receipt.delivery_state === "rescued",
             ).length;
             const skippedCount = receipts.filter(
               (receipt) => receipt.skipped !== undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -621,6 +621,7 @@ const DeliveryOutputShape = {
       "submitted",
       "queued",
       "queued_followup",
+      "rescued",
       "failed",
       "pending_verify",
       "failed_confirmed",
@@ -631,6 +632,7 @@ const DeliveryOutputShape = {
       "submitted",
       "queued",
       "queued_followup",
+      "rescued",
       "failed",
       "pending_verify",
       "failed_confirmed",
@@ -976,6 +978,7 @@ type PublicDeliveryState =
   | "submitted"
   | "queued"
   | "queued_followup"
+  | "rescued"
   | "failed"
   | "pending_verify"
   | "failed_confirmed";
@@ -994,6 +997,12 @@ export interface PublicDeliveryReceipt {
   duplicate_of?: string;
   needs_attention?: boolean;
   attention_reason?: string;
+  observation?: {
+    status: ParsedScreenResult["status"];
+    composer_empty: boolean;
+    prompt_echoed: boolean;
+    last_10_lines: string[];
+  };
   WARNING?: string;
 }
 
@@ -1012,11 +1021,13 @@ export function buildPublicDeliveryReceipt(input: {
   retry_count: number;
   needs_attention?: boolean;
   attention_reason?: string | null;
+  observation?: PublicDeliveryReceipt["observation"];
   WARNING?: string;
 }): PublicDeliveryReceipt {
   const evidencedState =
     input.delivery_state === "queued" ||
     input.delivery_state === "queued_followup" ||
+    input.delivery_state === "rescued" ||
     input.delivery_state === "failed" ||
     input.delivery_state === "pending_verify" ||
     input.delivery_state === "failed_confirmed"
@@ -1026,6 +1037,7 @@ export function buildPublicDeliveryReceipt(input: {
         : undefined;
   const terminal =
     evidencedState === "submitted" ||
+    evidencedState === "rescued" ||
     evidencedState === "failed" ||
     evidencedState === "failed_confirmed";
   const warning = input.WARNING ?? defaultNonDeliveryWarning(evidencedState);
@@ -1051,6 +1063,7 @@ export function buildPublicDeliveryReceipt(input: {
             : {}),
         }
       : {}),
+    ...(input.observation ? { observation: input.observation } : {}),
     ...(warning ? { WARNING: warning } : {}),
   };
 }
@@ -1081,6 +1094,12 @@ function defaultNonDeliveryWarning(
       return (
         `NOT DELIVERED — terminal failure (${state}). The message did not ` +
         "land and will not be retried; do not relay as sent."
+      );
+    case "rescued":
+      return (
+        "NOT VERIFIED — state rescued: the prompt first appeared after an " +
+        "interrupt, so external intervention delivered text but cmuxlayer did " +
+        "not verify an intact task turn. Do not relay as delivered."
       );
     default:
       return undefined;
@@ -5314,7 +5333,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_evidence: SubmitEvidence | null;
     submit_verification_reason: SubmitVerificationFailureReason | null;
     retry_count: number;
-    delivery: "submitted" | "queued" | "queued_followup" | "pending_verify";
+    delivery:
+      | "submitted"
+      | "queued"
+      | "queued_followup"
+      | "rescued"
+      | "pending_verify";
   }> => {
     if (!opts.verify_submit) {
       // null means submit verification was not attempted, usually because the
@@ -5346,6 +5370,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let sawReadableScreen = false;
     let sawBlankScreen = false;
     let lastBootConsumptionRefuted = false;
+    const interruptMarkerCount = (screenText: string | null | undefined) =>
+      screenText?.match(/Conversation interrupted/gi)?.length ?? 0;
+    const preReturnInterruptMarkers = Math.max(
+      interruptMarkerCount(opts.pre_type_screen),
+      interruptMarkerCount(opts.pre_return_screen),
+    );
     const screenIncludesSubmittedText = (screenText: string): boolean =>
       screenContainsCompleteSubmittedText(screenText, opts.text);
 
@@ -5467,6 +5497,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         bootFrameAdvanced &&
         !hasPendingSubmitEvidence &&
         screenIncludesSubmittedText(snapshot.text);
+      const newInterruptObserved =
+        interruptMarkerCount(snapshot.text) > preReturnInterruptMarkers;
+      if (
+        newInterruptObserved &&
+        !hasPendingSubmitEvidence &&
+        (bootHasTranscriptEcho || bootHasTokenOrCostDelta)
+      ) {
+        return {
+          submit_verified: false,
+          submit_evidence: bootHasTranscriptEcho
+            ? "transcript_echo"
+            : "token_delta",
+          submit_verification_reason: null,
+          retry_count: retryCount,
+          delivery: "rescued",
+        };
+      }
       if (
         !hasPendingSubmitEvidence &&
         !bootConsumptionRefuted &&
@@ -5886,7 +5933,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       null;
     let retry_count = 0;
     let deliveryOutcome:
-      "submitted" | "queued" | "queued_followup" | "pending_verify" =
+      | "submitted"
+      | "queued"
+      | "queued_followup"
+      | "rescued"
+      | "pending_verify" =
       "submitted";
 
     if (opts.press_enter) {
@@ -6016,6 +6067,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     ? ("queued_followup" as const)
                     : deliveryOutcome === "pending_verify"
                       ? ("pending_verify" as const)
+                      : deliveryOutcome === "rescued"
+                        ? ("rescued" as const)
                       : submit_verified === false
                         ? ("failed" as const)
                         : ("submitted" as const),
@@ -6032,6 +6085,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? "queued_followup"
             : deliveryOutcome === "pending_verify"
               ? "pending_verify"
+              : deliveryOutcome === "rescued"
+                ? "rescued"
               : submit_verified === true
                 ? "submitted"
                 : undefined,
@@ -6047,6 +6102,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       submit_verified === false &&
       deliveryOutcome !== "queued" &&
       deliveryOutcome !== "queued_followup" &&
+      deliveryOutcome !== "rescued" &&
       deliveryOutcome !== "pending_verify"
     ) {
       const timeoutMs =
@@ -6066,13 +6122,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     surface: string;
     workspace?: string;
     cli?: CliType;
+    text: string;
     timeout_ms: number;
     onUpdateShellRelaunch?: () => Promise<void>;
     resolveRoute?: () => Promise<{ surface: string; workspace?: string }>;
   }): Promise<{
+    delivery_state: "ready" | "queued";
     metrics: RawSubmitEvidenceMetrics | null;
     route: { surface: string; workspace?: string };
     cli: CliType;
+    observation?: NonNullable<PublicDeliveryReceipt["observation"]>;
   }> => {
     let deadline = Date.now() + opts.timeout_ms;
     let lastText = "";
@@ -6085,6 +6144,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateShellRelaunches = 0;
     let codexUpdateMenuAccepted = false;
     let codexUpdateMenuAcceptedAt: number | null = null;
+    let queuedObservation:
+      | {
+          metrics: RawSubmitEvidenceMetrics;
+          route: { surface: string; workspace?: string };
+          cli: CliType;
+          observation: NonNullable<PublicDeliveryReceipt["observation"]>;
+        }
+      | null = null;
     const updateMaxMs = bootPromptUpdateMaxMs();
     const postUpdateReadyBudgetMs = () =>
       Math.max(opts.timeout_ms, BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS);
@@ -6106,6 +6173,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const parsed = parseScreen(screen.text);
         const now = Date.now();
         const updateState = parsed.cli_update_state;
+        const runningTurn =
+          parsed.status === "working" || parsed.status === "thinking";
 
         const launcherFailure = launcherFailureFromShell(screen.text);
         if (launcherFailure) {
@@ -6231,9 +6300,40 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
         for (const candidate of candidates) {
           const match = matchReadyPattern(candidate, screen.text);
-          const ready =
+          const identified =
             match.matched &&
             screenHasReadyAgentIdentity(candidate, screen.text, parsed);
+          const bannerIndependentIdentity =
+            screenHasAnyAgentIdentity(screen.text, parsed) &&
+            inferComposerCli(screen.text, parsed) === candidate;
+          const composer = extractComposerInputRegion(screen.text, opts.text);
+          const promptEchoed = screenContainsCompleteSubmittedText(
+            screen.text,
+            opts.text,
+          );
+          const codexTurnStillRunning = candidate === "codex" && runningTurn;
+          if (
+            bannerIndependentIdentity &&
+            codexTurnStillRunning &&
+            composer !== null &&
+            composer.trim() === "" &&
+            !promptEchoed
+          ) {
+            queuedObservation = {
+              metrics: parseSubmitEvidenceMetrics(screen.text, parsed),
+              route: target,
+              cli: candidate,
+              observation: {
+                status: parsed.status,
+                composer_empty: true,
+                prompt_echoed: false,
+                last_10_lines: tailLines(screen.text, 10),
+              },
+            };
+          } else if (identified || bannerIndependentIdentity) {
+            queuedObservation = null;
+          }
+          const ready = identified && !codexTurnStillRunning;
           const count = ready
             ? (consecutiveMatches.get(candidate) ?? 0) + 1
             : 0;
@@ -6242,6 +6342,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             count >= requiredBootReadyObservations(candidate, screen.text)
           ) {
             return {
+              delivery_state: "ready",
               metrics: parseSubmitEvidenceMetrics(screen.text, parsed),
               route: target,
               cli: candidate,
@@ -6267,6 +6368,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         break;
       }
       await delay(Math.min(BOOT_PROMPT_READY_POLL_MS, remaining));
+    }
+
+    if (queuedObservation) {
+      return {
+        delivery_state: "queued",
+        ...queuedObservation,
+      };
     }
 
     throw new BootPromptTimeoutError(
@@ -6930,18 +7038,41 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       };
     }
 
+    const rawPrompt = bootPromptPath
+      ? await readFile(bootPromptPath, "utf8")
+      : (opts.prompt ?? "");
+    const useFilePointer =
+      Boolean(bootPromptPath) &&
+      (/[\r\n]/.test(rawPrompt) ||
+        rawPrompt.length > SEND_INPUT_MAX_INLINE_CHARS);
+    const promptWarning =
+      bootPromptPath &&
+      rawPrompt.length > BOOT_PROMPT_PATH_WARNING_CHARS &&
+      !useFilePointer
+        ? `boot_prompt_path is ${rawPrompt.length} characters; prefer a one-line file pointer for boot prompts over ${BOOT_PROMPT_PATH_WARNING_CHARS} characters`
+        : null;
+    const callerDeliveryText = useFilePointer
+      ? `Read and follow ${bootPromptPath}`
+      : rawPrompt;
+    const deliveryText = [callerDeliveryText, opts.injected_prompt]
+      .filter((part): part is string => hasInlinePrompt(part))
+      .join("\n\n");
+    const sanitizedText = sanitizeTerminalInput(deliveryText);
+    const chunks =
+      sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
+        ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
+        : [sanitizedText];
+
     let readiness = await waitForBootPromptReady({
       surface: opts.surface,
       workspace: opts.workspace,
       cli: opts.cli,
+      text: sanitizedText,
       timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
       onUpdateShellRelaunch: opts.onUpdateShellRelaunch,
       resolveRoute: opts.resolveRoute,
     });
 
-    const rawPrompt = bootPromptPath
-      ? await readFile(bootPromptPath, "utf8")
-      : (opts.prompt ?? "");
     let deliveryRoute = opts.resolveRoute
       ? await opts.resolveRoute()
       : readiness.route;
@@ -6956,6 +7087,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         surface: deliveryRoute.surface,
         workspace: deliveryRoute.workspace,
         cli: opts.cli,
+        text: sanitizedText,
         timeout_ms: opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS,
         onUpdateShellRelaunch: opts.onUpdateShellRelaunch,
         resolveRoute: opts.resolveRoute,
@@ -6979,27 +7111,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         }
       : undefined;
-    const useFilePointer =
-      Boolean(bootPromptPath) &&
-      (/[\r\n]/.test(rawPrompt) ||
-        rawPrompt.length > SEND_INPUT_MAX_INLINE_CHARS);
-    const promptWarning =
-      bootPromptPath &&
-      rawPrompt.length > BOOT_PROMPT_PATH_WARNING_CHARS &&
-      !useFilePointer
-        ? `boot_prompt_path is ${rawPrompt.length} characters; prefer a one-line file pointer for boot prompts over ${BOOT_PROMPT_PATH_WARNING_CHARS} characters`
-        : null;
-    const callerDeliveryText = useFilePointer
-      ? `Read and follow ${bootPromptPath}`
-      : rawPrompt;
-    const deliveryText = [callerDeliveryText, opts.injected_prompt]
-      .filter((part): part is string => hasInlinePrompt(part))
-      .join("\n\n");
-    const sanitizedText = sanitizeTerminalInput(deliveryText);
-    const chunks =
-      sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
-        ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
-        : [sanitizedText];
+    if (readiness.delivery_state === "queued") {
+      return {
+        ...buildPublicDeliveryReceipt({
+          delivery_state: "queued",
+          typed: false,
+          submit_attempted: false,
+          submit_verified: null,
+          retry_count: 0,
+          observation: readiness.observation,
+          WARNING:
+            "BOOT PROMPT QUEUED — the agent turn remained active through the " +
+            `${opts.timeout_ms ?? BOOT_PROMPT_TIMEOUT_MS}ms deadline with an ` +
+            "empty composer and no prompt echo. No text or Return was sent; " +
+            "the live pane remains available for inspection or retry.",
+        }),
+        bytes: 0,
+        prompt_text: hasInlinePrompt(rawPrompt) ? rawPrompt : null,
+        prompt_warning: promptWarning,
+      };
+    }
     let sentChunks = 0;
 
     try {
@@ -12351,6 +12482,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         ...(delivery.delivery === "submitted" ||
         delivery.delivery === "queued" ||
         delivery.delivery === "queued_followup" ||
+        delivery.delivery === "rescued" ||
         delivery.delivery === "pending_verify"
           ? { delivery: delivery.delivery }
           : {}),
@@ -12361,7 +12493,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       recipient: AgentRecord,
       message: ReturnType<typeof dispatch>,
     ): Promise<{
-      delivery: "submitted" | "queued" | "queued_followup" | "pending_verify";
+      delivery:
+        | "submitted"
+        | "queued"
+        | "queued_followup"
+        | "rescued"
+        | "pending_verify";
       delivery_id?: string;
     }> => {
       const pointer = formatInboxPing(
@@ -12407,6 +12544,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         delivered.delivery !== "submitted" &&
         delivered.delivery !== "queued" &&
         delivered.delivery !== "queued_followup" &&
+        delivered.delivery !== "rescued" &&
         delivered.delivery !== "pending_verify"
       ) {
         throw new Error(
@@ -12435,6 +12573,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           source_event: "report_to_parent",
           retry_count: delivered.retry_count,
         });
+      } else if (delivered.delivery === "rescued") {
+        engine.resolveDelivery({
+          delivery_id: deliveryId,
+          agent_id: recipient.agent_id,
+          text: pointer,
+          press_enter: true,
+          source_event: "report_to_parent",
+          delivery_state: "rescued",
+          terminal: true,
+          retry_count: delivered.retry_count,
+          submit_verified: false,
+          error: "Prompt appeared only after an external interrupt",
+        });
+        throw new Error(
+          "parent blocker wake was rescued by an external interrupt, not verified",
+        );
       } else {
         engine.resolveDelivery({
           delivery_id: deliveryId,
@@ -13557,7 +13711,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     bootPromptDelivery.prompt_text,
                     bootPromptPath,
                   ),
-                  boot_prompt_pending: false,
+                  boot_prompt_pending:
+                    bootPromptDelivery.delivery_state === "queued",
                   prompt_delivered: bootPromptDelivery.submit_verified === true,
                   submit_verified: bootPromptDelivery.submit_verified,
                 });
@@ -13964,7 +14119,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...bootPromptRegistryFields(
                 bootPromptDelivery.prompt_text ?? args.prompt ?? "",
               ),
-              boot_prompt_pending: false,
+              boot_prompt_pending:
+                bootPromptDelivery.delivery_state === "queued",
+              prompt_delivered: bootPromptDelivery.submit_verified === true,
+              submit_verified: bootPromptDelivery.submit_verified,
             });
             registry.set(result.agent_id, updated);
           }
@@ -14374,7 +14532,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 ...bootPromptRegistryFields(
                   bootPromptDelivery.prompt_text ?? agent.prompt ?? "",
                 ),
-                boot_prompt_pending: false,
+                boot_prompt_pending:
+                  bootPromptDelivery.delivery_state === "queued",
                 prompt_delivered:
                   hasPrompt && bootPromptDelivery.submit_verified === true,
                 submit_verified: hasPrompt
@@ -14384,7 +14543,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               registry.set(result.agent_id, updated);
 
               const current = engine.getAgentState(result.agent_id);
-              if (current?.state === "booting" && hasPrompt) {
+              if (
+                current?.state === "booting" &&
+                hasPrompt &&
+                bootPromptDelivery.submit_verified === true
+              ) {
                 const ready = stateMgr.transition(result.agent_id, "ready");
                 registry.set(result.agent_id, ready);
                 result.state = "ready";
@@ -16161,6 +16324,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                           source_event: "send_to",
                           retry_count: delivery.retry_count,
                         })
+                      : delivery.delivery === "rescued"
+                        ? engine.resolveDelivery({
+                            delivery_id: deliveryId,
+                            agent_id: agent.agent_id,
+                            text: args.text,
+                            press_enter: args.press_enter,
+                            source_event: "send_to",
+                            delivery_state: "rescued",
+                            terminal: true,
+                            retry_count: delivery.retry_count,
+                            submit_verified: false,
+                            error:
+                              "Prompt appeared only after an external interrupt",
+                          })
                       : delivery.delivery === "submitted"
                         ? engine.resolveDelivery({
                             delivery_id: deliveryId,
@@ -16480,6 +16657,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     source_event: "send_to",
                     retry_count: delivery.retry_count,
                   })
+                : delivery.delivery === "rescued"
+                  ? engine.resolveDelivery({
+                      delivery_id: deliveryId,
+                      agent_id: agentId,
+                      text: args.text,
+                      press_enter: args.press_enter,
+                      source_event: "send_to",
+                      delivery_state: "rescued",
+                      terminal: true,
+                      retry_count: delivery.retry_count,
+                      submit_verified: false,
+                      error: "Prompt appeared only after an external interrupt",
+                    })
                 : delivery.delivery === "submitted"
                   ? engine.resolveDelivery({
                       delivery_id: deliveryId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5666,6 +5666,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         retryEligiblePendingInput &&
         Date.now() - retriedAt >= SEND_INPUT_POST_RETRY_VERIFY_GRACE_MS
       ) {
+        if (sawNewInterrupt) {
+          return {
+            submit_verified: false,
+            submit_evidence: null,
+            submit_verification_reason: null,
+            retry_count: retryCount,
+            delivery: "rescued",
+          };
+        }
         return {
           submit_verified: false,
           submit_evidence: null,
@@ -5683,8 +5692,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
+    // A latched interrupt is terminal evidence that this verifier cannot
+    // attribute the task turn. Never hand it to the marker-unaware background
+    // verifier as pending_verify, where an empty composer could false-green it.
+    if (sawNewInterrupt) {
+      return {
+        submit_verified: false,
+        submit_evidence: null,
+        submit_verification_reason: null,
+        retry_count: retryCount,
+        delivery: "rescued",
+      };
+    }
     if (
-      !sawNewInterrupt &&
       sawClearedComposerEvidence &&
       sawAllowedClearedComposerEvidence
     ) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5516,14 +5516,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         bootFrameAdvanced &&
         !hasPendingSubmitEvidence &&
         screenIncludesSubmittedText(snapshot.text);
+      const interruptedHasTranscriptEcho =
+        bootHasTranscriptEcho ||
+        (opts.require_attributable_submit_evidence !== true &&
+          !hasPendingSubmitEvidence &&
+          screenIncludesSubmittedText(snapshot.text));
       if (
         sawNewInterrupt &&
         !hasPendingSubmitEvidence &&
-        (bootHasTranscriptEcho || bootHasTokenOrCostDelta)
+        (interruptedHasTranscriptEcho || bootHasTokenOrCostDelta)
       ) {
         return {
           submit_verified: false,
-          submit_evidence: bootHasTranscriptEcho
+          submit_evidence: interruptedHasTranscriptEcho
             ? "transcript_echo"
             : "token_delta",
           submit_verification_reason: null,
@@ -5532,6 +5537,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         };
       }
       if (
+        !sawNewInterrupt &&
         !hasPendingSubmitEvidence &&
         !bootConsumptionRefuted &&
         ((opts.require_attributable_submit_evidence !== true &&
@@ -5566,7 +5572,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const allowClearedComposerSubmitEvidence =
           opts.source_event !== "spawn_agent" ||
           !screenIncludesSubmittedText(snapshot.text);
-        if (allowClearedComposerSubmitEvidence) {
+        if (allowClearedComposerSubmitEvidence && !sawNewInterrupt) {
           sawAllowedClearedComposerEvidence = true;
           return {
             submit_verified: true,
@@ -5677,7 +5683,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
       await delay(SEND_INPUT_SUBMIT_VERIFY_POLL_MS);
     }
-    if (sawClearedComposerEvidence && sawAllowedClearedComposerEvidence) {
+    if (
+      !sawNewInterrupt &&
+      sawClearedComposerEvidence &&
+      sawAllowedClearedComposerEvidence
+    ) {
       return {
         submit_verified: true,
         submit_evidence: "cleared_composer",

--- a/src/server.ts
+++ b/src/server.ts
@@ -945,6 +945,7 @@ type BroadcastReceipt = {
   agent_id: string;
   seat: string;
   delivered: boolean;
+  delivery_state?: PublicDeliveryState;
   submit_verified: boolean | null;
   submit_verification_reason?: SubmitVerificationFailureReason;
   retry_safe?: false;
@@ -2319,12 +2320,23 @@ function hasParsedAgentIdentity(
   return Boolean(parsed && parsed.agent_type !== "unknown");
 }
 
+function screenHasWorkingCodexChrome(screenText: string): boolean {
+  return (
+    /(?:^|\n)\s*(?:•\s*)?(?:Working|Waiting|Thinking)\b[^\n]*\besc to interrupt\b/im.test(
+      screenText,
+    ) &&
+    /(?:^|\n)[ \t]*[›»][ \t]*$/m.test(screenText) &&
+    /(?:^|\n)\s*tab to queue message\b/im.test(screenText)
+  );
+}
+
 function screenHasAnyAgentIdentity(
   screenText: string,
   parsed: ParsedScreenResult = parseScreen(screenText),
 ): boolean {
   return (
     hasParsedAgentIdentity(parsed) ||
+    screenHasWorkingCodexChrome(screenText) ||
     /Claude Code|CLAUDE_COUNTER|bypass permissions on|What can I help you with\?|(?:^|\n)\s*(?:codex>|cursor>|kiro>)(?:\s|$)/im.test(
       screenText,
     )
@@ -2382,7 +2394,8 @@ function inferComposerCli(
   }
   if (
     /\bOpenAI\s+Codex\b/i.test(screenText) ||
-    /(?:^|\n)\s*(?:Model:\s*)?gpt-[0-9]/i.test(screenText)
+    /(?:^|\n)\s*(?:Model:\s*)?gpt-[0-9]/i.test(screenText) ||
+    screenHasWorkingCodexChrome(screenText)
   ) {
     return "codex";
   }
@@ -5372,9 +5385,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let lastBootConsumptionRefuted = false;
     const interruptMarkerCount = (screenText: string | null | undefined) =>
       screenText?.match(/Conversation interrupted/gi)?.length ?? 0;
-    const preReturnInterruptMarkers = Math.max(
-      interruptMarkerCount(opts.pre_type_screen),
-      interruptMarkerCount(opts.pre_return_screen),
+    // The pre-Return frame is the current marker epoch. A stale marker may be
+    // visible before typing and then scroll away while the composer fills; a
+    // later marker is a new interrupt even when its ordinal matches the stale
+    // pre-type occurrence.
+    const preReturnInterruptMarkers = interruptMarkerCount(
+      opts.pre_return_screen,
     );
     const screenIncludesSubmittedText = (screenText: string): boolean =>
       screenContainsCompleteSubmittedText(screenText, opts.text);
@@ -5896,6 +5912,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         ? { draftGuardText }
         : {}),
     });
+    // Boot delivery is always attributable. Established relay paths retain
+    // their lighter verification unless an existing interrupt marker makes a
+    // later marker ambiguous; in that collision case, observe the payload
+    // before Return so `rescued` is both reachable and correctly attributed.
+    const requireObservedPayloadBeforeEnter =
+      opts.require_observed_payload_before_enter === true &&
+      (opts.source_event === "boot_prompt" ||
+        /Conversation interrupted/i.test(deliverySafetySnapshot?.text ?? ""));
     const deliveryBatches = buildInputDeliveryBatches(opts.chunks);
     const shouldPaste = shouldPasteInputDelivery(
       opts.chunks,
@@ -5943,7 +5967,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (opts.press_enter) {
       let cursorResponseBaseline: readonly string[] | null = null;
       const preReturnBootEvidence =
-        opts.require_observed_payload_before_enter === true &&
+        requireObservedPayloadBeforeEnter &&
         (opts.verify_submit ?? false)
           ? await waitForCompletePayloadInComposer({
               surface: opts.surface,
@@ -5959,7 +5983,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             })
           : null;
       if (
-        opts.require_observed_payload_before_enter === true &&
+        requireObservedPayloadBeforeEnter &&
         (opts.verify_submit ?? false) &&
         preReturnBootEvidence === null
       ) {
@@ -6020,7 +6044,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           pre_return_screen: preReturnBootEvidence?.screenText,
           pre_return_metrics: preReturnBootEvidence?.metrics,
           require_attributable_submit_evidence:
-            opts.require_observed_payload_before_enter === true,
+            requireObservedPayloadBeforeEnter,
           require_working_status: opts.source_event === "boot_prompt",
           beforeMutation: opts.beforeMutation,
         });
@@ -6144,14 +6168,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateShellRelaunches = 0;
     let codexUpdateMenuAccepted = false;
     let codexUpdateMenuAcceptedAt: number | null = null;
-    let queuedObservation:
-      | {
-          metrics: RawSubmitEvidenceMetrics;
-          route: { surface: string; workspace?: string };
-          cli: CliType;
-          observation: NonNullable<PublicDeliveryReceipt["observation"]>;
-        }
-      | null = null;
+    type QueuedBootObservation = {
+      metrics: RawSubmitEvidenceMetrics;
+      route: { surface: string; workspace?: string };
+      cli: CliType;
+      observation: NonNullable<PublicDeliveryReceipt["observation"]>;
+    };
+    let queuedObservation: QueuedBootObservation | null = null;
     const updateMaxMs = bootPromptUpdateMaxMs();
     const postUpdateReadyBudgetMs = () =>
       Math.max(opts.timeout_ms, BOOT_PROMPT_POST_UPDATE_READY_GRACE_MS);
@@ -6298,6 +6321,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           continue;
         }
 
+        let frameQueuedObservation: QueuedBootObservation | null = null;
         for (const candidate of candidates) {
           const match = matchReadyPattern(candidate, screen.text);
           const identified =
@@ -6319,7 +6343,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             composer.trim() === "" &&
             !promptEchoed
           ) {
-            queuedObservation = {
+            frameQueuedObservation = {
               metrics: parseSubmitEvidenceMetrics(screen.text, parsed),
               route: target,
               cli: candidate,
@@ -6330,8 +6354,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 last_10_lines: tailLines(screen.text, 10),
               },
             };
-          } else if (identified || bannerIndependentIdentity) {
-            queuedObservation = null;
           }
           const ready = identified && !codexTurnStillRunning;
           const count = ready
@@ -6349,6 +6371,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             };
           }
         }
+        queuedObservation = frameQueuedObservation;
       } catch (error) {
         if (
           error instanceof BootPromptTimeoutError ||
@@ -6360,6 +6383,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         if (isSurfaceGoneReadFailure(error, target.surface)) {
           throw new SurfaceGoneError(target.surface, error);
         }
+        queuedObservation = null;
         lastText = error instanceof Error ? error.message : String(error);
       }
 
@@ -12446,6 +12470,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               args.source_event === "send_to" ||
               args.source_event === "dispatch_nudge" ||
               args.source_event === "report_to_parent",
+            require_observed_payload_before_enter:
+              args.source_event === "send_to" ||
+              args.source_event === "dispatch_nudge" ||
+              args.source_event === "report_to_parent",
             submit_verify_timeout_ms: args.allow_busy
               ? BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS
               : undefined,
@@ -13719,7 +13747,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 registry.set(result.agent_id, updated);
               } else {
                 const updated = stateMgr.updateRecord(result.agent_id, {
-                  boot_prompt_pending: false,
+                  boot_prompt_pending:
+                    bootPromptDelivery.delivery_state === "queued",
                   prompt_delivered: false,
                   submit_verified: null,
                 });
@@ -15822,11 +15851,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 press_enter: args.press_enter,
                 source_event: "send_to",
               });
+              const nonterminalDelivery =
+                delivery.delivery_state === "queued" ||
+                delivery.delivery_state === "queued_followup" ||
+                delivery.delivery_state === "pending_verify" ||
+                delivery.delivery_state === "rescued";
               receipts.push({
                 agent_id: agent.agent_id,
                 seat: agentSeatLabel(agent),
-                delivered: true,
+                delivered: !nonterminalDelivery,
+                delivery_state: delivery.delivery_state,
                 submit_verified: delivery.submit_verified,
+                ...(delivery.delivery_state === "rescued"
+                  ? {
+                      error:
+                        "Prompt appeared only after an external interrupt",
+                    }
+                  : {}),
               });
             } catch (e) {
               receipts.push({

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -8936,6 +8936,46 @@ Session ID: ${sessionId}`,
       });
     });
 
+    it("does not manufacture boot delivery from an active Codex front-matter turn", async () => {
+      stateMgr.writeState(
+        makeRecord({
+          agent_id: "agent-undelivered-front-matter",
+          state: "booting",
+          surface_id: "surface:undelivered-front-matter",
+          cli: "codex",
+          boot_prompt_pending: true,
+          task_summary: "Read and follow docs.local/front-matter.md",
+          prompt_delivered: false,
+          submit_verified: null,
+          updated_at: new Date().toISOString(),
+        }),
+      );
+      liveSurfaces = [makeSurface("surface:undelivered-front-matter")];
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: "surface:undelivered-front-matter",
+        text: [
+          ">_ OpenAI Codex",
+          "Working (1s • esc to interrupt)",
+          "› Ask Codex to do anything",
+          "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+        ].join("\n"),
+        lines: 20,
+        scrollback_used: false,
+      });
+      await engine.getRegistry().reconstitute();
+
+      await engine.runSweep();
+
+      expect(
+        engine.getAgentState("agent-undelivered-front-matter"),
+      ).toMatchObject({
+        state: "booting",
+        boot_prompt_pending: true,
+        prompt_delivered: false,
+        submit_verified: false,
+      });
+    });
+
     it("errors a stale managed pane whose boot prompt was never delivered", async () => {
       stateMgr.writeState(
         makeRecord({

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -735,10 +735,18 @@ describe("boot-submit readiness and attributable evidence", () => {
     payloadAppears: boolean;
     submitAfterReturn?: number | null;
     staleReadyAfterReturn?: boolean;
+    frontMatterReads?: number;
+    interruptAfterReturn?: boolean;
     cli?: "codex" | "claude";
-  }): { exec: ExecFn; returnPresses: () => number } {
+  }): {
+    exec: ExecFn;
+    returnPresses: () => number;
+    promptSentAfterRead: () => number | null;
+  } {
     let promptSent = false;
+    let promptSentAfterRead: number | null = null;
     let returnPresses = 0;
+    let screenReads = 0;
     const exec: ExecFn = vi.fn().mockImplementation(
       async (_cmd, args: string[]) => {
         if (args.includes("new-split")) {
@@ -794,6 +802,7 @@ describe("boot-submit readiness and attributable evidence", () => {
         }
         if (args.includes("send") && !args.includes("send-key")) {
           promptSent = true;
+          promptSentAfterRead = screenReads;
           return { stdout: "{}", stderr: "" };
         }
         if (args.includes("send-key") && args.includes("return")) {
@@ -801,11 +810,20 @@ describe("boot-submit readiness and attributable evidence", () => {
           return { stdout: "{}", stderr: "" };
         }
         if (args.includes("read-screen")) {
+          screenReads += 1;
           const cli = opts.cli ?? "codex";
+          const frontMatterActive =
+            cli === "codex" && screenReads <= (opts.frontMatterReads ?? 0);
           const readyScreen =
             cli === "claude"
               ? ["Claude Code", "What can I help you with?", "❯"].join("\n")
-              : codexReady;
+              : frontMatterActive
+                ? [
+                    "Working (1s • esc to interrupt)",
+                    "› Ask Codex to do anything",
+                    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+                  ].join("\n")
+                : codexReady;
           const submitted =
             opts.submitAfterReturn !== null &&
             opts.submitAfterReturn !== undefined &&
@@ -824,6 +842,9 @@ describe("boot-submit readiness and attributable evidence", () => {
                   ].join("\n")
                 : [
                     ">_ OpenAI Codex",
+                    ...(opts.interruptAfterReturn
+                      ? ["Conversation interrupted"]
+                      : []),
                     "• Read and follow the brief",
                     "Working (1s • esc to interrupt)",
                     "gpt-5.6-sol high · ~/Gits/cmuxlayer",
@@ -857,7 +878,11 @@ describe("boot-submit readiness and attributable evidence", () => {
         return { stdout: "{}", stderr: "" };
       },
     );
-    return { exec, returnPresses: () => returnPresses };
+    return {
+      exec,
+      returnPresses: () => returnPresses,
+      promptSentAfterRead: () => promptSentAfterRead,
+    };
   }
 
   it("correlates the complete multi-paragraph Codex composer including blank lines and the » glyph", async () => {
@@ -917,6 +942,97 @@ describe("boot-submit readiness and attributable evidence", () => {
       __submitEvidenceTestHooks.extractComposerInputRegion(screen),
     ).toBe("");
   });
+
+  it("waits for the front-matter turn to become idle before typing the boot prompt", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      frontMatterReads: 1,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 5_000,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(harness.promptSentAfterRead()).toBeGreaterThan(1);
+    expect(parsed.boot_prompt_receipt.submit_verified).toBe(true);
+  }, 20_000);
+
+  it("returns banner-independent queued state by deadline without typing or pressing Return", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      frontMatterReads: 100,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 250,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "queued",
+      terminal: false,
+      delivered: false,
+      typed: false,
+      submit_attempted: false,
+      submit_verified: null,
+      observation: {
+        status: "working",
+        composer_empty: true,
+        prompt_echoed: false,
+      },
+    });
+    expect(harness.promptSentAfterRead()).toBeNull();
+    expect(harness.returnPresses()).toBe(0);
+  }, 20_000);
+
+  it("classifies transcript echo after a new interrupt as rescued, never verified", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      interruptAfterReturn: true,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 1_000,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "rescued",
+      terminal: true,
+      delivered: false,
+      submit_verified: false,
+      submit_evidence: "transcript_echo",
+    });
+  }, 20_000);
 
   it("does not press Return or certify status plus token_count:null before observing the payload", async () => {
     const { createServer } = await loadServerModule();

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -736,6 +736,8 @@ describe("boot-submit readiness and attributable evidence", () => {
     submitAfterReturn?: number | null;
     staleReadyAfterReturn?: boolean;
     frontMatterReads?: number;
+    blankAfterFrontMatter?: boolean;
+    staleInterruptBeforeType?: boolean;
     interruptAfterReturn?: boolean;
     cli?: "codex" | "claude";
   }): {
@@ -814,16 +816,28 @@ describe("boot-submit readiness and attributable evidence", () => {
           const cli = opts.cli ?? "codex";
           const frontMatterActive =
             cli === "codex" && screenReads <= (opts.frontMatterReads ?? 0);
+          const liveWorkingCodexScreen = [
+            " ",
+            "• Ran 6 commands · ctrl + t to view transcript",
+            " ",
+            "Working (19s • esc to interrupt)",
+            " ",
+            " ",
+            "›",
+            " ",
+            " ",
+            "  tab to queue message                                                    88% context left",
+          ].join("\n");
           const readyScreen =
             cli === "claude"
               ? ["Claude Code", "What can I help you with?", "❯"].join("\n")
               : frontMatterActive
-                ? [
-                    "Working (1s • esc to interrupt)",
-                    "› Ask Codex to do anything",
-                    "gpt-5.6-sol high · ~/Gits/cmuxlayer",
-                  ].join("\n")
-                : codexReady;
+                ? liveWorkingCodexScreen
+                : opts.blankAfterFrontMatter && !promptSent
+                  ? ""
+                  : opts.staleInterruptBeforeType && !promptSent
+                    ? ["Conversation interrupted", codexReady].join("\n")
+                    : codexReady;
           const submitted =
             opts.submitAfterReturn !== null &&
             opts.submitAfterReturn !== undefined &&
@@ -1005,11 +1019,68 @@ describe("boot-submit readiness and attributable evidence", () => {
     expect(harness.returnPresses()).toBe(0);
   }, 20_000);
 
+  it("drops queued evidence when the live working frame is followed by a blank frame", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      frontMatterReads: 1,
+      blankAfterFrontMatter: true,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 600,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.boot_prompt_receipt).toBeUndefined();
+    expect(harness.promptSentAfterRead()).toBeNull();
+    expect(harness.returnPresses()).toBe(0);
+  }, 20_000);
+
   it("classifies transcript echo after a new interrupt as rescued, never verified", async () => {
     const { createServer } = await loadServerModule();
     const harness = makeCodexBootExec({
       payloadAppears: true,
       submitAfterReturn: 1,
+      interruptAfterReturn: true,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 1_000,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "rescued",
+      terminal: true,
+      delivered: false,
+      submit_verified: false,
+      submit_evidence: "transcript_echo",
+    });
+  }, 20_000);
+
+  it("classifies a new interrupt as rescued when an older marker scrolled off before Return", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      staleInterruptBeforeType: true,
       interruptAfterReturn: true,
     });
     const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -854,8 +854,11 @@ describe("boot-submit readiness and attributable evidence", () => {
             : opts.interruptBeforeEchoAfterReturn && postReturnReads === 1
               ? [
                   ">_ OpenAI Codex",
-                  "Conversation interrupted",
-                  "Working (1s • esc to interrupt)",
+                  "■ Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/",
+                  "  feedback` to report the issue.",
+                  "",
+                  "› Ask Codex to do anything",
+                  "",
                   "gpt-5.6-sol high · ~/Gits/cmuxlayer",
                 ].join("\n")
             : submitted

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -739,6 +739,7 @@ describe("boot-submit readiness and attributable evidence", () => {
     blankAfterFrontMatter?: boolean;
     staleInterruptBeforeType?: boolean;
     interruptAfterReturn?: boolean;
+    interruptBeforeEchoAfterReturn?: boolean;
     cli?: "codex" | "claude";
   }): {
     exec: ExecFn;
@@ -749,6 +750,7 @@ describe("boot-submit readiness and attributable evidence", () => {
     let promptSentAfterRead: number | null = null;
     let returnPresses = 0;
     let screenReads = 0;
+    let postReturnReads = 0;
     const exec: ExecFn = vi.fn().mockImplementation(
       async (_cmd, args: string[]) => {
         if (args.includes("new-split")) {
@@ -813,6 +815,9 @@ describe("boot-submit readiness and attributable evidence", () => {
         }
         if (args.includes("read-screen")) {
           screenReads += 1;
+          if (returnPresses > 0) {
+            postReturnReads += 1;
+          }
           const cli = opts.cli ?? "codex";
           const frontMatterActive =
             cli === "codex" && screenReads <= (opts.frontMatterReads ?? 0);
@@ -846,6 +851,13 @@ describe("boot-submit readiness and attributable evidence", () => {
             ? readyScreen
             : opts.staleReadyAfterReturn && returnPresses > 0
               ? readyScreen
+            : opts.interruptBeforeEchoAfterReturn && postReturnReads === 1
+              ? [
+                  ">_ OpenAI Codex",
+                  "Conversation interrupted",
+                  "Working (1s • esc to interrupt)",
+                  "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+                ].join("\n")
             : submitted
               ? cli === "claude"
                 ? [
@@ -1082,6 +1094,35 @@ describe("boot-submit readiness and attributable evidence", () => {
       submitAfterReturn: 1,
       staleInterruptBeforeType: true,
       interruptAfterReturn: true,
+    });
+    const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
+
+    const result = await (server as any)._registeredTools.new_split.handler(
+      {
+        direction: "right",
+        workspace: "workspace:1",
+        boot_prompt_path: writeBootPrompt(),
+        boot_prompt_timeout_ms: 1_000,
+      },
+      {} as any,
+    );
+    const parsed = parseToolResult(result);
+
+    expect(parsed.boot_prompt_receipt).toMatchObject({
+      delivery_state: "rescued",
+      terminal: true,
+      delivered: false,
+      submit_verified: false,
+      submit_evidence: "transcript_echo",
+    });
+  }, 20_000);
+
+  it("latches a new interrupt that appears before the transcript echo frame", async () => {
+    const { createServer } = await loadServerModule();
+    const harness = makeCodexBootExec({
+      payloadAppears: true,
+      submitAfterReturn: 1,
+      interruptBeforeEchoAfterReturn: true,
     });
     const server = createServer({ exec: harness.exec, skipAgentLifecycle: true });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1816,9 +1816,11 @@ function makeBroadcastClient(
     failSurface?: string;
     callerSurface?: string;
     malformedEnumeration?: boolean;
+    rescuedSurface?: string;
   } = {},
 ): BroadcastMockClient {
   const submittedSurfaces = new Set<string>();
+  const pendingTextBySurface = new Map<string, string>();
   const sendCalls: Array<{
     surface: string;
     text: string;
@@ -1841,6 +1843,15 @@ function makeBroadcastClient(
       (candidate) => candidate.surface_id === surface,
     );
     if (submittedSurfaces.has(surface)) {
+      if (opts.rescuedSurface === surface) {
+        return [
+          ">_ OpenAI Codex",
+          "■ Conversation interrupted - tell the model what to do differently",
+          `• ${pendingTextBySurface.get(surface) ?? ""}`,
+          "Working (1s • esc to interrupt)",
+          "gpt-5.6-sol medium · ~/Gits/cmuxlayer",
+        ].join("\n");
+      }
       return record?.cli === "claude"
         ? "Claude Code\nWorking\n"
         : "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\nWorking (1s - esc to interrupt)";
@@ -1850,6 +1861,21 @@ function makeBroadcastClient(
     }
     if (record?.cli === "cursor") {
       return "cursor>\n";
+    }
+    if (opts.rescuedSurface === surface) {
+      const pendingText = pendingTextBySurface.get(surface);
+      return pendingText
+        ? [
+            ">_ OpenAI Codex",
+            `» ${pendingText}`,
+            "gpt-5.6-sol medium · ~/Gits/cmuxlayer",
+          ].join("\n")
+        : [
+            ">_ OpenAI Codex",
+            "Conversation interrupted",
+            "›",
+            "gpt-5.6-sol medium · ~/Gits/cmuxlayer",
+          ].join("\n");
     }
     return "gpt-5.5 xhigh - 99% left - ~/Gits/cmuxlayer\ncodex> ";
   };
@@ -1912,6 +1938,7 @@ function makeBroadcastClient(
     })),
     send: vi.fn().mockImplementation(async (surface, text, sendOpts) => {
       sendCalls.push({ surface, text, workspace: sendOpts?.workspace });
+      pendingTextBySurface.set(surface, text);
       if (opts.failSurface === surface) {
         throw new Error(`send failed for ${surface}`);
       }
@@ -1958,6 +1985,7 @@ async function createBroadcastServer(
     failSurface?: string;
     callerSurface?: string;
     malformedEnumeration?: boolean;
+    rescuedSurface?: string;
   } = {},
 ) {
   const ownedRecords = records.map((record) => ({
@@ -6888,12 +6916,13 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
-  it("spawn_agent reports readiness timeout without poisoning agent state", async () => {
+  it("spawn_agent timeout keeps the live pane bound through close_surface and explicit resume", async () => {
     const promptPath = join(TEST_DIR, "mandate.md");
     writeFileSync(promptPath, "file prompt body", "utf8");
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     let launchSent = false;
     let readCountAfterLaunch = 0;
+    let surfaceClosed = false;
     mockExec = vi.fn().mockImplementation(async (_cmd, args) => {
       if (args.includes("list-windows")) {
         return {
@@ -6904,7 +6933,19 @@ describe("agent lifecycle tool handlers", () => {
         };
       }
       if (args.includes("send")) {
+        if (surfaceClosed) {
+          surfaceClosed = false;
+          readCountAfterLaunch = 0;
+        }
         launchSent = true;
+      }
+      if (args.includes("close-surface")) {
+        surfaceClosed = true;
+      }
+      if (args.includes("new-split")) {
+        surfaceClosed = false;
+        launchSent = false;
+        readCountAfterLaunch = 0;
       }
       if (args.includes("list-workspaces")) {
         return {
@@ -6928,14 +6969,27 @@ describe("agent lifecycle tool handlers", () => {
             workspace_ref: "workspace:1",
             window_ref: "window:1",
             panes: [
+              ...(surfaceClosed
+                ? []
+                : [
+                    {
+                      ref: "pane:1",
+                      index: 0,
+                      focused: true,
+                      surface_count: 1,
+                      surface_refs: ["surface:new"],
+                      surface_ids: [stableUuid],
+                      selected_surface_ref: "surface:new",
+                    },
+                  ]),
               {
-                ref: "pane:1",
-                index: 0,
-                focused: true,
+                ref: "pane:2",
+                index: 1,
+                focused: surfaceClosed,
                 surface_count: 1,
-                surface_refs: ["surface:new"],
-                surface_ids: [stableUuid],
-                selected_surface_ref: "surface:new",
+                surface_refs: ["surface:witness"],
+                surface_ids: ["aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"],
+                selected_surface_ref: "surface:witness",
               },
             ],
           }),
@@ -6943,21 +6997,36 @@ describe("agent lifecycle tool handlers", () => {
         };
       }
       if (args.includes("list-pane-surfaces")) {
+        const pane = args[args.indexOf("--pane") + 1];
         return {
           stdout: JSON.stringify({
             workspace_ref: "workspace:1",
             window_ref: "window:1",
-            pane_ref: "pane:1",
-            surfaces: [
-              {
-                id: stableUuid,
-                ref: "surface:new",
-                title: "agent-pane",
-                type: "terminal",
-                index: 0,
-                selected: true,
-              },
-            ],
+            pane_ref: pane,
+            surfaces:
+              pane === "pane:2"
+                ? [
+                    {
+                      id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                      ref: "surface:witness",
+                      title: "witness",
+                      type: "terminal",
+                      index: 0,
+                      selected: true,
+                    },
+                  ]
+                : surfaceClosed
+                  ? []
+                  : [
+                      {
+                        id: stableUuid,
+                        ref: "surface:new",
+                        title: "agent-pane",
+                        type: "terminal",
+                        index: 0,
+                        selected: true,
+                      },
+                    ],
           }),
           stderr: "",
         };
@@ -7005,6 +7074,7 @@ describe("agent lifecycle tool handlers", () => {
     });
     const spawn = (server as any)._registeredTools["spawn_agent"];
     const getState = (server as any)._registeredTools["get_agent_state"];
+    const close = (server as any)._registeredTools["close_surface"];
 
     const spawnResult = await spawn.handler(
       {
@@ -7050,6 +7120,30 @@ describe("agent lifecycle tool handlers", () => {
         "file prompt body",
       ]),
     );
+
+    const closeResult = await close.handler(
+      { scope: "agent", agent_id: parsed.agent_id, force: true },
+      {} as any,
+    );
+    const closed = parseToolResult(closeResult);
+    expect(surfaceClosed).toBe(true);
+    expect(closed).toMatchObject({
+      scope: "agent",
+    });
+    expect(closed.ok, JSON.stringify(closed)).toBe(true);
+    expect(String(closed.error ?? "")).not.toMatch(/Agent not found/i);
+
+    const resumeResult = await spawn.handler(
+      { resume_agent_id: parsed.agent_id, force: true },
+      {} as any,
+    );
+    const resumed = parseToolResult(resumeResult);
+    expect(resumed, JSON.stringify(resumed)).toMatchObject({
+      ok: true,
+      resumed: true,
+      agent_id: parsed.agent_id,
+      surface_id: "surface:new",
+    });
   });
 
   it("spawn_agent keeps a live registered pane when front-matter delivery reaches its queued deadline", async () => {
@@ -7067,9 +7161,16 @@ describe("agent lifecycle tool handlers", () => {
           stdout: JSON.stringify({
             surface: "surface:new",
             text: [
-              "Working (1s • esc to interrupt)",
-              "› Ask Codex to do anything",
-              "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+              " ",
+              "• Ran 6 commands · ctrl + t to view transcript",
+              " ",
+              "Working (19s • esc to interrupt)",
+              " ",
+              " ",
+              "›",
+              " ",
+              " ",
+              "  tab to queue message                                                    88% context left",
             ].join("\n"),
             lines: 20,
             scrollback_used: false,
@@ -7123,6 +7224,77 @@ describe("agent lifecycle tool handlers", () => {
       "cmux",
       expect.arrayContaining(["close-surface", "surface:new"]),
     );
+  }, 20_000);
+
+  it("spawn_agent keeps injected-only queued boot work pending", async () => {
+    const baseExec = makeLifecycleExec();
+    let launched = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && /Codex\b/.test(text)) {
+        launched = true;
+      }
+      if (launched && args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: [
+              " ",
+              "• Ran 6 commands · ctrl + t to view transcript",
+              " ",
+              "Working (19s • esc to interrupt)",
+              " ",
+              " ",
+              "›",
+              " ",
+              " ",
+              "  tab to queue message                                                    88% context left",
+            ].join("\n"),
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const result = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          boot_prompt_timeout_ms: 250,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(result.boot_prompt_receipt).toMatchObject({
+      delivery_state: "queued",
+      delivered: false,
+      typed: false,
+      submit_verified: null,
+      prompt_text: null,
+    });
+    const state = parseToolResult(
+      await getState.handler({ agent_id: result.agent_id }, {} as any),
+    );
+    expect(state).toMatchObject({
+      state: "booting",
+      surface_id: "surface:new",
+      boot_prompt_pending: true,
+      prompt_delivered: false,
+      submit_verified: null,
+    });
   }, 20_000);
 
   it("spawn_agent defaults managed agents to lifecycle escalation and persists explicit opt-outs", async () => {
@@ -8065,6 +8237,43 @@ describe("agent lifecycle tool handlers", () => {
       ]),
     );
   });
+
+  it("broadcast does not count a rescued send as delivered", async () => {
+    const record = makeServerAgentRecord({
+      agent_id: "rescued-lead",
+      surface_id: "surface:rescued",
+      state: "ready",
+      role: "orchestrator",
+      cli: "codex",
+      task_summary: "rescued lead",
+    });
+    const { server } = await createBroadcastServer([record], {
+      rescuedSurface: record.surface_id,
+    });
+    const broadcast = (server as any)._registeredTools["broadcast"];
+
+    const result = parseToolResult(
+      await broadcast.handler(
+        { text: "Reply with the single word OK", role: "leads" },
+        {} as any,
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      target_count: 1,
+      delivered_count: 0,
+      failed_count: 1,
+      receipts: [
+        expect.objectContaining({
+          agent_id: record.agent_id,
+          delivered: false,
+          delivery_state: "rescued",
+          submit_verified: false,
+        }),
+      ],
+    });
+  }, 20_000);
 
   it("RC6: broadcast receipt seat labels never contain the full boot prompt", async () => {
     const bootPrompt = "Implement the registry liveness brief. ".repeat(40);
@@ -12973,6 +13182,102 @@ codex>
     expect(deliveredText).not.toContain("\x1b");
     expect(deliveredText).not.toContain("\x07");
   });
+
+  it("send_to reports rescued when a new interrupt follows a scrolled-off stale marker", async () => {
+    const message = "Reply with the single word OK";
+    const baseExec = makeLifecycleExec();
+    let relayActive = false;
+    let relayTyped = false;
+    let relayReturned = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (
+        relayActive &&
+        (args.includes("send") || args.includes("set-buffer")) &&
+        text.includes(message)
+      ) {
+        relayTyped = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (
+        relayActive &&
+        args.includes("send-key") &&
+        args.includes("return")
+      ) {
+        relayReturned = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (relayActive && args.includes("read-screen")) {
+        const screen = !relayTyped
+          ? [
+              ">_ OpenAI Codex",
+              "Conversation interrupted",
+              "›",
+              "gpt-5.6-sol medium · ~/Gits/brainlayer",
+            ].join("\n")
+          : !relayReturned
+            ? [
+                ">_ OpenAI Codex",
+                `» ${message}`,
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n")
+            : [
+                ">_ OpenAI Codex",
+                "■ Conversation interrupted - tell the model what to do differently",
+                `• ${message}`,
+                "Working (1s • esc to interrupt)",
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n");
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: screen,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+    const spawned = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "initial work",
+        },
+        {} as any,
+      ),
+    );
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const ready = engine.stateMgr.updateRecord(spawned.agent_id, {
+      state: "ready",
+    });
+    registry.set(spawned.agent_id, ready);
+    relayActive = true;
+
+    const result = parseToolResult(
+      await sendTo.handler(
+        { agent_id: spawned.agent_id, text: message, press_enter: true },
+        {} as any,
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      delivery_state: "rescued",
+      terminal: true,
+      delivered: false,
+      submit_verified: false,
+      submit_evidence: "transcript_echo",
+    });
+  }, 20_000);
 
   it("send_to submits chunked multiline text as one receiver message", async () => {
     const baseExec = makeLifecycleExec();

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -13320,6 +13320,101 @@ codex>
     });
   }, 20_000);
 
+  it("send_to reports rescued on a first-ever interrupt after Return", async () => {
+    const message = "Reply with the single word OK";
+    const baseExec = makeLifecycleExec();
+    let relayActive = false;
+    let relayTyped = false;
+    let relayReturned = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (
+        relayActive &&
+        (args.includes("send") || args.includes("set-buffer")) &&
+        text.includes(message)
+      ) {
+        relayTyped = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (
+        relayActive &&
+        args.includes("send-key") &&
+        args.includes("return")
+      ) {
+        relayReturned = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (relayActive && args.includes("read-screen")) {
+        const screen = !relayTyped
+          ? [
+              ">_ OpenAI Codex",
+              "› Ask Codex to do anything",
+              "gpt-5.6-sol medium · ~/Gits/brainlayer",
+            ].join("\n")
+          : !relayReturned
+            ? [
+                ">_ OpenAI Codex",
+                `» ${message}`,
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n")
+            : [
+                ">_ OpenAI Codex",
+                "■ Conversation interrupted - tell the model what to do differently",
+                `• ${message}`,
+                "Working (1s • esc to interrupt)",
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n");
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: screen,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+    const spawned = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "initial work",
+        },
+        {} as any,
+      ),
+    );
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const ready = engine.stateMgr.updateRecord(spawned.agent_id, {
+      state: "ready",
+    });
+    registry.set(spawned.agent_id, ready);
+    relayActive = true;
+
+    const result = parseToolResult(
+      await sendTo.handler(
+        { agent_id: spawned.agent_id, text: message, press_enter: true },
+        {} as any,
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      delivery_state: "rescued",
+      terminal: true,
+      delivered: false,
+      submit_verified: false,
+      submit_evidence: "transcript_echo",
+    });
+  }, 20_000);
+
   it("send_to submits chunked multiline text as one receiver message", async () => {
     const baseExec = makeLifecycleExec();
     const buffers = new Map<string, string>();

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -13415,6 +13415,102 @@ codex>
     });
   }, 20_000);
 
+  it("keeps a latched interrupt rescued after pending delivery verification sweeps", async () => {
+    const message = "Reply with the single word OK";
+    const baseExec = makeLifecycleExec();
+    let relayActive = false;
+    let relayTyped = false;
+    let relayReturned = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (
+        relayActive &&
+        (args.includes("send") || args.includes("set-buffer")) &&
+        text.includes(message)
+      ) {
+        relayTyped = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (
+        relayActive &&
+        args.includes("send-key") &&
+        args.includes("return")
+      ) {
+        relayReturned = true;
+        return { stdout: "{}", stderr: "" };
+      }
+      if (relayActive && args.includes("read-screen")) {
+        const screen = !relayTyped
+          ? [
+              ">_ OpenAI Codex",
+              "› Ask Codex to do anything",
+              "gpt-5.6-sol medium · ~/Gits/brainlayer",
+            ].join("\n")
+          : !relayReturned
+            ? [
+                ">_ OpenAI Codex",
+                `» ${message}`,
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n")
+            : [
+                ">_ OpenAI Codex",
+                "■ Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/",
+                "  feedback` to report the issue.",
+                "",
+                "› Ask Codex to do anything",
+                "",
+                "gpt-5.6-sol medium · ~/Gits/brainlayer",
+              ].join("\n");
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: screen,
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createLifecycleServer(exec);
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const sendTo = (server as any)._registeredTools["send_to"];
+    const spawned = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          prompt: "initial work",
+        },
+        {} as any,
+      ),
+    );
+    const engine = (server as any)._registeredTools["interact"]._engine;
+    const registry = engine.getRegistry();
+    const ready = engine.stateMgr.updateRecord(spawned.agent_id, {
+      state: "ready",
+    });
+    registry.set(spawned.agent_id, ready);
+    relayActive = true;
+
+    const sent = parseToolResult(
+      await sendTo.handler(
+        { agent_id: spawned.agent_id, text: message, press_enter: true },
+        {} as any,
+      ),
+    );
+    await engine.verifyPendingDeliveries();
+
+    expect(engine.getDeliveryReceipt(sent.delivery_id)).toMatchObject({
+      delivery_id: sent.delivery_id,
+      delivery_state: "rescued",
+      terminal: true,
+      submit_verified: false,
+    });
+  }, 20_000);
+
   it("send_to submits chunked multiline text as one receiver message", async () => {
     const baseExec = makeLifecycleExec();
     const buffers = new Map<string, string>();

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -8981,6 +8981,47 @@ describe("agent lifecycle tool handlers", () => {
     expect(sendCalls).toHaveLength(0);
   });
 
+  it("send_to targeting counts a rescued target as failed", async () => {
+    const record = makeServerAgentRecord({
+      agent_id: "rescued-target",
+      surface_id: "surface:rescued-target",
+      state: "ready",
+      function: "reviewer",
+      cli: "codex",
+    });
+    const { server } = await createBroadcastServer([record], {
+      rescuedSurface: record.surface_id,
+    });
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        text: "Reply with the single word OK",
+        targeting: { agent_ids: [record.agent_id] },
+      },
+      {},
+    );
+    const parsed = parseToolResult(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed).toMatchObject({
+      target_count: 1,
+      submitted_count: 0,
+      queued_count: 0,
+      delivered_count: 0,
+      failed_count: 1,
+      skipped_count: 0,
+      receipts: [
+        expect.objectContaining({
+          agent_id: record.agent_id,
+          delivery_state: "rescued",
+          delivered: false,
+          terminal: true,
+        }),
+      ],
+    });
+    expect(result.content[0].text).toContain("1 failed");
+  }, 20_000);
+
   it("send_to rejects targeting combined with a singular agent id", async () => {
     const { server, sendCalls } = await createBroadcastServer([]);
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7052,6 +7052,79 @@ describe("agent lifecycle tool handlers", () => {
     );
   });
 
+  it("spawn_agent keeps a live registered pane when front-matter delivery reaches its queued deadline", async () => {
+    const promptPath = join(TEST_DIR, "front-matter.md");
+    writeFileSync(promptPath, "file prompt body", "utf8");
+    const baseExec = makeLifecycleExec();
+    let launched = false;
+    const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      const text = String(args.at(-1) ?? "");
+      if (args.includes("send") && /Codex\b/.test(text)) {
+        launched = true;
+      }
+      if (launched && args.includes("read-screen")) {
+        return {
+          stdout: JSON.stringify({
+            surface: "surface:new",
+            text: [
+              "Working (1s • esc to interrupt)",
+              "› Ask Codex to do anything",
+              "gpt-5.6-sol high · ~/Gits/cmuxlayer",
+            ].join("\n"),
+            lines: 20,
+            scrollback_used: false,
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+    });
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const getState = (server as any)._registeredTools["get_agent_state"];
+
+    const result = parseToolResult(
+      await spawn.handler(
+        {
+          repo: "brainlayer",
+          model: "codex",
+          cli: "codex",
+          boot_prompt_path: promptPath,
+          boot_prompt_timeout_ms: 250,
+        },
+        {} as any,
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.surface_id).toBe("surface:new");
+    expect(result.boot_prompt_receipt).toMatchObject({
+      delivery_state: "queued",
+      delivered: false,
+      terminal: false,
+      typed: false,
+      submit_attempted: false,
+      submit_verified: null,
+    });
+    const state = parseToolResult(
+      await getState.handler({ agent_id: result.agent_id }, {} as any),
+    );
+    expect(state).toMatchObject({
+      surface_id: "surface:new",
+      boot_prompt_pending: true,
+      prompt_delivered: false,
+      submit_verified: null,
+    });
+    expect(exec).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["close-surface", "surface:new"]),
+    );
+  }, 20_000);
+
   it("spawn_agent defaults managed agents to lifecycle escalation and persists explicit opt-outs", async () => {
     const server = createLifecycleServer(mockExec);
     const spawn = (server as any)._registeredTools["spawn_agent"];


### PR DESCRIPTION
## Summary

- hold Codex boot prompts until the first real idle composer instead of treating an active front-matter turn as ready
- recognize the verbatim installed Codex working chrome (`Working` + empty `›` + `tab to queue message`) and return a bounded `queued` receipt while retaining the live pane
- classify prompt evidence that appears only after a new external interrupt as terminal `rescued`, including `send_to` when a stale interrupt marker makes attribution ambiguous
- retain injected-only queued work as pending, clear stale queued observations per frame, and keep boot-timeout agents addressable through close and explicit resume

The active-turn refusal itself was already enforced by `CODEX_ACTIVE_RE` on main. This PR adds real-chrome queued classification, bounded truthful receipts, interrupt-safe attribution, and lifecycle retention; it does not claim to introduce the initial idle wait.

D82 is Codex-specific. Claude/Cursor front-matter parity is tracked separately as D106 and is not widened in this PR.

## Verification

- failing-first round-2 regressions use the lead's verbatim installed-0.4.60 screen tail; no invented model row
- D94 mutation proof: explicit timeout-record eviction makes the close/resume regression fail; restored production behavior passes
- focused delivery suites: 368 passed
- agent-engine suite: 349 passed
- typecheck passed
- full suite: 145 files passed; 3,426 tests passed; 1 skipped
- pre-push contract lanes and full suite passed at `cc215eb`
- local CodeRabbit 0.7.5 exceeded the bounded three-minute window and ended with a WebSocket connection error; `cr review findings` reported no stored findings

- Final gate 3 design choice: terminalize synchronously as `rescued` whenever the synchronous verifier has latched a new interrupt. This keeps interrupt evidence at the decision point and never hands an undecidable `pending_verify` receipt to the marker-unaware asynchronous verifier; the sweep regression covers the real interrupted empty-composer frame.
- Pre-push contract lanes and the full suite passed at `1a568bf`.

## Live evidence gates

- Installed-0.4.60 no-human D82 reproduction, including the verbatim 60-second timeout receipt and post-timeout screen state: `/Users/etanheyman/Gits/cmuxlayer/docs.local/golden-path/run4-live-before-receipt.md`
- BEFORE merge-gate Way-1 harness evidence:
  - [before ▶](https://macbook-pro.tail5ef6be.ts.net/dashboards/cmuxlayer/evidence/run4/before.mp4) — 44.9s, Way-1 control on installed 0.4.58; QA verdict `USABLE AS BEFORE` from the Gemini seat; HTTP 200 verified by the lead
  - run receipt: `/Users/etanheyman/Gits/cmuxlayer/docs.local/dashboards/evidence/run4/takes/way1-0.4.58/run.json`
- AFTER run-close gate (`after ▶`): pending lead-owned recording after release and install; this gates the run card's PASSED pill, not this merge

The installed-0.4.60 probe reproduced D82 without human input: boot readiness timed out while Codex was `Working` with an empty `›`; the prompt never appeared and no `OK` was produced. Merge requires the BEFORE evidence above, exact-head checks green, zero unanswered findings/P1s, and the lead's verdict. The AFTER artifact remains mandatory for run close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer boot-prompt delivery statuses, including queued and rescued outcomes.
  * Delivery receipts now include observations and warnings when prompts cannot be verified.
  * Agents remain active and pending when boot prompts are queued, rather than being marked ready prematurely.
  * Interrupted prompt echoes are no longer reported as verified submissions.
  * Broadcast and targeted delivery now identify rescued prompts as unsuccessful.

* **Tests**
  * Added coverage for delayed readiness, queued delivery deadlines, interrupted prompts, broadcast failures, and preserving live agent sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rescued` and `queued` delivery states to fix boot prompt truthfulness
> - Introduces a `rescued` delivery state across [server.ts](https://github.com/EtanHey/cmuxlayer/pull/547/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/547/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5): terminal, `delivered=false`, `submit_verified=false`. Classifies deliveries where transcript echo appears only after a new `Conversation interrupted` marker epoch, preventing false `submitted` or `pending_verify` outcomes.
> - Introduces a `queued` boot-readiness state in `waitForBootPromptReady` / `waitForBootPromptSubmitEvidence`: when the agent is mid-turn (working/thinking) with an empty composer, returns an observational non-sent receipt instead of typing or pressing Return.
> - Tightens boot-readiness gating in `AgentEngine`: active Codex evidence no longer disqualifies `awaitingManagedBootPrompt`, and reaching `ready` no longer auto-clears `boot_prompt_pending` when `prompt_delivered === false`.
> - Adds `screenHasWorkingCodexChrome` to infer Codex identity from working chrome without a banner, broadening `inferComposerCli` and `screenHasAnyAgentIdentity`.
> - Risk: `spawn`/registry now requires `submit_verified === true` to transition to `ready` (previously allowed when `hasPrompt` only); broadcast `failedCount` now counts `rescued` alongside `failed`. Reviewers should verify callers of `get_agent_state` and broadcast stat consumers handle the new `rescued` and `queued` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a568bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches managed spawn, boot readiness, and submit-verification semantics that orchestrators rely on; new `rescued`/`queued` outcomes and stricter lifecycle rules can change externally asserted delivery success.
> 
> **Overview**
> Makes Codex **boot-prompt delivery** wait for an idle composer instead of treating an active front-matter **Working** turn as ready, and stops lifecycle reconciliation from clearing `boot_prompt_pending` / marking `prompt_delivered` when the server already recorded undelivered or unverified boot work.
> 
> When readiness times out with a still-running turn, empty composer, and no prompt echo, **`deliverBootPrompt`** returns **`delivery_state: "queued"`** without typing or Return, attaches an **`observation`** snapshot on public receipts, and spawn paths keep **`boot_prompt_pending: true`** so the pane stays registered (including close/resume).
> 
> Submit verification gains terminal **`rescued`**: a new **`Conversation interrupted`** marker after the pre-Return screen plus transcript/token evidence is never treated as verified submission; **`send_to`**, **broadcast**, and engine receipts propagate **`delivered: false`** and count rescued like failures. Relay paths can require observed payload before Enter when boot delivery or stale interrupt markers make attribution ambiguous.
> 
> Adds D82 design/plan docs and broad Vitest coverage for idle-wait, queued deadlines, interrupt rescue, and registry retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a568bf19f9fd88bd48ee00e43f159fe33511944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

— cmuxlayerCodex-a974e266 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-a974e266","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a039df","ts":"2026-08-25T19:17:57Z"} -->
