### PR TITLE
fix: launch Codex workers in worker mode

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1374,6 +1374,8 @@ export function buildLaunchCommand(
     allowModelOverride?: boolean;
     effort?: CodexEffort;
     launchMode?: AgentLaunchMode;
+    /** Worker-authority Codex launches use repoGolem's light worker prompt. */
+    authority?: AgentAuthority;
     /** Approval handling for this launch; defaults to the machine's setting. */
     permissionMode?: SpawnPermissionMode;
   },
@@ -1394,6 +1396,7 @@ export function buildLaunchCommand(
     opts?.permissionMode ?? resolveSpawnPermissionMode(),
   );
   const launcherSkipArg = bypassApprovals ? " -s" : "";
+  const launcherWorkerArg = opts?.authority === "worker" ? " --worker" : "";
   const launcherWorktreeArg = opts?.cwd ? ` -w ${shellQuote(opts.cwd)}` : "";
   const launcherEffortArg = opts?.effort ? ` -E ${opts.effort}` : "";
   const rawCdPrefix = opts?.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
@@ -1444,7 +1447,7 @@ export function buildLaunchCommand(
       // repoGolem launcher handles env vars via ralph-registry
       return `${envPrefix}${launcherName ?? `${safeRepo}Claude`}${launcherSkipArg}${claudeModelArgs}${launcherWorktreeArg}`;
     case "codex":
-      return `${envPrefix}${launcherName ?? `${safeRepo}Codex`}${launcherSkipArg}${launcherModelArgs}${launcherEffortArg}${launcherWorktreeArg}`;
+      return `${envPrefix}${launcherName ?? `${safeRepo}Codex`}${launcherSkipArg}${launcherWorkerArg}${launcherModelArgs}${launcherEffortArg}${launcherWorktreeArg}`;
     case "gemini":
       // repoGolem launcher (e.g. golemsGemini -s) wires antigravity + MCP.
       return `${envPrefix}${launcherName ?? `${safeRepo}Gemini`}${launcherSkipArg}${launcherModelArgs}${launcherWorktreeArg}`;
@@ -8174,6 +8177,8 @@ export class AgentEngine {
       spawnParams.role !== undefined
         ? inferAgentRole({ role: spawnParams.role })
         : "worker";
+    const authority =
+      spawnParams.authority ?? (role === "orchestrator" ? "lead" : "worker");
 
     this.spawnGuard.check(spawnParams.workspace);
 
@@ -8314,8 +8319,7 @@ export class AgentEngine {
       parent_agent_id: parentAgentId,
       spawn_depth: spawnDepth,
       role,
-      authority:
-        spawnParams.authority ?? (role === "orchestrator" ? "lead" : "worker"),
+      authority,
       function: spawnParams.function ?? "implementor",
       placement:
         spawnParams.placement ?? (role === "orchestrator" ? "left" : "right"),
@@ -8417,6 +8421,7 @@ export class AgentEngine {
         allowModelOverride: modelPolicy.override_allowed,
         effort: effort ?? undefined,
         launchMode,
+        authority,
       },
     );
     try {

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -13718,6 +13718,22 @@ describe("buildLaunchCommand", () => {
     );
   });
 
+  it("launches worker-authority Codex roles in launcher worker mode", () => {
+    expect(
+      buildLaunchCommand("codex", "brainlayer", undefined, undefined, {
+        authority: "worker",
+      }),
+    ).toBe("brainlayerCodex -s --worker");
+  });
+
+  it("leaves lead-authority Codex launches out of launcher worker mode", () => {
+    expect(
+      buildLaunchCommand("codex", "brainlayer", undefined, undefined, {
+        authority: "lead",
+      }),
+    ).toBe("brainlayerCodex -s");
+  });
+
   it("passes an explicit Codex model with the launcher override env", () => {
     expect(
       buildLaunchCommand("codex", "brainlayer", "gpt-5.6-luna"),

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -1246,7 +1246,10 @@ describe("lean spawn tool responses", () => {
     expect(result.structuredContent.ok).toBe(true);
     expect(mockExec).toHaveBeenCalledWith(
       "cmux",
-      expect.arrayContaining(["send", "cmuxlayerCodex -s -E medium"]),
+      expect.arrayContaining([
+        "send",
+        "cmuxlayerCodex -s --worker -E medium",
+      ]),
     );
   });
 
@@ -4038,7 +4041,7 @@ describe("agent lifecycle tool handlers", () => {
         "send",
         "--surface",
         "surface:new",
-        `cmuxlayerCodex -s -w '${worktreePath}'`,
+        `cmuxlayerCodex -s --worker -w '${worktreePath}'`,
       ]),
     );
   });
@@ -4408,7 +4411,10 @@ describe("agent lifecycle tool handlers", () => {
       let launcherSentAt: number | null = null;
       const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
         const text = String(args.at(-1) ?? "");
-        if (args.includes("send") && text === "voicelayerCodex -s") {
+        if (
+          args.includes("send") &&
+          text === "voicelayerCodex -s --worker"
+        ) {
           launcherSentAt = Date.now();
           return { stdout: "{}", stderr: "" };
         }
@@ -4424,7 +4430,8 @@ describe("agent lifecycle tool handlers", () => {
           return {
             stdout: JSON.stringify({
               surface: "surface:new",
-              text: elapsed < 800 ? "$ voicelayerCodex -s" : "codex> ",
+              text:
+                elapsed < 800 ? "$ voicelayerCodex -s --worker" : "codex> ",
               lines: 20,
               scrollback_used: false,
             }),
@@ -4718,7 +4725,7 @@ describe("agent lifecycle tool handlers", () => {
         "send",
         "--surface",
         "surface:new",
-        `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s -w '${worktreePath}'`,
+        `CMUXLAYER_MCP_PROFILE=sterile cmuxlayerCodex -s --worker -w '${worktreePath}'`,
       ]),
     );
   });
@@ -5305,7 +5312,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s") {
+        if (lastSentText === "voicelayerCodex -s --worker") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -5319,7 +5326,7 @@ describe("agent lifecycle tool handlers", () => {
               : lastSentText === ""
                 ? "$ "
                 : launcherReturnCount < 2
-                  ? "$ voicelayerCodex -s"
+                  ? "$ voicelayerCodex -s --worker"
                   : "codex> ",
             lines: 20,
             scrollback_used: false,
@@ -5393,7 +5400,10 @@ describe("agent lifecycle tool handlers", () => {
       let launcherReturns = 0;
       const exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
         const text = String(args.at(-1) ?? "");
-        if (args.includes("send") && text === "voicelayerCodex -s") {
+        if (
+          args.includes("send") &&
+          text === "voicelayerCodex -s --worker"
+        ) {
           launcherSent = true;
           return { stdout: "{}", stderr: "" };
         }
@@ -5409,7 +5419,7 @@ describe("agent lifecycle tool handlers", () => {
           return {
             stdout: JSON.stringify({
               surface: "surface:new",
-              text: "bash-5.2$ voicelayerCodex -s",
+              text: "bash-5.2$ voicelayerCodex -s --worker",
               lines: 20,
               scrollback_used: false,
             }),
@@ -5437,7 +5447,9 @@ describe("agent lifecycle tool handlers", () => {
       expect(parsed.error).toContain(
         "launcher command remained pending after Return",
       );
-      expect(parsed.last_10_lines).toContain("bash-5.2$ voicelayerCodex -s");
+      expect(parsed.last_10_lines).toContain(
+        "bash-5.2$ voicelayerCodex -s --worker",
+      );
       expect(launcherReturns).toBeGreaterThanOrEqual(1);
     } finally {
       vi.useRealTimers();
@@ -6348,7 +6360,7 @@ describe("agent lifecycle tool handlers", () => {
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
       }
       if (args.includes("send-key")) {
-        if (lastSentText === "voicelayerCodex -s") {
+        if (lastSentText === "voicelayerCodex -s --worker") {
           launcherReturnCount += 1;
         }
         return { stdout: JSON.stringify({ ok: true }), stderr: "" };
@@ -6361,7 +6373,7 @@ describe("agent lifecycle tool handlers", () => {
               ? "gpt-5.5 xhigh · 99% left · ~/Gits/voicelayer\nWorking (1s • esc to interrupt)"
               : lastSentText === ""
                 ? "$ "
-                : "$ voicelayerCodex -s\ncodex> ",
+                : "$ voicelayerCodex -s --worker\ncodex> ",
             lines: 20,
             scrollback_used: false,
           }),

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -8596,6 +8596,10 @@ describe("tool handler integration", () => {
           string
         >;
       };
+      const workerLauncherCommand = fixture.launcher_command.replace(
+        " -s ",
+        " -s --worker ",
+      );
 
       let launcherSends = 0;
       let promptSent = false;
@@ -8762,7 +8766,7 @@ describe("tool handler integration", () => {
               text.includes("cmuxlayerCodex") &&
               !text.includes("cmuxlayer contract for"),
           ),
-        ).toEqual([fixture.launcher_command, fixture.launcher_command]);
+        ).toEqual([workerLauncherCommand, workerLauncherCommand]);
         expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(1);
         expect(returnPresses).toBeGreaterThanOrEqual(3);
         expect(
@@ -8928,6 +8932,7 @@ describe("tool handler integration", () => {
       corrupted_command: string;
       screen: string;
     };
+    const workerLauncherCommand = `${fixture.launcher_command} --worker`;
 
     let composer = "";
     let launcherSendAttempts = 0;
@@ -8982,7 +8987,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send")) {
         const text = String(args.at(-1) ?? "");
-        if (text === fixture.launcher_command) {
+        if (text === workerLauncherCommand) {
           launcherSendAttempts += 1;
           composer += text;
           if (launcherSendAttempts === 1) {
@@ -9005,7 +9010,7 @@ describe("tool handler integration", () => {
             ? codexComposerFrame(composer)
             : submitted === fixture.corrupted_command
             ? fixture.screen
-            : submitted === fixture.launcher_command
+            : submitted === workerLauncherCommand
               ? "OpenAI Codex\nmodel: gpt-5.6-sol high\n\n›"
               : submitted?.includes("cmuxlayer contract for")
                 ? codexSubmittedFrame(submitted)
@@ -9046,7 +9051,7 @@ describe("tool handler integration", () => {
         2_000,
       );
 
-      expect(submittedCommands[0]).toBe(fixture.launcher_command);
+      expect(submittedCommands[0]).toBe(workerLauncherCommand);
       expect(submittedCommands[1]).toContain("cmuxlayer contract for");
       expect(submittedCommands).not.toContain(fixture.corrupted_command);
       expect(launcherSendAttempts).toBe(1);
@@ -9106,6 +9111,13 @@ describe("tool handler integration", () => {
         pending_probe_screen: string;
       };
     };
+    const workerLauncherCommand = `${fixture.launcher_command} --worker`;
+    const workerCorruptedCommand =
+      workerLauncherCommand + workerLauncherCommand;
+    const workerPendingProbeScreen = fixture.replay.pending_probe_screen.replace(
+      fixture.launcher_command,
+      workerLauncherCommand,
+    );
 
     let composer = "";
     let launcherSendAttempts = 0;
@@ -9154,7 +9166,7 @@ describe("tool handler integration", () => {
       }
       if (args.includes("send")) {
         const text = String(args.at(-1) ?? "");
-        if (text === fixture.launcher_command) {
+        if (text === workerLauncherCommand) {
           launcherSendAttempts += 1;
           composer += text;
           if (launcherSendAttempts === 1) {
@@ -9187,7 +9199,7 @@ describe("tool handler integration", () => {
             );
           }
           if (probe === "delayed-visible" && ambiguityProbeReads > 1) {
-            text = fixture.replay.pending_probe_screen;
+            text = workerPendingProbeScreen;
           }
         }
         return {
@@ -9238,7 +9250,7 @@ describe("tool handler integration", () => {
         probe === "delayed-visible" ? 2 : 1,
       );
       if (probe === "delayed-visible") {
-        expect(submittedCommands[0]).toBe(fixture.launcher_command);
+        expect(submittedCommands[0]).toBe(workerLauncherCommand);
         expect(submittedCommands[1]).toContain("cmuxlayer contract for");
       } else {
         expect(submittedCommands).toEqual([]);
@@ -9246,6 +9258,7 @@ describe("tool handler integration", () => {
       expect(submittedCommands).not.toContain(
         fixture.captured_corrupted_command,
       );
+      expect(submittedCommands).not.toContain(workerCorruptedCommand);
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
     }

--- a/tests/spawn-resume-parity.test.ts
+++ b/tests/spawn-resume-parity.test.ts
@@ -139,7 +139,9 @@ const RESUMABLE_CLIS = CLIS.filter(
 );
 
 function expectedLaunch(cli: CliType, path: LauncherPath, root: string): string {
-  if (path === "registry") return `${EXPECTED_LAUNCHER_NAME[cli]} -s`;
+  if (path === "registry") {
+    return `${EXPECTED_LAUNCHER_NAME[cli]} -s${cli === "codex" ? " --worker" : ""}`;
+  }
   const cd = `cd '${root}' && `;
   switch (cli) {
     case "claude":


### PR DESCRIPTION
## Summary

- pass normalized worker authority into the Codex repoGolem launch command
- append `--worker` only for worker-authority Codex spawns; lead, raw-launch, and resume paths remain unchanged
- align the spawn/readiness/replay fixtures with the real worker command shape

This shrinks D82's collision window; run 4's honest delivery stays the guarantee.

## Failing first

`npx vitest run tests/agent-engine.test.ts -t 'launcher worker mode'`

- RED: 1 failed / 1 passed — expected `brainlayerCodex -s --worker`, received `brainlayerCodex -s`
- GREEN: 2 passed / 349 skipped

## Verification

- `npx vitest run tests/agent-engine.test.ts`: 351 passed
- affected server/spawn suites: 602 passed
- `npx vitest run --silent=passed-only --reporter=basic`: 145 files passed; 3428 passed, 1 skipped
- `npm run typecheck && npm run build && git diff --check`: passed
- repository pre-push gate completed and exact head `1eb832f7ed17aa53645532fe520a5d394080083e` is on the remote
- bounded local CodeRabbit review reached its 180-second timeout after analysis/reviewing with no finding emitted; this is recorded as degraded local review, not an independent verdict

## Live built-dist proof

Isolated D45/D64 probe used built `dist/daemon.js` + `dist/index.js`, a dedicated socket/state root, `workspace:2`, Codex `gpt-5.6-terra` at low effort, role `implementor`, authority `worker`, and no worktree.

Agent `cmuxlayerCodex-7550a396`, surface `surface:146`. First 10 boot lines:

```text
Last login: Tue Aug 25 22:42:23 on ttys028
etanheyman ~  $ REPOGOLEM_ALLOW_MODEL=1 cmuxlayerCodex -s --worker -m gpt-5.6-terra -E low
[5] 53291
cmuxlayerCodexWorker

[5]  + done       ( /Applications/iTerm.app/Contents/Resources/it2profile -s Golems 2> /dev/nul)
╭───────────────────────────────────────────────────╮
│ >_ OpenAI Codex (v0.149.1)                        │
│                                                   │
│ model:       gpt-5.6-terra low   /model to change │
```

First-turn frame:

```text
› D111 FIRST TURN PROOF: reply with exactly D111_WORKER_MODE_OK, then wait.

  cmuxlayer contract for cmuxlayerCodex-7550a396: Read and follow /Users/etanheyman/.cmux/
  agents/cmuxlayerCodex-7550a396/contract.md

 
Working (0s • esc to interrupt)
 
 
› Ask Codex to do anything
```

Receipt: `delivered:true`, `terminal:true`, `typed:true`, `submit_attempted:true`, `submit_verified:true`, `submit_evidence:transcript_echo`, `retry_count:0`. The first-turn frame contained no `agent_context` or `START-HERE`. Cleanup returned `agent_stopped:true` and `surface_closed:true`.

— cmuxlayerCodex-a974e266 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-a974e266","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a039df","ts":"2026-08-25T19:51:02Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Codex spawn command for worker agents, which affects boot prompts and launcher behavior; scope is limited to Codex launcher mode with an explicit authority gate.
> 
> **Overview**
> **Codex worker spawns** now pass normalized **authority** from the spawn path into `buildLaunchCommand`, which appends **`--worker`** to the repoGolem launcher line only when authority is **`worker`** (default for non-orchestrator roles). **Lead** orchestrators and non-Codex CLIs are unchanged; raw/resume launcher shapes are not given the flag.
> 
> Spawn record creation reuses a single **`authority`** variable (same default: orchestrator → lead, else worker) and forwards it at launch time so engine spawns and `spawn_agent` tooling emit commands like `repoCodex -s --worker` instead of bare `-s`.
> 
> Tests and replay fixtures were updated to expect the worker launcher string across effort, worktree, MCP env, first-paint, and parity cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb832f7ed17aa53645532fe520a5d394080083e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--worker` flag to Codex worker-mode launches in `AgentEngine`
> - Introduces an `authority` field on the agent record: `lead` when role is `orchestrator`, otherwise `worker`.
> - `buildLaunchCommand` in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/548/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) now appends `--worker` to the Codex launcher command when `opts.authority === 'worker'`; other CLIs are unaffected.
> - Updates tests across [agent-engine.test.ts](https://github.com/EtanHey/cmuxlayer/pull/548/files#diff-23c096d87b5f141db61c3014b45beb25da33800c0513e4ca132c5c9b5a6aac46), [server-agent-tools.test.ts](https://github.com/EtanHey/cmuxlayer/pull/548/files#diff-b02b20318090fbe2fe9736638b282662f0d778996959f4a29828dc0dab2debff), [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/548/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d), and [spawn-resume-parity.test.ts](https://github.com/EtanHey/cmuxlayer/pull/548/files#diff-7cf7f5f791de52e4a51b411b7e4515493e7534213da3832f8f3cef91480d2eb5) to expect the new flag in worker-mode Codex commands.
> - Risk: any external caller of `buildLaunchCommand` that does not pass `opts.authority` defaults to non-worker behavior; only the Codex launcher path is affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1eb832f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for launching agents with worker authority using the appropriate worker mode.
  - Agent authority is retained when agents are spawned and relaunched.

- **Bug Fixes**
  - Updated launch handling across standard, worktree, retry, readiness, and resume scenarios to consistently use the correct worker mode.

- **Tests**
  - Expanded coverage for worker and lead launch behavior, including command detection and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->