### PR TITLE
perf: bound terminal I/O latency

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -257,6 +257,7 @@ import {
   isSurfaceObserverEpochCurrent,
   resolveAgentSurfaceBinding,
   runWithSurfaceTopologyCallScope,
+  withSurfaceTopologyMutationInvalidation,
   type SurfaceObserverEpoch,
   type SurfaceObserverIdProvider,
   type SurfaceTopologySnapshot,
@@ -3860,7 +3861,7 @@ function buildLifecycleChannelMeta(
 export function createServer(opts?: CreateServerOptions): McpServer {
   const ownsContext = !opts?.context;
   const context = opts?.context ?? createServerContext(opts);
-  const client = context.client;
+  const client = withSurfaceTopologyMutationInvalidation(context.client);
   const listAllWorkspaces = async () => {
     const listed = await enumerateAllWindowWorkspacesWithRetry(
       client,

--- a/src/server.ts
+++ b/src/server.ts
@@ -250,11 +250,13 @@ import {
   captureSurfaceObserverEpoch as captureObserverEpoch,
   collectSurfaceTopology as collectCmuxSurfaceTopology,
   enumerateAllWindowWorkspacesWithRetry,
+  invalidateSurfaceTopologyCallScope,
   EMPTY_SURFACE_TOPOLOGY,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   isSurfaceObserverEpochCurrent,
   resolveAgentSurfaceBinding,
+  runWithSurfaceTopologyCallScope,
   type SurfaceObserverEpoch,
   type SurfaceObserverIdProvider,
   type SurfaceTopologySnapshot,
@@ -498,6 +500,8 @@ export const SEND_INPUT_MAX_INLINE_CHARS = parseMaxInlineChars(
   DEFAULT_SEND_INPUT_MAX_INLINE_CHARS,
 );
 const SEND_INPUT_SUBMIT_VERIFY_POLL_MS = 100;
+const SHORT_POINTER_MAX_CHARS = 200;
+const SHORT_POINTER_SUBMIT_VERIFY_TIMEOUT_MS = 750;
 // A bare submit key either takes effect on the next render or it did not take
 // effect at all -- there is no chunked typing to wait out, so the key path uses
 // a much shorter verification window than the text path (#484).
@@ -4514,7 +4518,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const handler = args[handlerIndex];
     if (typeof handler === "function") {
       const trackedHandler = (...handlerArgs: unknown[]) =>
-        withTransportRetryTracking(() => handler(...handlerArgs));
+        runWithSurfaceTopologyCallScope(() =>
+          withTransportRetryTracking(() => handler(...handlerArgs)),
+        );
       args[handlerIndex] = trackedHandler;
       if (typeof toolName === "string") {
         toolHandlersByName.set(
@@ -4942,6 +4948,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         } else {
           await client.send(surface, chunk, opts);
         }
+        invalidateSurfaceTopologyCallScope(client as object);
         return;
       } catch (error) {
         lastError = error;
@@ -5027,6 +5034,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       try {
         await beforeMutation?.();
         await client.sendKey(surface, key, { workspace });
+        invalidateSurfaceTopologyCallScope(client as object);
         return;
       } catch (error) {
         attempt += 1;
@@ -12298,6 +12306,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // healthy relay.
       const liveSurfaceRefs = async (): Promise<Set<string> | null> => {
         try {
+          // A UUID-less route is safe only if this check is newer than the
+          // resolver that supplied its mutable ref.
+          invalidateSurfaceTopologyCallScope(client as object);
           const surfaces = await surfaceProvider();
           return surfaces.length > 0
             ? new Set(surfaces.map((surface) => surface.ref))
@@ -12316,6 +12327,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ) {
         discovery.invalidate();
         await registry.listMerged(discovery, { force: true });
+        invalidateSurfaceTopologyCallScope(client as object);
         // Re-resolve after the resync. The agent may have been evicted (its
         // surface vanished) or still point at a dead surface — either way,
         // refuse with a clear stale-ref error instead of misdelivering.
@@ -12438,6 +12450,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         sanitizedText.length > SEND_INPUT_CHUNK_THRESHOLD
           ? chunkTerminalInput(sanitizedText, SEND_INPUT_CHUNK_THRESHOLD)
           : [sanitizedText];
+      const shortPointerVerifyTimeoutMs =
+        args.source_event === "send_to" &&
+        sanitizedText.length <= SHORT_POINTER_MAX_CHARS
+          ? Math.min(
+              SEND_INPUT_SUBMIT_VERIFY_TIMEOUT_MS,
+              SHORT_POINTER_SUBMIT_VERIFY_TIMEOUT_MS,
+            )
+          : undefined;
 
       // All validation above can await. Establish the delivery binding only
       // after those gates, then prove the exact UUID/ref/workspace pair again
@@ -12448,7 +12468,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       await assertAgentRouteHasTui(route);
       const deliveryRoute = route;
       const assertDeliveryRouteCurrent = async (): Promise<void> => {
-        const current = await engine.resolveAgentIoRoute(args.agent_id);
+        let current: typeof deliveryRoute;
+        try {
+          current = await engine.resolveAgentIoRoute(args.agent_id);
+        } catch {
+          throw new Error(
+            `Agent "${args.agent_id}" surface route changed during terminal ` +
+              `delivery; refusing to continue on another surface.`,
+          );
+        }
         if (
           current.surface_id !== deliveryRoute.surface_id ||
           (current.surface_uuid ?? null) !==
@@ -12507,7 +12535,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               args.source_event === "report_to_parent",
             submit_verify_timeout_ms: args.allow_busy
               ? BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS
-              : undefined,
+              : shortPointerVerifyTimeoutMs,
             beforeMutation: assertDeliveryRouteCurrent,
           });
           if (args.press_enter && delivery.submit_verified === true) {
@@ -15677,10 +15705,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             );
             return { merged: scoped, discovered, observedAtMs };
           }, { label: "list-agents" });
+          invalidateSurfaceTopologyCallScope(client as object);
+          const reconciledTopology = await collectSurfaceTopology();
+          const reconciledTopologySignature =
+            listAgentsTopologySignature(reconciledTopology);
           return await buildListAgentsResponse(
             live.merged,
-            topology,
-            topologySignature,
+            reconciledTopology,
+            reconciledTopologySignature,
             {
               rows: live.discovered,
               observed_at_ms: live.observedAtMs,
@@ -17398,6 +17430,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             () => registry.listMerged(discovery),
             { label: "list-agent-hierarchy" },
           );
+          invalidateSurfaceTopologyCallScope(client as object);
           const agents = args.parent_agent_id
             ? (() => {
                 const childIds = new Set(

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -149,6 +149,44 @@ export function invalidateSurfaceTopologyCallScope(
   }
 }
 
+const SURFACE_TOPOLOGY_MUTATION_METHODS = new Set<PropertyKey>([
+  "closeSurface",
+  "createWorkspace",
+  "deleteWorkspace",
+  "focusSurface",
+  "moveSurface",
+  "newSplit",
+  "newSurface",
+  "renameTab",
+  "selectWorkspace",
+]);
+
+/** Centralize call-scope invalidation at the cmux mutation boundary. */
+export function withSurfaceTopologyMutationInvalidation<T extends object>(
+  client: T,
+): T {
+  const boundMethods = new Map<PropertyKey, unknown>();
+  let wrapped: T;
+  wrapped = new Proxy(client, {
+    get(target, property) {
+      const value = Reflect.get(target, property, target);
+      if (typeof value !== "function") return value;
+      if (boundMethods.has(property)) return boundMethods.get(property);
+
+      const bound = SURFACE_TOPOLOGY_MUTATION_METHODS.has(property)
+        ? async (...args: unknown[]) => {
+            const result = await Reflect.apply(value, target, args);
+            invalidateSurfaceTopologyCallScope(wrapped);
+            return result;
+          }
+        : value.bind(target);
+      boundMethods.set(property, bound);
+      return bound;
+    },
+  });
+  return wrapped;
+}
+
 let workspaceEnumerationCache = new WeakMap<
   object,
   CachedWorkspaceEnumeration
@@ -287,15 +325,25 @@ export async function enumerateAllWindowWorkspacesWithRetry(
     observerEpochProvider,
   );
   if (first.complete) return first;
+  invalidateSurfaceTopologyCallScope(client as object);
+  const retryObserverEpoch = captureSurfaceObserverEpoch(
+    observerEpochProvider,
+  );
   const retried = await enumerateAllWindowWorkspaces(
     client,
     observerEpochProvider,
     { cache: false },
   );
-  const observerEpoch = captureSurfaceObserverEpoch(observerEpochProvider);
-  if (observerEpoch) {
+  const completedObserverEpoch = captureSurfaceObserverEpoch(
+    observerEpochProvider,
+  );
+  if (
+    retried.complete &&
+    retryObserverEpoch &&
+    retryObserverEpoch === completedObserverEpoch
+  ) {
     currentWorkspaceEnumerationCallScope()?.cache.set(client as object, {
-      observerEpoch,
+      observerEpoch: retryObserverEpoch,
       pending: Promise.resolve(retried),
     });
   }

--- a/src/surface-topology.ts
+++ b/src/surface-topology.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { AgentRecord } from "./agent-types.js";
 import type { AgentTopologyHealthInput } from "./agent-health.js";
 import type { AgentHealthInputOverrides } from "./agent-health-input.js";
@@ -89,7 +90,66 @@ interface CachedWorkspaceEnumeration {
   pending: Promise<AllWindowWorkspaceEnumeration>;
 }
 
-const workspaceEnumerationCache = new WeakMap<
+interface WorkspaceEnumerationCallScope {
+  active: boolean;
+  cache: WeakMap<object, CachedWorkspaceEnumeration>;
+}
+
+const workspaceEnumerationCallScope =
+  new AsyncLocalStorage<WorkspaceEnumerationCallScope>();
+
+/**
+ * Give one public tool invocation a consistent window -> workspace snapshot.
+ * Nested tool adapters reuse the same scope. Async work that outlives the
+ * handler sees the inactive marker and cannot retain the completed snapshot
+ * across public calls.
+ */
+export async function runWithSurfaceTopologyCallScope<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const existing = workspaceEnumerationCallScope.getStore();
+  if (existing?.active) return operation();
+
+  const scope: WorkspaceEnumerationCallScope = {
+    active: true,
+    cache: new WeakMap(),
+  };
+  try {
+    return await workspaceEnumerationCallScope.run(scope, operation);
+  } finally {
+    scope.active = false;
+  }
+}
+
+function currentWorkspaceEnumerationCallScope(): WorkspaceEnumerationCallScope | null {
+  const scope = workspaceEnumerationCallScope.getStore();
+  return scope?.active ? scope : null;
+}
+
+/**
+ * Start a new topology phase inside the current public tool call.
+ *
+ * A call-scoped workspace snapshot is valid only until that call mutates cmux
+ * or completes lifecycle reconciliation that may have observed a moved pane.
+ * Clearing it at those boundaries preserves the fresh-route checks while
+ * still coalescing every topology reader within one stable phase.
+ */
+export function invalidateSurfaceTopologyCallScope(
+  client?: object,
+): void {
+  const scope = currentWorkspaceEnumerationCallScope();
+  if (!scope) return;
+  if (client) {
+    scope.cache.delete(client);
+    workspaceEnumerationCache.delete(client);
+  } else {
+    scope.cache = new WeakMap<object, CachedWorkspaceEnumeration>();
+    workspaceEnumerationCache =
+      new WeakMap<object, CachedWorkspaceEnumeration>();
+  }
+}
+
+let workspaceEnumerationCache = new WeakMap<
   object,
   CachedWorkspaceEnumeration
 >();
@@ -122,6 +182,11 @@ export async function enumerateAllWindowWorkspaces(
   const observerEpoch = captureSurfaceObserverEpoch(observerEpochProvider);
   const cacheKey = client as object;
   if (observerEpoch && opts.cache !== false) {
+    const callCached =
+      currentWorkspaceEnumerationCallScope()?.cache.get(cacheKey);
+    if (callCached?.observerEpoch === observerEpoch) {
+      return callCached.pending;
+    }
     const cached = workspaceEnumerationCache.get(cacheKey);
     if (cached?.observerEpoch === observerEpoch) return cached.pending;
   }
@@ -193,6 +258,10 @@ export async function enumerateAllWindowWorkspaces(
 
   const pending = enumerate();
   if (observerEpoch && opts.cache !== false) {
+    currentWorkspaceEnumerationCallScope()?.cache.set(cacheKey, {
+      observerEpoch,
+      pending,
+    });
     // Coalesce the N callers in one observer epoch that arrive together, but
     // do not retain a completed map: windows/workspaces can change without an
     // observer reconnect, and route-proof callers must see that same-epoch
@@ -218,9 +287,19 @@ export async function enumerateAllWindowWorkspacesWithRetry(
     observerEpochProvider,
   );
   if (first.complete) return first;
-  return enumerateAllWindowWorkspaces(client, observerEpochProvider, {
-    cache: false,
-  });
+  const retried = await enumerateAllWindowWorkspaces(
+    client,
+    observerEpochProvider,
+    { cache: false },
+  );
+  const observerEpoch = captureSurfaceObserverEpoch(observerEpochProvider);
+  if (observerEpoch) {
+    currentWorkspaceEnumerationCallScope()?.cache.set(client as object, {
+      observerEpoch,
+      pending: Promise.resolve(retried),
+    });
+  }
+  return retried;
 }
 
 export async function listAllWindowWorkspaces(

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -635,7 +635,10 @@ describe("enter reliability", () => {
     expect(parsed.error).toMatch(/press_enter|allow_busy|boolean/i);
   });
 
-  it("retries Enter once when a Codex composer still holds the exact send", async () => {
+  it.each([
+    ["short pointer", "Read and follow /tmp/run5-pointer.md"],
+    ["long inline", "x".repeat(2000)],
+  ] as const)("retries Enter once for a %s whose Codex composer still holds the exact send", async (_name, text) => {
     const client = new FakeClaudeSurfaceClient();
     client.cli = "codex";
     server = createReliabilityServer(client);
@@ -643,7 +646,7 @@ describe("enter reliability", () => {
 
     const result = await callTool(server, "send_to", {
       agent_id: "agent-1",
-      text: "x".repeat(2000),
+      text,
       press_enter: true,
       allow_long_inline: true,
     });
@@ -656,7 +659,7 @@ describe("enter reliability", () => {
     expect(parsed.submit_verified).toBe(true);
     expect(parsed.submit_evidence).toBe("cleared_composer");
     expect(parsed.retry_count).toBe(1);
-    expect(client.sendCalls.join("")).toHaveLength(2000);
+    expect(client.sendCalls.join("")).toBe(text);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       2,
     );
@@ -731,8 +734,10 @@ describe("enter reliability", () => {
     },
   );
 
-  it("bounds a short pointer send to one second with a 750ms verify budget", async () => {
-    const client = new FakeUnavailableVerificationScreenClient("throw");
+  it.each(["throw", "blank"] as const)(
+    "bounds a short pointer send with %s verification to one second",
+    async (mode) => {
+    const client = new FakeUnavailableVerificationScreenClient(mode);
     client.requiredReturns = 1;
     server = createReliabilityServer(client);
     registerAgent(server);
@@ -768,7 +773,7 @@ describe("enter reliability", () => {
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
-  });
+  }, 10_000);
 
   it("surface-mode pointer sends bypass a held lifecycle lock", async () => {
     const client = new FakeClaudeSurfaceClient();

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -716,7 +716,7 @@ describe("enter reliability", () => {
 
       const result = await callTool(server, "send_to", {
         agent_id: "agent-1",
-        text: "slow first token",
+        text: `slow first token ${"x".repeat(190)}`,
         press_enter: true,
       });
       const parsed = parseResult(result);
@@ -730,6 +730,86 @@ describe("enter reliability", () => {
       expect(parsed.retry_count).toBe(0);
     },
   );
+
+  it("bounds a short pointer send to one second with a 750ms verify budget", async () => {
+    const client = new FakeUnavailableVerificationScreenClient("throw");
+    client.requiredReturns = 1;
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const tool = (server as any)._registeredTools["send_to"];
+    let settledAt: number | null = null;
+    const startedAt = Date.now();
+    const resultPromise = tool
+      .handler(
+        {
+          agent_id: "agent-1",
+          text: "Read and follow /tmp/run5-pointer.md",
+          press_enter: true,
+        },
+        {} as any,
+      )
+      .then((result: any) => {
+        settledAt = Date.now();
+        return result;
+      });
+
+    for (let elapsed = 0; elapsed < 2_000 && settledAt === null; elapsed += 50) {
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    const result = await resultPromise;
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed.delivery_state).toBe("pending_verify");
+    expect(parsed.submit_verified).toBeNull();
+    expect(settledAt).not.toBeNull();
+    expect(settledAt! - startedAt).toBeLessThanOrEqual(1_000);
+    expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
+      1,
+    );
+  });
+
+  it("surface-mode pointer sends bypass a held lifecycle lock", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+    const engine = server._registeredTools["interact"]._engine;
+    let releaseLock!: () => void;
+    const held = engine.runLifecycleMutation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        }),
+      { label: "held-for-surface-send-test" },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    let settled = false;
+    const resultPromise = server._registeredTools.send_to
+      .handler(
+        {
+          mode: "surface",
+          surface: client.surface,
+          text: "surface pointer",
+          press_enter: false,
+        },
+        {} as any,
+      )
+      .then((result: any) => {
+        settled = true;
+        return result;
+      });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(settled).toBe(true);
+    const result = await resultPromise;
+    expect(result.isError).not.toBe(true);
+    expect(client.sendCalls).toEqual(["surface pointer"]);
+
+    releaseLock();
+    await held;
+  });
 
   it("reports send_to input as still pending when the composer never clears", async () => {
     const client = new FakeClaudeSurfaceClient();
@@ -833,7 +913,7 @@ describe("enter reliability", () => {
       const resultPromise = tool.handler(
         {
           agent_id: "agent-1",
-          text: "land once but evidence stays unavailable",
+          text: `land once but evidence stays unavailable ${"x".repeat(170)}`,
           press_enter: true,
         },
         {} as any,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -11121,6 +11121,8 @@ codex>
     const server = await createUuidRouteServer(routeClient, record);
     routeClient.client.send.mockClear();
     routeClient.sendCalls.length = 0;
+    routeClient.client.listWindows.mockClear();
+    routeClient.client.listWorkspaces.mockClear();
 
     const result = await registeredTestTool(server, "send_to").handler(
       {
@@ -11136,6 +11138,15 @@ codex>
     expect(routeClient.sendCalls).toEqual([
       { surface: "surface:B", text: "cross-window delivery" },
     ]);
+    // D97 regression budget: one enumeration per stable phase -- initial
+    // route proof, post-write evidence, and derived status publication --
+    // instead of allowing the old route/read/guard multiplier to return.
+    expect(routeClient.client.listWindows.mock.calls.length).toBeLessThanOrEqual(
+      3,
+    );
+    expect(
+      routeClient.client.listWorkspaces.mock.calls.length,
+    ).toBeLessThanOrEqual(6);
   });
 
   it("spawn_agent creates a worker in an explicit workspace in another window", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10762,6 +10762,47 @@ codex>
     );
   });
 
+  it("send_to delivers to an idle live agent with a recorded pid when its stable UUID route is valid", async () => {
+    const stableUuid = "11111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:send-1",
+        id: stableUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    const record = makeServerAgentRecord({
+      agent_id: "send-1-recorded-pid",
+      surface_id: "surface:send-1",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:1",
+      state: "idle",
+      pid: process.pid,
+      repo: "cmuxlayer",
+      cli: "codex",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+    routeClient.client.send.mockClear();
+    routeClient.sendCalls.length = 0;
+
+    const result = await registeredTestTool(server, "send_to").handler(
+      {
+        agent_id: record.agent_id,
+        text: "send 1",
+        press_enter: false,
+      },
+      {} as any,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(routeClient.sendCalls).toEqual([
+      { surface: "surface:send-1", text: "send 1" },
+    ]);
+    expect(String(parseToolResult(result).error ?? "")).not.toMatch(
+      /topology did not prove its surface route/i,
+    );
+  });
+
   it("send_to rechecks for a bare shell after its final agent route resolution", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -8117,97 +8117,7 @@ describe("tool handler integration", () => {
   });
 
   it("new_split with launcher-style title honors explicit pane when role is omitted", async () => {
-    mockExec = vi
-      .fn()
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspaces: [
-            {
-              ref: "workspace:1",
-              title: "brainlayer",
-              current_directory: "/Users/etanheyman/Gits/brainlayer",
-            },
-          ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspace_ref: "workspace:1",
-          window_ref: "window:1",
-          panes: [
-            {
-              ref: "pane:manual",
-              index: 0,
-              focused: true,
-              surface_count: 1,
-              surface_refs: ["surface:manual-anchor"],
-            },
-          ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspaces: [
-            {
-              ref: "workspace:1",
-              title: "brainlayer",
-              current_directory: "/Users/etanheyman/Gits/brainlayer",
-            },
-          ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspaces: [
-            {
-              ref: "workspace:1",
-              title: "brainlayer",
-              current_directory: "/Users/etanheyman/Gits/brainlayer",
-            },
-          ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: "[]",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspace_ref: "workspace:1",
-          window_ref: "window:1",
-          pane_ref: "pane:manual",
-          surfaces: [
-            {
-              ref: "surface:manual-anchor",
-              title: "existing",
-              type: "terminal",
-              index: 0,
-              selected: true,
-            },
-          ],
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          workspace: "workspace:1",
-          surface: "surface:manual-title",
-          pane: "pane:manual",
-          title: "brainlayerCodex",
-          type: "terminal",
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({ ok: true }),
-        stderr: "",
-      });
-    const queuedExec = mockExec;
-    mockExec = vi.fn(async (cmd: string, args: string[]) => {
+    mockExec = vi.fn(async (_cmd: string, args: string[]) => {
       if (args.includes("list-windows")) {
         return {
           stdout: JSON.stringify({
@@ -8216,7 +8126,76 @@ describe("tool handler integration", () => {
           stderr: "",
         };
       }
-      return queuedExec(cmd, args);
+      if (args.includes("list-workspaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspaces: [
+              {
+                ref: "workspace:1",
+                title: "brainlayer",
+                current_directory: "/Users/etanheyman/Gits/brainlayer",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-panes")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            panes: [
+              {
+                ref: "pane:manual",
+                index: 0,
+                focused: true,
+                surface_count: 1,
+                surface_refs: ["surface:manual-anchor"],
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("list-status")) {
+        return { stdout: "[]", stderr: "" };
+      }
+      if (args.includes("list-pane-surfaces")) {
+        return {
+          stdout: JSON.stringify({
+            workspace_ref: "workspace:1",
+            window_ref: "window:1",
+            pane_ref: "pane:manual",
+            surfaces: [
+              {
+                ref: "surface:manual-anchor",
+                title: "existing",
+                type: "terminal",
+                index: 0,
+                selected: true,
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:manual-title",
+            pane: "pane:manual",
+            title: "brainlayerCodex",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      if (args.includes("rename-tab")) {
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      throw new Error(`Unexpected cmux command in test: ${args.join(" ")}`);
     }) as typeof mockExec;
     const server = createServer({
       exec: mockExec,

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -4,12 +4,14 @@ import type { AgentRecord } from "../src/agent-types.js";
 import {
   collectSurfaceTopology,
   enumerateAllWindowWorkspaces,
+  enumerateAllWindowWorkspacesWithRetry,
   listAllWindowWorkspaces,
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   resolveAgentSurfaceBinding,
   runWithSurfaceTopologyCallScope,
   SurfaceIdentityConflictError,
+  withSurfaceTopologyMutationInvalidation,
 } from "../src/surface-topology.js";
 import type {
   CmuxPane,
@@ -396,6 +398,84 @@ describe("collectSurfaceTopology", () => {
     });
     expect(client.listWindows).toHaveBeenCalledTimes(2);
     expect(client.listWorkspaces).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a retry across an observer epoch change", async () => {
+    let observerEpoch = "observer:epoch:A";
+    const client = {
+      listWindows: vi
+        .fn()
+        .mockResolvedValueOnce({ windows: [{ ref: "window:A", workspace_count: 2 }] })
+        .mockResolvedValue({ windows: [{ ref: "window:A", workspace_count: 1 }] }),
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValueOnce({ workspaces: [workspace("workspace:OLD")] })
+        .mockImplementationOnce(async () => {
+          observerEpoch = "observer:epoch:B";
+          return { workspaces: [workspace("workspace:OLD")] };
+        })
+        .mockResolvedValue({ workspaces: [workspace("workspace:NEW")] }),
+    };
+
+    const result = await runWithSurfaceTopologyCallScope(async () => {
+      await enumerateAllWindowWorkspacesWithRetry(client, () => observerEpoch);
+      return enumerateAllWindowWorkspaces(client, () => observerEpoch);
+    });
+
+    expect(result.workspaces[0]?.ref).toBe("workspace:NEW");
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not cache an incomplete retry", async () => {
+    const client = {
+      listWindows: vi
+        .fn()
+        .mockResolvedValueOnce({ windows: [{ ref: "window:A", workspace_count: 2 }] })
+        .mockResolvedValueOnce({ windows: [{ ref: "window:A", workspace_count: 2 }] })
+        .mockResolvedValue({ windows: [{ ref: "window:A", workspace_count: 1 }] }),
+      listWorkspaces: vi
+        .fn()
+        .mockResolvedValueOnce({ workspaces: [workspace("workspace:OLD")] })
+        .mockResolvedValueOnce({ workspaces: [workspace("workspace:OLD")] })
+        .mockResolvedValue({ workspaces: [workspace("workspace:NEW")] }),
+    };
+
+    const result = await runWithSurfaceTopologyCallScope(async () => {
+      await enumerateAllWindowWorkspacesWithRetry(
+        client,
+        () => "observer:epoch:A",
+      );
+      return enumerateAllWindowWorkspaces(client, () => "observer:epoch:A");
+    });
+
+    expect(result.workspaces[0]?.ref).toBe("workspace:NEW");
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidates the call-scope workspace map after a structural mutation", async () => {
+    let workspaceRef = "workspace:OLD";
+    const rawClient = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [{ ref: "window:A", workspace_count: 1 }],
+      }),
+      listWorkspaces: vi.fn(async () => ({
+        workspaces: [workspace(workspaceRef)],
+      })),
+      createWorkspace: vi.fn(async () => {
+        workspaceRef = "workspace:NEW";
+        return { workspace: workspaceRef, title: "new" };
+      }),
+    };
+    const client = withSurfaceTopologyMutationInvalidation(rawClient);
+
+    const result = await runWithSurfaceTopologyCallScope(async () => {
+      await enumerateAllWindowWorkspaces(client, () => "observer:epoch:A");
+      await client.createWorkspace();
+      return enumerateAllWindowWorkspaces(client, () => "observer:epoch:A");
+    });
+
+    expect(result.workspaces[0]?.ref).toBe("workspace:NEW");
+    expect(rawClient.listWorkspaces).toHaveBeenCalledTimes(2);
   });
 
   it("marks malformed pane enumeration incomplete", async () => {

--- a/tests/surface-topology.test.ts
+++ b/tests/surface-topology.test.ts
@@ -8,6 +8,7 @@ import {
   enrichSurfaceIdsFromPanes,
   healthTopologyOverrides,
   resolveAgentSurfaceBinding,
+  runWithSurfaceTopologyCallScope,
   SurfaceIdentityConflictError,
 } from "../src/surface-topology.js";
 import type {
@@ -193,6 +194,39 @@ describe("enrichSurfaceIdsFromPanes", () => {
 });
 
 describe("collectSurfaceTopology", () => {
+  it("reuses one completed workspace map within a call and refreshes it across calls", async () => {
+    let workspaceRef = "workspace:A";
+    const client = {
+      listWindows: vi.fn().mockResolvedValue({
+        windows: [{ ref: "window:A", workspace_count: 1 }],
+      }),
+      listWorkspaces: vi.fn(async () => ({
+        workspaces: [workspace(workspaceRef)],
+      })),
+    };
+    const observerEpoch = () => "observer@test:1";
+
+    const first = await runWithSurfaceTopologyCallScope(async () => {
+      const one = await enumerateAllWindowWorkspaces(client, observerEpoch);
+      const two = await enumerateAllWindowWorkspaces(client, observerEpoch);
+      return { one, two };
+    });
+
+    expect(first.one.workspaces[0]?.ref).toBe("workspace:A");
+    expect(first.two.workspaces[0]?.ref).toBe("workspace:A");
+    expect(client.listWindows).toHaveBeenCalledTimes(1);
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(1);
+
+    workspaceRef = "workspace:B";
+    const second = await runWithSurfaceTopologyCallScope(() =>
+      enumerateAllWindowWorkspaces(client, observerEpoch),
+    );
+
+    expect(second.workspaces[0]?.ref).toBe("workspace:B");
+    expect(client.listWindows).toHaveBeenCalledTimes(2);
+    expect(client.listWorkspaces).toHaveBeenCalledTimes(2);
+  });
+
   it("enumerates workspaces in every cmux window before marking topology complete", async () => {
     const surfaceAUuid = "11111111-2222-4333-8444-555555555555";
     const surfaceBUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";


### PR DESCRIPTION
## Summary

- reuse one completed all-window workspace enumeration throughout each stable phase of a public MCP call
- invalidate that call-scope map centrally after every topology-affecting cmux mutation
- cap `send_to` verification for pointers up to 200 characters at 750 ms while preserving honest `pending_verify` receipts
- preserve fail-closed UUID/ref route checks, including cross-workspace moves and UUID-less stale-ref repair

## Root cause and round-2 corrections

Agent delivery repeated all-window enumeration across route resolution, target reads, mutation guards, and response enrichment. The original optimization added two cache-consistency regressions, now covered failing-first:

1. Retry results are cached only when complete and when the observer epoch is unchanged from before to after the retry. An incomplete first result is evicted before retry.
2. A single client mutation-boundary wrapper invalidates the call-scope map after `renameTab`, `newSplit`, `newSurface`, `focusSurface`, `createWorkspace`, `deleteWorkspace`, `closeSurface`, `moveSurface`, and `selectWorkspace`.

The recorded pid 94886 from send 1 was live; the failure was a topology-proof inconsistency around a valid stable UUID, not proof that the process was stale. A new gate test pins the exact IDLE/LIVE/recorded-pid send shape and requires agent-mode `send_to` delivery through the stable UUID route.

## BEFORE — installed/runtime evidence

| Operation | Build / source | MCP-visible wall time | Receipt | Evidence boundary |
|---|---|---:|---|---|
| agent `send_to` → idle prober | installed 0.4.60 recording, send 1 | 45.750 s | failed, `typed:false`, route/pid error | pixel-observed and receipt-confirmed |
| agent `send_to` → idle worker | installed 0.4.60 recording, send 3 | at least 38.375 s | current receipt not visible | unresolved; not claimed delivered |
| surface `send_to` → same pane | installed 0.4.60 recording, send 2 | 0.125 s to MCP receipt | provisional; later prompt + `ACK` | end-to-end remains inconclusive |

BEFORE clip: [run-5 latency evidence](https://macbook-pro.tail5ef6be.ts.net/dashboards/cmuxlayer/evidence/run5/before.mp4) (`QA: USABLE AS BEFORE`, SHA-256 `348b057bb02f9e40042421ac1f1438b436f577f455c97466dded5da6da963313`).

## AFTER — exact pushed source head

| Gate | Result at `d524eae4d889ab13b3fd45b2ebbf38b12138be04` |
|---|---|
| cross-window agent send enumeration budget | at most 3 stable phases / 6 per-window workspace RPCs |
| short pointer submit-verification cap | 750 ms; ≤1,000 ms test wall budget with unavailable or blank verification |
| pointer Enter safety matrix | both short and long exact-composer cases retain the bounded recovery Return behavior |
| send-1 route shape | idle live agent with a recorded pid delivers by valid stable UUID; no route-proof refusal |
| retry epoch safety | reconnect during retry cannot cache the old map under the new epoch |
| structural mutation safety | a workspace created between two same-call enumerations is visible after centralized invalidation |

## Verification

- typecheck and build pass
- full Vitest suite: 145 files passed, 3,437 tests passed, 1 skipped
- pre-push hook reran the full suite with the same 145 / 3,437 / 1 result
- focused topology and Enter gates: 71 passed
- `tests/server-agent-tools.test.ts`: 341 passed, including the send-1 regression
- CodeRabbit uncommitted diff review: 0 findings across all five changed files

The performance regression tests run in the Vitest suite and therefore in CI on every PR. The installed-runtime wall-clock target (agent pointer `send_to` ≤2 s on socket / ≤4 s on CLI) is a lead deploy gate on the released build, not a source-PR gate and not claimed here.

Released AFTER runtime/video evidence remains pending that deploy gate.

STATUS: REVIEW_NEEDED

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03a91","ts":"2026-08-25T21:23:31Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound terminal I/O latency with short-pointer verify timeout and per-call topology scope
> - Adds a shorter submit verification timeout (up to 750ms) for `send_to` inputs under 200 chars, replacing the default timeout path
> - Introduces `runWithSurfaceTopologyCallScope` to wrap all tool handlers in a per-call scope backed by `AsyncLocalStorage`, with a `WeakMap` cache that coalesces workspace enumerations within the same call and observer epoch
> - Wraps the cmux client via `withSurfaceTopologyMutationInvalidation` so structural mutations (e.g. `createWorkspace`, `moveSurface`, `newSplit`, `renameTab`, `selectWorkspace`) automatically invalidate the call-scope cache after success
> - `client.send` and `client.sendKey` now call `invalidateSurfaceTopologyCallScope` so topology reads later in the same call observe a fresh phase; `enumerateAllWindowWorkspacesWithRetry` invalidates before retry and seeds the per-call cache only when the observer epoch is unchanged
> - The `list-agents` tool now recomputes a reconciled topology and its signature for each response instead of using a potentially stale snapshot; `assertDeliveryRouteCurrent` rethrows resolve errors as a consistent route-changed refusal
> - Behavioral Change: `shortPointerVerifyTimeoutMs` replaces the prior `submit_verify_timeout_ms` conditional in delivery options; `workspaceEnumerationCache` is now `let` to allow full reset during invalidation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d524eae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent message delivery after terminal or workspace changes.
  * Refreshed routing information before sending messages to avoid stale destinations.
  * Added controlled errors when delivery routes cannot be resolved.
  * Added bounded verification for short-pointer sends when screens are unavailable.
  * Improved lifecycle and agent-list updates after workspace changes.

* **Reliability**
  * Reduced duplicate topology lookups while maintaining accurate results after mutations.
  * Improved retry handling when workspace state changes during discovery.
  * Expanded coverage for message delivery, routing, and topology refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->