### PR TITLE
fix: bound first agent delivery latency

### DIFF
--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import net from "node:net";
@@ -304,11 +305,6 @@ function write(value) {
   process.stdout.write(JSON.stringify(value));
 }
 if (command === "list-workspaces") {
-  if (state.hold_next_sweep === true) {
-    patchState({ hold_next_sweep: false, sweep_hold_started: true });
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 3500);
-    patchState({ sweep_hold_finished: true });
-  }
   write({ workspaces: [{ ref: "workspace:bench", title: "Bench", index: 0, selected: true, pinned: false, current_directory: cwd }] });
 } else if (command === "list-windows") {
   write({ windows: [{ ref: "window:bench", title: "Bench", index: 0, selected: true, workspace_refs: ["workspace:bench"] }] });
@@ -442,38 +438,33 @@ async function readFakeState(statePath) {
   }
 }
 
-async function armSweepHold(statePath) {
-  const current = await readFakeState(statePath);
+async function armSweepHold(statePath, holdToken) {
   await writeFile(
     statePath,
-    JSON.stringify({
-      ...current,
-      hold_next_sweep: true,
-      sweep_hold_started: false,
-      sweep_hold_finished: false,
-    }),
+    JSON.stringify({ token: holdToken, state: "armed" }),
   );
 }
 
-async function waitForSweepHoldStarted(statePath, timeoutMs = 5_000) {
+async function waitForSweepHoldState(
+  statePath,
+  holdToken,
+  expectedState,
+  timeoutMs = 5_000,
+) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if ((await readFakeState(statePath)).sweep_hold_started === true) return;
+    const state = await readFakeState(statePath);
+    if (state.token === holdToken && state.state === expectedState) {
+      return;
+    }
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
   }
-  throw new Error("timed out waiting for the benchmark startup sweep hold");
+  throw new Error(
+    `timed out waiting for benchmark hold ${holdToken} state ${expectedState}`,
+  );
 }
 
-async function waitForSweepHoldFinished(statePath, timeoutMs = 5_000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if ((await readFakeState(statePath)).sweep_hold_finished === true) return;
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
-  }
-  throw new Error("timed out waiting for the benchmark startup sweep release");
-}
-
-async function measureFirstSendAfterSpawn(client, lockClient, fakeCmuxState) {
+async function measureFirstSendAfterSpawn(client, sweepHoldState) {
   const spawnResult = toolData(
     await client.callTool("spawn_agent", {
       repo: "cmuxlayer",
@@ -501,23 +492,21 @@ async function measureFirstSendAfterSpawn(client, lockClient, fakeCmuxState) {
     return { elapsed_ms: round(nowMs() - startedAt), receipt };
   };
 
-  // Simulate the startup sweep with the same daemon lifecycle lock: a second
-  // client starts a real managed-metadata refresh whose topology enumeration is
-  // held for 3.5s. Removing the target-scoped send path must push this over 2s.
-  await armSweepHold(fakeCmuxState);
-  const heldRefresh = lockClient.callTool("wait_for", {
-    agent_id: spawnResult.agent_id,
-    target_state: "ready",
-    timeout_ms: 1_000,
-  });
-  await waitForSweepHoldStarted(fakeCmuxState);
+  // The daemon sweep acknowledges this unique token only after it owns the
+  // lifecycle mutex. Restoring the fleet refresh must push first send over 2s.
+  const holdToken = `sweep-daemon-owner-${Date.now()}`;
+  await armSweepHold(sweepHoldState, holdToken);
+  await waitForSweepHoldState(sweepHoldState, holdToken, "held");
   const first = await measureSend({
     agent_id: spawnResult.agent_id,
     text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-first-send.md`,
     press_enter: true,
   });
-  await waitForSweepHoldFinished(fakeCmuxState);
-  toolData(await heldRefresh, "held lifecycle refresh");
+  await writeFile(
+    sweepHoldState,
+    JSON.stringify({ token: holdToken, state: "release" }),
+  );
+  await waitForSweepHoldState(sweepHoldState, holdToken, "complete");
   const second = await measureSend({
     agent_id: spawnResult.agent_id,
     text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-second-send.md`,
@@ -570,18 +559,28 @@ async function main() {
     : join(repoRoot, "docs.local", "scratch", "run5r3");
   await mkdir(scratchRoot, { recursive: true });
   const tempRoot = await mkdtemp(join(scratchRoot, "b-"));
+  const socketScratchRoot = join(
+    homedir(),
+    ".local",
+    "state",
+    "cmuxlayer",
+    "bench",
+  );
+  await mkdir(socketScratchRoot, { recursive: true });
+  const socketRoot = await mkdtemp(join(socketScratchRoot, "b-"));
   const binDir = join(tempRoot, "bin");
   await mkdir(binDir, { recursive: true });
   await writeFile(join(binDir, "package.json"), '{"type":"commonjs"}\n');
   await writeFakeCmux(binDir);
-  const daemonSocket = join(tempRoot, "d.sock");
-  const missingCmuxSocket = join(tempRoot, "m.sock");
+  const daemonSocket = join(socketRoot, "d.sock");
+  const missingCmuxSocket = join(socketRoot, "m.sock");
   const fakeCmuxSocketServer = net.createServer((socket) => socket.destroy());
   await new Promise((resolvePromise, reject) => {
     fakeCmuxSocketServer.once("error", reject);
     fakeCmuxSocketServer.listen(missingCmuxSocket, resolvePromise);
   });
   const fakeCmuxState = join(tempRoot, "fake-cmux-state.json");
+  const sweepHoldState = join(tempRoot, "sweep-hold-state.json");
   const baseEnv = {
     ...process.env,
     CMUX_AGENT_ID: "",
@@ -594,8 +593,8 @@ async function main() {
     CMUXLAYER_BENCH_STATE: fakeCmuxState,
     CMUXLAYER_STATE_DIR: join(tempRoot, "state"),
     CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS: "0",
-    CMUXLAYER_SWEEP_INTERVAL_MS: "60000",
-    CMUXLAYER_SWEEP_IDLE_INTERVAL_MS: "60000",
+    CMUXLAYER_SWEEP_INTERVAL_MS: "1000",
+    CMUXLAYER_SWEEP_IDLE_INTERVAL_MS: "1000",
     CMUXLAYER_NODE_MAX_OLD_SPACE_MB: "1536",
   };
 
@@ -606,7 +605,7 @@ async function main() {
     baselineClients = await startClients("baseline", clientCount, {
       ...baseEnv,
       CMUXLAYER_FORCE_INPROCESS: "1",
-      CMUXLAYER_DAEMON_SOCKET: join(tempRoot, "baseline-unused.sock"),
+      CMUXLAYER_DAEMON_SOCKET: join(socketRoot, "u.sock"),
     });
     const baselineLatency = await measureLatency(baselineClients);
     const baselineRssMb = await totalRssMb(
@@ -617,6 +616,7 @@ async function main() {
       cwd: repoRoot,
       env: {
         ...baseEnv,
+        CMUXLAYER_BENCH_SWEEP_HOLD_STATE: sweepHoldState,
         CMUXLAYER_DAEMON_SOCKET: daemonSocket,
       },
       stdio: ["ignore", "ignore", "pipe"],
@@ -647,8 +647,7 @@ async function main() {
     const daemonLatency = await measureLatency(daemonClients);
     const firstSendAfterSpawn = await measureFirstSendAfterSpawn(
       daemonClients[0],
-      daemonClients[1],
-      fakeCmuxState,
+      sweepHoldState,
     );
     const daemonRssMb = await totalRssMb(
       [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
@@ -747,6 +746,7 @@ async function main() {
       fakeCmuxSocketServer.close(resolvePromise),
     );
     await rm(tempRoot, { recursive: true, force: true });
+    await rm(socketRoot, { recursive: true, force: true });
   }
 }
 

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -232,13 +232,22 @@ class McpProcess {
       pending.reject(new Error(`${this.label} closed`));
     }
     this.pending.clear();
-    this.child.kill("SIGTERM");
-    setTimeout(() => {
-      if (this.child.exitCode === null) {
-        this.child.kill("SIGKILL");
-      }
-    }, 1_000).unref();
+    return stopChild(this.child);
   }
+}
+
+function stopChild(child) {
+  if (!child || child.exitCode !== null) return Promise.resolve();
+  return new Promise((resolvePromise) => {
+    const forceTimer = setTimeout(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+    }, 1_000);
+    child.once("exit", () => {
+      clearTimeout(forceTimer);
+      resolvePromise();
+    });
+    child.kill("SIGTERM");
+  });
 }
 
 async function writeFakeCmux(binDir) {
@@ -246,37 +255,86 @@ async function writeFakeCmux(binDir) {
   await writeFile(
     fakePath,
     `#!/usr/bin/env node
+const fs = require("node:fs");
 const rawArgs = process.argv.slice(2);
-const args = rawArgs[0] === "--json" ? rawArgs.slice(1) : rawArgs;
+const args = [...rawArgs];
+if (args[0] === "--json") args.shift();
+if (args[0] === "--id-format") args.splice(0, 2);
 const command = args[0] || "";
 const surfaceCount = Number(process.env.CMUXLAYER_BENCH_SURFACES || "8");
 const cwd = process.env.PWD || process.cwd();
+const statePath = process.env.CMUXLAYER_BENCH_STATE;
+function readState() {
+  try { return JSON.parse(fs.readFileSync(statePath, "utf8")); }
+  catch { return { composer: "", transcript: "", title: "bench-spawn" }; }
+}
+function writeState(state) {
+  if (statePath) fs.writeFileSync(statePath, JSON.stringify(state));
+}
+const state = readState();
 const surfaces = Array.from({ length: surfaceCount }, (_, index) => ({
   ref: "surface:bench-" + index,
+  id: "00000000-0000-4000-8000-" + String(index).padStart(12, "0"),
   title: "bench-agent-" + index,
   type: "terminal",
   index,
   selected: index === 0,
   current_directory: cwd
-}));
+})).concat([{
+  ref: "surface:bench-spawn",
+  id: "00000000-0000-4000-8000-999999999999",
+  title: state.title,
+  type: "terminal",
+  index: surfaceCount,
+  selected: false,
+  current_directory: cwd
+}]);
 function write(value) {
   process.stdout.write(JSON.stringify(value));
 }
 if (command === "list-workspaces") {
   write({ workspaces: [{ ref: "workspace:bench", title: "Bench", index: 0, selected: true, pinned: false, current_directory: cwd }] });
 } else if (command === "list-panes") {
-  write({ workspace_ref: "workspace:bench", window_ref: "window:bench", panes: [{ ref: "pane:bench", index: 0, focused: true, surface_count: surfaces.length, surface_refs: surfaces.map((surface) => surface.ref), selected_surface_ref: surfaces[0].ref, current_directory: cwd }] });
+  write({ workspace_ref: "workspace:bench", window_ref: "window:bench", panes: [{ ref: "pane:bench", index: 0, focused: true, surface_count: surfaces.length, surface_refs: surfaces.map((surface) => surface.ref), surface_ids: surfaces.map((surface) => surface.id), selected_surface_ref: surfaces[0].ref, current_directory: cwd }] });
 } else if (command === "list-pane-surfaces") {
   write({ workspace_ref: "workspace:bench", window_ref: "window:bench", pane_ref: "pane:bench", surfaces });
+} else if (command === "new-split") {
+  write({ workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: "surface:bench-spawn", surface_id: "00000000-0000-4000-8000-999999999999", title: state.title, type: "terminal" });
 } else if (command === "debug-terminals") {
   write({ terminals: surfaces.map((surface) => ({ surface_ref: surface.ref, current_directory: cwd })) });
 } else if (command === "read-screen") {
   const surface = args[args.indexOf("--surface") + 1] || surfaces[0].ref;
-  write({ surface_ref: surface, text: "codex> benchmark ready on " + surface + "\\nTASK_DONE", lines: 2, scrollback_used: false });
+  const composer = state.composer ? "› " + state.composer : "› ";
+  const transcript = state.transcript ? "\\n› " + state.transcript + "\\n" : "";
+  write({ surface_ref: surface, text: "╭ OpenAI Codex ╮\\nmodel: gpt-5.6-sol\\n" + transcript + "\\n" + composer, lines: 8, scrollback_used: false });
 } else if (command === "identify") {
   write({ caller: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref }, focused: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref } });
 } else if (command === "list-status") {
   write([]);
+} else if (command === "send") {
+  state.composer += args.at(-1) || "";
+  writeState(state);
+  write({ ok: true });
+} else if (command === "set-buffer") {
+  state.buffer = args.at(-1) || "";
+  writeState(state);
+  write({ ok: true });
+} else if (command === "paste-buffer") {
+  state.composer += state.buffer || "";
+  state.buffer = "";
+  writeState(state);
+  write({ ok: true });
+} else if (command === "send-key") {
+  if ((args.at(-1) || "").toLowerCase() === "return") {
+    state.transcript = state.composer;
+    state.composer = "";
+    writeState(state);
+  }
+  write({ ok: true });
+} else if (command === "rename-tab") {
+  state.title = args.at(-1) || state.title;
+  writeState(state);
+  write({ ok: true });
 } else {
   write({ ok: true });
 }
@@ -348,6 +406,71 @@ function latencyGate(baseline, daemon, tool, percentileName) {
   );
 }
 
+function toolData(result, label) {
+  if (result?.isError) {
+    throw new Error(`${label} failed: ${compact(result)}`);
+  }
+  if (result?.structuredContent) return result.structuredContent;
+  const text = result?.content?.find((entry) => entry.type === "text")?.text;
+  if (!text) throw new Error(`${label} returned no structured receipt`);
+  return JSON.parse(text);
+}
+
+async function measureFirstSendAfterSpawn(client) {
+  const spawnResult = toolData(
+    await client.callTool("spawn_agent", {
+      repo: "cmuxlayer",
+      cli: "codex",
+      role: "worker",
+      authority: "worker",
+      placement: "right",
+      workspace: "workspace:bench",
+      cwd: repoRoot,
+      worktree: false,
+      mcp_profile: "sterile",
+      title: "bench-first-send",
+      prompt: "benchmark boot prompt",
+      boot_prompt_timeout_ms: 2_000,
+    }),
+    "spawn_agent",
+  );
+  if (!spawnResult.agent_id || !spawnResult.surface_id) {
+    throw new Error(`spawn_agent omitted identity: ${compact(spawnResult)}`);
+  }
+
+  const measureSend = async (args) => {
+    const startedAt = nowMs();
+    const receipt = toolData(await client.callTool("send_to", args), "send_to");
+    return { elapsed_ms: round(nowMs() - startedAt), receipt };
+  };
+
+  const first = await measureSend({
+    agent_id: spawnResult.agent_id,
+    text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-first-send.md`,
+    press_enter: true,
+  });
+  const second = await measureSend({
+    agent_id: spawnResult.agent_id,
+    text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-second-send.md`,
+    press_enter: true,
+  });
+  const surface = await measureSend({
+    mode: "surface",
+    surface: spawnResult.surface_id,
+    workspace: "workspace:bench",
+    text: "surface benchmark",
+    press_enter: true,
+  });
+
+  return {
+    agent_id: spawnResult.agent_id,
+    surface_id: spawnResult.surface_id,
+    first,
+    second,
+    surface,
+  };
+}
+
 async function main() {
   if (!existsSync(distIndex) || !existsSync(distDaemon)) {
     throw new Error("dist/index.js and dist/daemon.js are required; run bun run build first");
@@ -360,11 +483,23 @@ async function main() {
   await writeFakeCmux(binDir);
   const daemonSocket = join(tempRoot, "cmuxlayer-stated.sock");
   const missingCmuxSocket = join(tempRoot, "missing-cmux.sock");
+  const fakeCmuxSocketServer = net.createServer((socket) => socket.destroy());
+  await new Promise((resolvePromise, reject) => {
+    fakeCmuxSocketServer.once("error", reject);
+    fakeCmuxSocketServer.listen(missingCmuxSocket, resolvePromise);
+  });
+  const fakeCmuxState = join(tempRoot, "fake-cmux-state.json");
   const baseEnv = {
     ...process.env,
+    CMUX_AGENT_ID: "",
+    CMUX_SURFACE_ID: "",
+    CMUX_WORKSPACE_ID: "",
+    CMUX_TAB_ID: "",
     PATH: `${binDir}:${process.env.PATH ?? ""}`,
     CMUX_SOCKET_PATH: missingCmuxSocket,
     CMUXLAYER_BENCH_SURFACES: String(clientCount),
+    CMUXLAYER_BENCH_STATE: fakeCmuxState,
+    CMUXLAYER_STATE_DIR: join(tempRoot, "state"),
     CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS: "0",
     CMUXLAYER_SWEEP_INTERVAL_MS: "60000",
     CMUXLAYER_SWEEP_IDLE_INTERVAL_MS: "60000",
@@ -411,6 +546,9 @@ async function main() {
       CMUXLAYER_DAEMON_SOCKET: daemonSocket,
     });
     const daemonLatency = await measureLatency(daemonClients);
+    const firstSendAfterSpawn = await measureFirstSendAfterSpawn(
+      daemonClients[0],
+    );
     const daemonRssMb = await totalRssMb(
       [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
     );
@@ -448,6 +586,11 @@ async function main() {
         "read_screen",
         "p99_ms",
       ),
+      first_send_after_spawn_within_2s:
+        firstSendAfterSpawn.first.elapsed_ms <= 2_000,
+      surface_receipt_is_waitable:
+        firstSendAfterSpawn.surface.receipt.terminal === true ||
+        typeof firstSendAfterSpawn.surface.receipt.delivery_id === "string",
     };
     const green = Object.values(gates).every(Boolean);
     const result = {
@@ -471,6 +614,7 @@ async function main() {
           list_surfaces: daemonLatency.list_surfaces,
           read_screen: daemonLatency.read_screen,
         },
+        first_send_after_spawn: firstSendAfterSpawn,
       },
       daemon_cpu_pct: round(daemonStats.cpuPct, 2),
       gates,
@@ -486,6 +630,9 @@ async function main() {
     console.log(
       `read_screen p50/p99 baseline=${result.latency.baseline_inprocess.read_screen.p50_ms}/${result.latency.baseline_inprocess.read_screen.p99_ms}ms daemon=${result.latency.daemon_path.read_screen.p50_ms}/${result.latency.daemon_path.read_screen.p99_ms}ms`,
     );
+    console.log(
+      `send_to first/second/surface=${result.latency.first_send_after_spawn.first.elapsed_ms}/${result.latency.first_send_after_spawn.second.elapsed_ms}/${result.latency.first_send_after_spawn.surface.elapsed_ms}ms`,
+    );
     console.log(`daemon CPU=${result.daemon_cpu_pct}%`);
     console.log(JSON.stringify(result, null, 2));
 
@@ -493,15 +640,13 @@ async function main() {
       process.exitCode = 1;
     }
   } finally {
-    for (const client of [...baselineClients, ...daemonClients]) {
-      client.close();
-    }
-    daemon?.kill("SIGTERM");
-    setTimeout(() => {
-      if (daemon && daemon.exitCode === null) {
-        daemon.kill("SIGKILL");
-      }
-    }, 1_000).unref();
+    await Promise.all(
+      [...baselineClients, ...daemonClients].map((client) => client.close()),
+    );
+    await stopChild(daemon);
+    await new Promise((resolvePromise) =>
+      fakeCmuxSocketServer.close(resolvePromise),
+    );
     await rm(tempRoot, { recursive: true, force: true });
   }
 }

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import net from "node:net";
@@ -16,6 +15,7 @@ const DEFAULT_CLIENTS = 8;
 const DEFAULT_ROUNDS = 12;
 const LATENCY_REGRESSION_RATIO = 1.25;
 const LATENCY_REGRESSION_SLACK_MS = 5;
+const READ_SCREEN_P50_BUDGET_MS = 250;
 let JsonRpcLineBuffer;
 
 function parsePositiveInt(raw, fallback) {
@@ -198,7 +198,11 @@ class McpProcess {
     return new Promise((resolvePromise, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`${this.label} timed out waiting for ${method}`));
+        reject(
+          new Error(
+            `${this.label} timed out waiting for ${method}; stderr=${this.stderr.trim()}`,
+          ),
+        );
       }, timeoutMs);
       this.pending.set(id, { resolve: resolvePromise, reject, timeout });
       this.send(message);
@@ -237,10 +241,14 @@ class McpProcess {
 }
 
 function stopChild(child) {
-  if (!child || child.exitCode !== null) return Promise.resolve();
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
   return new Promise((resolvePromise) => {
     const forceTimer = setTimeout(() => {
-      if (child.exitCode === null) child.kill("SIGKILL");
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
     }, 1_000);
     child.once("exit", () => {
       clearTimeout(forceTimer);
@@ -271,6 +279,9 @@ function readState() {
 function writeState(state) {
   if (statePath) fs.writeFileSync(statePath, JSON.stringify(state));
 }
+function patchState(patch) {
+  writeState({ ...readState(), ...patch });
+}
 const state = readState();
 const surfaces = Array.from({ length: surfaceCount }, (_, index) => ({
   ref: "surface:bench-" + index,
@@ -293,7 +304,14 @@ function write(value) {
   process.stdout.write(JSON.stringify(value));
 }
 if (command === "list-workspaces") {
+  if (state.hold_next_sweep === true) {
+    patchState({ hold_next_sweep: false, sweep_hold_started: true });
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 3500);
+    patchState({ sweep_hold_finished: true });
+  }
   write({ workspaces: [{ ref: "workspace:bench", title: "Bench", index: 0, selected: true, pinned: false, current_directory: cwd }] });
+} else if (command === "list-windows") {
+  write({ windows: [{ ref: "window:bench", title: "Bench", index: 0, selected: true, workspace_refs: ["workspace:bench"] }] });
 } else if (command === "list-panes") {
   write({ workspace_ref: "workspace:bench", window_ref: "window:bench", panes: [{ ref: "pane:bench", index: 0, focused: true, surface_count: surfaces.length, surface_refs: surfaces.map((surface) => surface.ref), surface_ids: surfaces.map((surface) => surface.id), selected_surface_ref: surfaces[0].ref, current_directory: cwd }] });
 } else if (command === "list-pane-surfaces") {
@@ -416,7 +434,46 @@ function toolData(result, label) {
   return JSON.parse(text);
 }
 
-async function measureFirstSendAfterSpawn(client) {
+async function readFakeState(statePath) {
+  try {
+    return JSON.parse(await readFile(statePath, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function armSweepHold(statePath) {
+  const current = await readFakeState(statePath);
+  await writeFile(
+    statePath,
+    JSON.stringify({
+      ...current,
+      hold_next_sweep: true,
+      sweep_hold_started: false,
+      sweep_hold_finished: false,
+    }),
+  );
+}
+
+async function waitForSweepHoldStarted(statePath, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await readFakeState(statePath)).sweep_hold_started === true) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+  }
+  throw new Error("timed out waiting for the benchmark startup sweep hold");
+}
+
+async function waitForSweepHoldFinished(statePath, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await readFakeState(statePath)).sweep_hold_finished === true) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+  }
+  throw new Error("timed out waiting for the benchmark startup sweep release");
+}
+
+async function measureFirstSendAfterSpawn(client, lockClient, fakeCmuxState) {
   const spawnResult = toolData(
     await client.callTool("spawn_agent", {
       repo: "cmuxlayer",
@@ -444,11 +501,23 @@ async function measureFirstSendAfterSpawn(client) {
     return { elapsed_ms: round(nowMs() - startedAt), receipt };
   };
 
+  // Simulate the startup sweep with the same daemon lifecycle lock: a second
+  // client starts a real managed-metadata refresh whose topology enumeration is
+  // held for 3.5s. Removing the target-scoped send path must push this over 2s.
+  await armSweepHold(fakeCmuxState);
+  const heldRefresh = lockClient.callTool("wait_for", {
+    agent_id: spawnResult.agent_id,
+    target_state: "ready",
+    timeout_ms: 1_000,
+  });
+  await waitForSweepHoldStarted(fakeCmuxState);
   const first = await measureSend({
     agent_id: spawnResult.agent_id,
     text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-first-send.md`,
     press_enter: true,
   });
+  await waitForSweepHoldFinished(fakeCmuxState);
+  toolData(await heldRefresh, "held lifecycle refresh");
   const second = await measureSend({
     agent_id: spawnResult.agent_id,
     text: `Read and follow ${repoRoot}/docs.local/scratch/run5r3/bench-second-send.md`,
@@ -461,13 +530,32 @@ async function measureFirstSendAfterSpawn(client) {
     text: "surface benchmark",
     press_enter: true,
   });
+  let surfaceWaitFor;
+  if (typeof surface.receipt.delivery_id === "string") {
+    try {
+      surfaceWaitFor = toolData(
+        await client.callTool("wait_for", {
+          delivery_id: surface.receipt.delivery_id,
+          timeout_ms: 2_000,
+        }),
+        "wait_for(surface receipt)",
+      );
+    } catch (error) {
+      surfaceWaitFor = {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  } else {
+    surfaceWaitFor = { ok: false, error: "surface receipt omitted delivery_id" };
+  }
 
   return {
     agent_id: spawnResult.agent_id,
     surface_id: spawnResult.surface_id,
     first,
     second,
-    surface,
+    surface: { ...surface, wait_for: surfaceWaitFor },
   };
 }
 
@@ -477,12 +565,17 @@ async function main() {
   }
   ({ JsonRpcLineBuffer } = await import("../dist/json-rpc-line-buffer.js"));
 
-  const tempRoot = await mkdtemp(join(tmpdir(), "cmuxlayer-daemon-bench-"));
+  const scratchRoot = process.env.CMUXLAYER_BENCH_SCRATCH
+    ? resolve(process.env.CMUXLAYER_BENCH_SCRATCH)
+    : join(repoRoot, "docs.local", "scratch", "run5r3");
+  await mkdir(scratchRoot, { recursive: true });
+  const tempRoot = await mkdtemp(join(scratchRoot, "b-"));
   const binDir = join(tempRoot, "bin");
   await mkdir(binDir, { recursive: true });
+  await writeFile(join(binDir, "package.json"), '{"type":"commonjs"}\n');
   await writeFakeCmux(binDir);
-  const daemonSocket = join(tempRoot, "cmuxlayer-stated.sock");
-  const missingCmuxSocket = join(tempRoot, "missing-cmux.sock");
+  const daemonSocket = join(tempRoot, "d.sock");
+  const missingCmuxSocket = join(tempRoot, "m.sock");
   const fakeCmuxSocketServer = net.createServer((socket) => socket.destroy());
   await new Promise((resolvePromise, reject) => {
     fakeCmuxSocketServer.once("error", reject);
@@ -541,13 +634,21 @@ async function main() {
     });
     await waitForSocket(daemonSocket);
 
-    daemonClients = await startClients("daemon", clientCount, {
-      ...baseEnv,
-      CMUXLAYER_DAEMON_SOCKET: daemonSocket,
-    });
+    try {
+      daemonClients = await startClients("daemon", clientCount, {
+        ...baseEnv,
+        CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+      });
+    } catch (error) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; daemon stderr=${daemonStderr.trim()}`,
+      );
+    }
     const daemonLatency = await measureLatency(daemonClients);
     const firstSendAfterSpawn = await measureFirstSendAfterSpawn(
       daemonClients[0],
+      daemonClients[1],
+      fakeCmuxState,
     );
     const daemonRssMb = await totalRssMb(
       [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
@@ -574,12 +675,8 @@ async function main() {
         "list_surfaces",
         "p99_ms",
       ),
-      read_screen_p50_no_regression: latencyGate(
-        baselineLatency,
-        daemonLatency,
-        "read_screen",
-        "p50_ms",
-      ),
+      read_screen_p50_within_250ms:
+        daemonLatency.read_screen.p50_ms <= READ_SCREEN_P50_BUDGET_MS,
       read_screen_p99_no_regression: latencyGate(
         baselineLatency,
         daemonLatency,
@@ -589,8 +686,10 @@ async function main() {
       first_send_after_spawn_within_2s:
         firstSendAfterSpawn.first.elapsed_ms <= 2_000,
       surface_receipt_is_waitable:
-        firstSendAfterSpawn.surface.receipt.terminal === true ||
-        typeof firstSendAfterSpawn.surface.receipt.delivery_id === "string",
+        typeof firstSendAfterSpawn.surface.receipt.delivery_id === "string" &&
+        firstSendAfterSpawn.surface.wait_for.delivery_id ===
+          firstSendAfterSpawn.surface.receipt.delivery_id &&
+        firstSendAfterSpawn.surface.wait_for.terminal === true,
     };
     const green = Object.values(gates).every(Boolean);
     const result = {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -259,6 +259,7 @@ import {
 } from "./process-liveness.js";
 
 export type AgentDeliveryState =
+  | "typed"
   | "submitted"
   | "queued"
   | "queued_followup"
@@ -311,6 +312,8 @@ export interface AgentDeliveryReceipt {
   unchanged_screen_retry_count?: number;
   /** Internal digest for comparing retry snapshots without persisting screen text. */
   retry_screen_fingerprint?: string | null;
+  /** Delivery is owned by an already-running direct surface write, not the retry drain. */
+  externally_managed?: boolean;
 }
 
 export const DEFAULT_DELIVERY_VERIFY_DEADLINE_MS = 10 * 60 * 1000;
@@ -6852,6 +6855,39 @@ export class AgentEngine {
     return { ...receipt };
   }
 
+  registerExternalDelivery(input: {
+    delivery_id: string;
+    agent_id: string;
+    text: string;
+    press_enter: boolean;
+    source_event: DeliveryEventType;
+  }): AgentDeliveryReceipt {
+    const now = new Date().toISOString();
+    const receipt: AgentDeliveryReceipt = {
+      ...input,
+      delivery_state: "queued",
+      terminal: false,
+      created_at: now,
+      resolved_at: null,
+      retry_count: 0,
+      submit_verified: null,
+      error: null,
+      submission_started_at: now,
+      next_attempt_at: null,
+      composer_accepted: false,
+      verify_deadline_at: null,
+      externally_managed: true,
+    };
+    this.deliveryReceipts.set(receipt.delivery_id, receipt);
+    try {
+      this.persistDeliveryReceipts();
+    } catch (error) {
+      this.deliveryReceipts.delete(receipt.delivery_id);
+      throw error;
+    }
+    return { ...receipt };
+  }
+
   acceptComposerQueue(input: {
     delivery_id: string;
     agent_id: string;
@@ -7276,6 +7312,7 @@ export class AgentEngine {
     try {
       for (const receipt of this.deliveryReceipts.values()) {
         if (receipt.delivery_state !== "queued") continue;
+        if (receipt.externally_managed === true) continue;
         if (receipt.composer_accepted === true) continue;
         const agent = this.getAgentState(receipt.agent_id);
         if (!agent) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6714,11 +6714,45 @@ export class AgentEngine {
   }
 
   async runSweep(): Promise<void> {
-    await this.runLifecycleMutation(() => this.runSweepOnce(), {
+    await this.runLifecycleMutation(async () => {
+      await this.holdBenchmarkSweepIfArmed();
+      await this.runSweepOnce();
+    }, {
       label: "sweep",
     });
     await this.drainDeliveryQueue();
     await this.verifyPendingDeliveries();
+  }
+
+  private async holdBenchmarkSweepIfArmed(): Promise<void> {
+    const statePath =
+      process.env.CMUXLAYER_BENCH_SWEEP_HOLD_STATE?.trim() ?? "";
+    if (!statePath) return;
+
+    let armed: { token?: unknown; state?: unknown };
+    try {
+      armed = JSON.parse(readFileSync(statePath, "utf8"));
+    } catch {
+      return;
+    }
+    if (armed.state !== "armed" || typeof armed.token !== "string") return;
+
+    const token = armed.token;
+    writeFileSync(statePath, JSON.stringify({ token, state: "held" }));
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      try {
+        const current = JSON.parse(readFileSync(statePath, "utf8"));
+        if (current.token === token && current.state === "release") {
+          writeFileSync(statePath, JSON.stringify({ token, state: "complete" }));
+          return;
+        }
+      } catch {
+        // The benchmark owns this opt-in state file and may be between writes.
+      }
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+    }
+    throw new Error(`benchmark lifecycle sweep hold timed out: ${token}`);
   }
 
   setDeliverySubmitter(submitter: DeliverySubmitter | null): void {

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -296,6 +296,7 @@ export interface DeliveryTelemetryEvent {
   delivery_id?: string;
   /** Nonterminal acceptance or terminal resolution. */
   delivery_state?:
+    | "typed"
     | "submitted"
     | "queued"
     | "queued_followup"

--- a/src/server.ts
+++ b/src/server.ts
@@ -624,6 +624,7 @@ const DeliveryOutputShape = {
   delivery: z
     .enum([
       "submitted",
+      "typed",
       "queued",
       "queued_followup",
       "rescued",
@@ -635,6 +636,7 @@ const DeliveryOutputShape = {
   delivery_state: z
     .enum([
       "submitted",
+      "typed",
       "queued",
       "queued_followup",
       "rescued",
@@ -981,6 +983,7 @@ export type SubmitEvidence =
   | "status_only";
 
 type PublicDeliveryState =
+  | "typed"
   | "submitted"
   | "queued"
   | "queued_followup"
@@ -1062,6 +1065,7 @@ export function buildPublicDeliveryReceipt(input: {
   WARNING?: string;
 }): PublicDeliveryReceipt {
   const evidencedState =
+    input.delivery_state === "typed" ||
     input.delivery_state === "queued" ||
     input.delivery_state === "queued_followup" ||
     input.delivery_state === "rescued" ||
@@ -1069,17 +1073,19 @@ export function buildPublicDeliveryReceipt(input: {
     input.delivery_state === "pending_verify" ||
     input.delivery_state === "failed_confirmed"
       ? input.delivery_state
-      : input.delivery_state === "submitted" && input.submit_verified === true
+      : input.delivery_state === "submitted"
         ? "submitted"
         : undefined;
   const terminal =
+    evidencedState === "typed" ||
     evidencedState === "submitted" ||
     evidencedState === "rescued" ||
     evidencedState === "failed" ||
     evidencedState === "failed_confirmed";
   const warning = input.WARNING ?? defaultNonDeliveryWarning(evidencedState);
   return {
-    delivered: evidencedState === "submitted",
+    delivered:
+      evidencedState === "submitted" && input.submit_verified === true,
     terminal,
     typed: input.typed,
     submit_attempted: input.submit_attempted,
@@ -3301,11 +3307,16 @@ function resolveTargetIdentity(
   stateMgr: StateManager,
   surfaceRef: string,
   surfaceTitle?: string | null,
+  stableSurfaceIdentity?: string | null,
 ): TargetIdentity {
   const identity: TargetIdentity = { surface: surfaceRef };
   const title = surfaceTitle?.trim();
   if (title) identity.title = title;
-  const record = resolveLatestSurfaceAgentRecord(stateMgr, surfaceRef);
+  const record = resolveLatestSurfaceAgentRecord(
+    stateMgr,
+    surfaceRef,
+    stableSurfaceIdentity,
+  );
   if (record?.model) identity.model = record.model;
   if (record?.cli) identity.agent_type = record.cli;
   return identity;
@@ -3314,10 +3325,16 @@ function resolveTargetIdentity(
 function resolveLatestSurfaceAgentRecord(
   stateMgr: StateManager,
   surfaceRef: string,
+  stableSurfaceIdentity?: string | null,
 ): AgentRecord | undefined {
+  const stableUuid = stableSurfaceIdentity?.trim().toLowerCase() ?? null;
   return stateMgr
     .listStates()
-    .filter((record) => record.surface_id === surfaceRef)
+    .filter((record) =>
+      stableUuid
+        ? record.surface_uuid?.trim().toLowerCase() === stableUuid
+        : record.surface_id === surfaceRef,
+    )
     .sort((a, b) => {
       if (b.version !== a.version) return b.version - a.version;
       return (
@@ -6172,7 +6189,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ? {
               delivery_id: opts.delivery_id,
               delivery_state:
-                deliveryOutcome === "queued"
+                !opts.press_enter
+                  ? ("typed" as const)
+                  : deliveryOutcome === "queued"
                   ? ("queued" as const)
                   : deliveryOutcome === "queued_followup"
                     ? ("queued_followup" as const)
@@ -6190,7 +6209,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const receipt = buildPublicDeliveryReceipt({
       delivery_state:
-        deliveryOutcome === "queued"
+        !opts.press_enter
+          ? "typed"
+          : deliveryOutcome === "queued"
           ? "queued"
           : deliveryOutcome === "queued_followup"
             ? "queued_followup"
@@ -6198,7 +6219,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? "pending_verify"
               : deliveryOutcome === "rescued"
                 ? "rescued"
-              : submit_verified === true
+              : submit_verified === true || opts.verify_submit !== true
                 ? "submitted"
                 : undefined,
       delivery_id: opts.delivery_id,
@@ -7765,7 +7786,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     }
   };
 
-  const startBackgroundDelivery = (record: DeliveryRecord) => {
+  type BackgroundDeliveryLifecycle = {
+    engine: AgentEngine;
+    agent_id: string;
+    text: string;
+    source_event: DeliveryEventType;
+  };
+
+  const startBackgroundDelivery = (
+    record: DeliveryRecord,
+    lifecycle?: BackgroundDeliveryLifecycle,
+  ) => {
     // Preserve the backend owner that accepted the asynchronous write. Reading
     // the observer after completion could attribute old-backend evidence to a
     // new backend that reused the same mutable ref.
@@ -7790,7 +7821,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           press_enter: record.press_enter,
           rename_to_task: record.rename_to_task,
           stableSurfaceIdentity: record.stableSurfaceIdentity,
-          source_event: "send_input",
+          source_event: lifecycle?.source_event ?? "send_input",
+          delivery_id: lifecycle ? record.delivery_id : undefined,
           verify_submit: record.verify_submit,
           beforeMutation: record.beforeMutation,
           onChunkDelivered: (sentChunks) => {
@@ -7800,6 +7832,52 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         record.submit_verified = delivery.submit_verified;
         record.retry_count = delivery.retry_count;
         finishDelivery(record, "delivered");
+        if (lifecycle) {
+          if (
+            delivery.delivery === "queued" ||
+            delivery.delivery === "queued_followup"
+          ) {
+            lifecycle.engine.acceptComposerQueue({
+              delivery_id: record.delivery_id,
+              agent_id: lifecycle.agent_id,
+              text: lifecycle.text,
+              press_enter: record.press_enter,
+              source_event: lifecycle.source_event,
+              retry_count: delivery.retry_count,
+              delivery_state: delivery.delivery,
+            });
+          } else if (delivery.delivery === "pending_verify") {
+            lifecycle.engine.acceptPendingVerify({
+              delivery_id: record.delivery_id,
+              agent_id: lifecycle.agent_id,
+              text: lifecycle.text,
+              press_enter: record.press_enter,
+              source_event: lifecycle.source_event,
+              retry_count: delivery.retry_count,
+            });
+          } else {
+            lifecycle.engine.resolveDelivery({
+              delivery_id: record.delivery_id,
+              agent_id: lifecycle.agent_id,
+              text: lifecycle.text,
+              press_enter: record.press_enter,
+              source_event: lifecycle.source_event,
+              delivery_state:
+                delivery.delivery === "rescued"
+                  ? "rescued"
+                  : delivery.delivery === "typed"
+                    ? "typed"
+                    : "submitted",
+              terminal: true,
+              retry_count: delivery.retry_count,
+              submit_verified: delivery.submit_verified,
+              error:
+                delivery.delivery === "rescued"
+                  ? "Prompt appeared only after an external interrupt"
+                  : null,
+            });
+          }
+        }
       } catch (error) {
         if (error instanceof SubmitVerificationError) {
           record.submit_verified = false;
@@ -7813,6 +7891,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const failedChunk =
           error instanceof DeliveryError ? error.failed_chunk : undefined;
         finishDelivery(record, "failed", message, failedChunk);
+        if (lifecycle) {
+          lifecycle.engine.resolveDelivery({
+            delivery_id: record.delivery_id,
+            agent_id: lifecycle.agent_id,
+            text: lifecycle.text,
+            press_enter: record.press_enter,
+            source_event: lifecycle.source_event,
+            delivery_state: "failed",
+            terminal: true,
+            retry_count: record.retry_count,
+            submit_verified: record.submit_verified,
+            error: message,
+          });
+        }
       }
     };
 
@@ -9711,6 +9803,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         const targetRecord = resolveLatestSurfaceAgentRecord(
           stateMgr,
           route.surface,
+          route.stableSurfaceIdentity,
         );
         // A public delivery_id is a promise that wait_for can resolve. Raw,
         // unmanaged surfaces have no lifecycle identity for the verifier, so
@@ -9736,7 +9829,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
           await route.assertCurrent();
           const record: DeliveryRecord = {
-            delivery_id: randomUUID(),
+            delivery_id: deliveryId ?? randomUUID(),
             surface: route.surface,
             workspace: route.workspace,
             status: "delivering",
@@ -9754,18 +9847,42 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             stableSurfaceIdentity: route.stableSurfaceIdentity,
             beforeMutation: route.assertCurrent,
           };
-          startBackgroundDelivery(record);
+          const receiptEngine = context.lifecycleSweepEngine;
+          const backgroundLifecycle =
+            targetRecord && receiptEngine
+              ? {
+                  engine: receiptEngine,
+                  agent_id: targetRecord.agent_id,
+                  text: sanitizedText,
+                  source_event: sourceEvent,
+                }
+              : undefined;
+          if (backgroundLifecycle) {
+            backgroundLifecycle.engine.registerExternalDelivery({
+              delivery_id: record.delivery_id,
+              agent_id: backgroundLifecycle.agent_id,
+              text: sanitizedText,
+              press_enter: args.press_enter,
+              source_event: sourceEvent,
+            });
+          }
+          startBackgroundDelivery(record, backgroundLifecycle);
+          const publicBackgroundDeliveryId =
+            backgroundLifecycle || sourceEvent !== "send_to"
+              ? record.delivery_id
+              : undefined;
 
           const identity = resolveTargetIdentity(
             stateMgr,
             route.surface,
             route.title,
+            route.stableSurfaceIdentity,
           );
           const data = {
             ...identity,
             ...buildPublicDeliveryReceipt({
               delivery_state: "queued",
-              delivery_id: record.delivery_id,
+              delivery_id: publicBackgroundDeliveryId,
               typed: false,
               submit_attempted: args.press_enter,
               submit_verified: record.submit_verified,
@@ -9779,7 +9896,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ...identity,
               delivered: false,
               pending: true,
-            }) + ` (background ${record.delivery_id})`,
+            }) +
+              (publicBackgroundDeliveryId
+                ? ` (background ${record.delivery_id})`
+                : " (background started; no wait_for receipt for unmanaged surface)"),
             data,
           );
         }
@@ -9851,7 +9971,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               press_enter: args.press_enter,
               source_event: "send_to",
               delivery_state:
-                delivery.delivery === "rescued" ? "rescued" : "submitted",
+                delivery.delivery === "rescued"
+                  ? "rescued"
+                  : delivery.delivery === "typed"
+                    ? "typed"
+                    : "submitted",
               terminal: true,
               retry_count: delivery.retry_count,
               submit_verified: delivery.submit_verified,
@@ -9867,6 +9991,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           stateMgr,
           route.surface,
           route.title,
+          route.stableSurfaceIdentity,
         );
         const data = {
           ...identity,
@@ -10044,6 +10169,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           stateMgr,
           route.surface,
           route.title,
+          route.stableSurfaceIdentity,
         );
         const data = {
           ...identity,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1073,7 +1073,7 @@ export function buildPublicDeliveryReceipt(input: {
     input.delivery_state === "pending_verify" ||
     input.delivery_state === "failed_confirmed"
       ? input.delivery_state
-      : input.delivery_state === "submitted"
+      : input.delivery_state === "submitted" && input.submit_verified === true
         ? "submitted"
         : undefined;
   const terminal =
@@ -6219,8 +6219,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? "pending_verify"
               : deliveryOutcome === "rescued"
                 ? "rescued"
-              : submit_verified === true || opts.verify_submit !== true
+              : submit_verified === true
                 ? "submitted"
+                : opts.verify_submit !== true
+                  ? "typed"
                 : undefined,
       delivery_id: opts.delivery_id,
       typed: bytes > 0,
@@ -6229,6 +6231,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       submit_evidence,
       retry_count,
       timings_ms: opts.timings,
+      WARNING:
+        opts.press_enter &&
+        submit_verified === null &&
+        opts.verify_submit !== true
+          ? "NOT VERIFIED — Return was dispatched, but submission was not verified; this receipt confirms only that text was typed."
+          : undefined,
     });
 
     if (
@@ -17062,6 +17070,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                       retry_count: delivery.retry_count,
                       submit_verified: false,
                       error: "Prompt appeared only after an external interrupt",
+                    })
+                : delivery.delivery === "typed"
+                  ? engine.resolveDelivery({
+                      delivery_id: deliveryId,
+                      agent_id: agentId,
+                      text: args.text,
+                      press_enter: args.press_enter,
+                      source_event: "send_to",
+                      delivery_state: "typed",
+                      terminal: true,
+                      retry_count: delivery.retry_count,
+                      submit_verified: null,
+                      error: null,
                     })
                 : delivery.delivery === "submitted"
                   ? engine.resolveDelivery({

--- a/src/server.ts
+++ b/src/server.ts
@@ -1003,6 +1003,7 @@ export interface PublicDeliveryReceipt {
   duplicate_of?: string;
   needs_attention?: boolean;
   attention_reason?: string;
+  timings_ms?: DeliveryPhaseTimings;
   observation?: {
     status: ParsedScreenResult["status"];
     composer_empty: boolean;
@@ -1010,6 +1011,35 @@ export interface PublicDeliveryReceipt {
     last_10_lines: string[];
   };
   WARNING?: string;
+}
+
+type DeliveryPhase = "route" | "lock" | "enumerate" | "type" | "verify";
+type DeliveryPhaseTimings = Record<DeliveryPhase, number>;
+
+function createDeliveryPhaseTimings(): DeliveryPhaseTimings {
+  return { route: 0, lock: 0, enumerate: 0, type: 0, verify: 0 };
+}
+
+function addDeliveryPhaseTiming(
+  timings: DeliveryPhaseTimings | undefined,
+  phase: DeliveryPhase,
+  startedAt: number,
+): void {
+  if (!timings) return;
+  timings[phase] += Math.max(0, Date.now() - startedAt);
+}
+
+async function timeDeliveryPhase<T>(
+  timings: DeliveryPhaseTimings | undefined,
+  phase: DeliveryPhase,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    return await operation();
+  } finally {
+    addDeliveryPhaseTiming(timings, phase, startedAt);
+  }
 }
 
 /**
@@ -1027,6 +1057,7 @@ export function buildPublicDeliveryReceipt(input: {
   retry_count: number;
   needs_attention?: boolean;
   attention_reason?: string | null;
+  timings_ms?: DeliveryPhaseTimings;
   observation?: PublicDeliveryReceipt["observation"];
   WARNING?: string;
 }): PublicDeliveryReceipt {
@@ -1069,6 +1100,7 @@ export function buildPublicDeliveryReceipt(input: {
             : {}),
         }
       : {}),
+    ...(input.timings_ms ? { timings_ms: { ...input.timings_ms } } : {}),
     ...(input.observation ? { observation: input.observation } : {}),
     ...(warning ? { WARNING: warning } : {}),
   };
@@ -5864,6 +5896,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     submit_verify_timeout_ms?: number;
     stableSurfaceIdentity?: string | null;
     beforeMutation?: () => Promise<void>;
+    timings?: DeliveryPhaseTimings;
   }): Promise<
     PublicDeliveryReceipt & {
       bytes: number;
@@ -5887,25 +5920,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : null;
       // sendKeyWithRetry throws when nothing reached the pane, so reaching the
       // next line is the dispatch evidence the receipt was missing (#484).
-      await sendKeyWithRetry(
-        opts.surface,
-        key,
-        opts.workspace,
-        opts.beforeMutation,
+      await timeDeliveryPhase(opts.timings, "type", () =>
+        sendKeyWithRetry(
+          opts.surface,
+          key,
+          opts.workspace,
+          opts.beforeMutation,
+        ),
       );
       const verification =
         submitAttempted && opts.verify_submit
-          ? await verifySubmitKeyOutcome({
-              surface: opts.surface,
-              workspace: opts.workspace,
-              baseline: submitBaseline,
-            })
+          ? await timeDeliveryPhase(opts.timings, "verify", () =>
+              verifySubmitKeyOutcome({
+                surface: opts.surface,
+                workspace: opts.workspace,
+                baseline: submitBaseline,
+              }),
+            )
           : { submit_verified: null, submit_verification_reason: null };
       const receipt = buildPublicDeliveryReceipt({
         typed: false,
         submit_attempted: submitAttempted,
         submit_verified: verification.submit_verified,
         retry_count: 0,
+        timings_ms: opts.timings,
         ...(submitAttempted && verification.submit_verified === null
           ? {
               WARNING:
@@ -5965,26 +6003,28 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       opts.chunks,
       deliveryBatches.length,
     );
-    for (const [index, batch] of deliveryBatches.entries()) {
-      await sendChunkWithRetry(
-        opts.surface,
-        batch.text,
-        {
-          workspace: opts.workspace,
-        },
-        batch.firstChunkNumber,
-        opts.chunks.length,
-        shouldPaste,
-        opts.source_event === "spawn_agent",
-        opts.beforeMutation,
-      );
-      for (const sentChunks of batch.deliveredChunkCounts) {
-        opts.onChunkDelivered?.(sentChunks);
+    await timeDeliveryPhase(opts.timings, "type", async () => {
+      for (const [index, batch] of deliveryBatches.entries()) {
+        await sendChunkWithRetry(
+          opts.surface,
+          batch.text,
+          {
+            workspace: opts.workspace,
+          },
+          batch.firstChunkNumber,
+          opts.chunks.length,
+          shouldPaste,
+          opts.source_event === "spawn_agent",
+          opts.beforeMutation,
+        );
+        for (const sentChunks of batch.deliveredChunkCounts) {
+          opts.onChunkDelivered?.(sentChunks);
+        }
+        if (index < deliveryBatches.length - 1) {
+          await delay(opts.chunk_delay_ms);
+        }
       }
-      if (index < deliveryBatches.length - 1) {
-        await delay(opts.chunk_delay_ms);
-      }
-    }
+    });
 
     const bytes = opts.chunks.reduce(
       (sum, chunk) => sum + Buffer.byteLength(chunk, "utf-8"),
@@ -6052,13 +6092,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               )
             : null;
         }
-        await delay(computeEnterDelayMs(bytes, opts.chunks.length));
-        await sendKeyWithRetry(
-          opts.surface,
-          "return",
-          opts.workspace,
-          opts.beforeMutation,
-        );
+        await timeDeliveryPhase(opts.timings, "type", async () => {
+          await delay(computeEnterDelayMs(bytes, opts.chunks.length));
+          await sendKeyWithRetry(
+            opts.surface,
+            "return",
+            opts.workspace,
+            opts.beforeMutation,
+          );
+        });
         appendDeliveryEvent({
           event_type: "press_enter",
           source_agent: opts.source_agent ?? null,
@@ -6069,25 +6111,30 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           retry_count,
         });
 
-        const verification = await verifySubmitAfterEnter({
-          surface: opts.surface,
-          workspace: opts.workspace,
-          text: submittedText,
-          bytes,
-          source_event: opts.source_event ?? "send_command",
-          source_agent: opts.source_agent,
-          verify_submit: opts.verify_submit ?? false,
-          allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
-          timeout_ms: opts.submit_verify_timeout_ms,
-          cursor_response_baseline: cursorResponseBaseline,
-          pre_type_screen: deliverySafetySnapshot?.text,
-          pre_return_screen: preReturnBootEvidence?.screenText,
-          pre_return_metrics: preReturnBootEvidence?.metrics,
-          require_attributable_submit_evidence:
-            requireObservedPayloadBeforeEnter,
-          require_working_status: opts.source_event === "boot_prompt",
-          beforeMutation: opts.beforeMutation,
-        });
+        const verification = await timeDeliveryPhase(
+          opts.timings,
+          "verify",
+          () =>
+            verifySubmitAfterEnter({
+              surface: opts.surface,
+              workspace: opts.workspace,
+              text: submittedText,
+              bytes,
+              source_event: opts.source_event ?? "send_command",
+              source_agent: opts.source_agent,
+              verify_submit: opts.verify_submit ?? false,
+              allow_recovery_enter_retry: opts.allow_recovery_enter_retry,
+              timeout_ms: opts.submit_verify_timeout_ms,
+              cursor_response_baseline: cursorResponseBaseline,
+              pre_type_screen: deliverySafetySnapshot?.text,
+              pre_return_screen: preReturnBootEvidence?.screenText,
+              pre_return_metrics: preReturnBootEvidence?.metrics,
+              require_attributable_submit_evidence:
+                requireObservedPayloadBeforeEnter,
+              require_working_status: opts.source_event === "boot_prompt",
+              beforeMutation: opts.beforeMutation,
+            }),
+        );
         submit_verified = verification.submit_verified;
         submit_evidence = verification.submit_evidence;
         submit_verification_reason = verification.submit_verification_reason;
@@ -6160,6 +6207,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       submit_verified,
       submit_evidence,
       retry_count,
+      timings_ms: opts.timings,
     });
 
     if (
@@ -9621,12 +9669,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.mutating,
     async (args) => {
       try {
+        const internalArgs = args as typeof args & {
+          _cmuxlayer_source_event?: DeliveryEventType;
+          _cmuxlayer_delivery_id?: string;
+          _cmuxlayer_timings?: DeliveryPhaseTimings;
+        };
         const sourceEvent =
-          (
-            args as typeof args & {
-              _cmuxlayer_source_event?: DeliveryEventType;
-            }
-          )._cmuxlayer_source_event ?? "send_input";
+          internalArgs._cmuxlayer_source_event ?? "send_input";
+        const requestedDeliveryId = internalArgs._cmuxlayer_delivery_id;
+        const timings = internalArgs._cmuxlayer_timings;
         assertInlineInputAllowed({
           tool: "send_input",
           arg: "text",
@@ -9650,15 +9701,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 chunkTerminalInput(sanitizedText, effectiveChunkSize),
               )
             : [sanitizedText];
-        const route = await resolveRawSurfaceMutationRoute(
-          args.surface,
-          args.workspace,
-          "send_input",
+        const route = await timeDeliveryPhase(timings, "enumerate", () =>
+          resolveRawSurfaceMutationRoute(
+            args.surface,
+            args.workspace,
+            "send_input",
+          ),
         );
         const targetRecord = resolveLatestSurfaceAgentRecord(
           stateMgr,
           route.surface,
         );
+        // A public delivery_id is a promise that wait_for can resolve. Raw,
+        // unmanaged surfaces have no lifecycle identity for the verifier, so
+        // keep their truthful queued receipt ID-free instead of exposing an
+        // orphaned handle.
+        const deliveryId = targetRecord ? requestedDeliveryId : undefined;
         assertInteractiveMultilineInputAllowed({
           tool: "send_input",
           value: args.text,
@@ -9726,9 +9784,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           );
         }
 
+        const lockStartedAt = Date.now();
         const delivery = await withSurfaceWrite(
           route.surface,
           async () => {
+            addDeliveryPhaseTiming(timings, "lock", lockStartedAt);
             await route.assertCurrent();
             return executeDeliveryEngine({
               surface: route.surface,
@@ -9740,8 +9800,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               rename_to_task: args.rename_to_task,
               stableSurfaceIdentity: route.stableSurfaceIdentity,
               source_event: sourceEvent,
+              delivery_id: deliveryId,
               verify_submit: shouldVerifySubmit,
               beforeMutation: route.assertCurrent,
+              timings,
             });
           },
           {
@@ -9751,6 +9813,55 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             stableSurfaceIdentity: route.stableSurfaceIdentity,
           },
         );
+
+        const receiptEngine = context.lifecycleSweepEngine;
+        if (
+          sourceEvent === "send_to" &&
+          deliveryId &&
+          targetRecord &&
+          receiptEngine
+        ) {
+          if (
+            delivery.delivery === "queued" ||
+            delivery.delivery === "queued_followup"
+          ) {
+            receiptEngine.acceptComposerQueue({
+              delivery_id: deliveryId,
+              agent_id: targetRecord.agent_id,
+              text: sanitizedText,
+              press_enter: args.press_enter,
+              source_event: "send_to",
+              retry_count: delivery.retry_count,
+              delivery_state: delivery.delivery,
+            });
+          } else if (delivery.delivery === "pending_verify") {
+            receiptEngine.acceptPendingVerify({
+              delivery_id: deliveryId,
+              agent_id: targetRecord.agent_id,
+              text: sanitizedText,
+              press_enter: args.press_enter,
+              source_event: "send_to",
+              retry_count: delivery.retry_count,
+            });
+          } else {
+            receiptEngine.resolveDelivery({
+              delivery_id: deliveryId,
+              agent_id: targetRecord.agent_id,
+              text: sanitizedText,
+              press_enter: args.press_enter,
+              source_event: "send_to",
+              delivery_state:
+                delivery.delivery === "rescued" ? "rescued" : "submitted",
+              terminal: true,
+              retry_count: delivery.retry_count,
+              submit_verified: delivery.submit_verified,
+              error:
+                delivery.delivery === "rescued"
+                  ? "Prompt appeared only after an external interrupt"
+                  : null,
+            });
+          }
+        }
 
         const identity = resolveTargetIdentity(
           stateMgr,
@@ -12293,9 +12404,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       allow_busy?: boolean;
       source_event: DeliveryEventType;
       delivery_id?: string;
+      timings?: DeliveryPhaseTimings;
     }) => {
-      await refreshManagedMetadataBestEffort(args.agent_id);
-      let route = await engine.resolveAgentIoRoute(args.agent_id);
+      const routeStartedAt = Date.now();
+      const enumerateStartedAt = args.timings?.enumerate ?? 0;
+      // Delivery already proves the UUID route from fresh topology and scans the
+      // one target TUI before mutation. A fleet-wide managed-metadata refresh
+      // here only queued the first send behind the startup sweep's lifecycle
+      // lock, adding 11-15 seconds without strengthening the route proof.
+      let route = await timeDeliveryPhase(args.timings, "enumerate", () =>
+        engine.resolveAgentIoRoute(args.agent_id),
+      );
       const requiresMutableRefGuards = !route.surface_uuid;
       // Guard against stale surface refs before sending. Registry refs drift
       // after a crash/respawn (a pane closes or is recycled), so a cached
@@ -12310,7 +12429,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // A UUID-less route is safe only if this check is newer than the
           // resolver that supplied its mutable ref.
           invalidateSurfaceTopologyCallScope(client as object);
-          const surfaces = await surfaceProvider();
+          const surfaces = await timeDeliveryPhase(
+            args.timings,
+            "enumerate",
+            surfaceProvider,
+          );
           return surfaces.length > 0
             ? new Set(surfaces.map((surface) => surface.ref))
             : null;
@@ -12327,14 +12450,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         isPositivelyStale(await liveSurfaceRefs(), route.surface_id)
       ) {
         discovery.invalidate();
-        await registry.listMerged(discovery, { force: true });
+        await timeDeliveryPhase(args.timings, "enumerate", () =>
+          registry.listMerged(discovery, { force: true }),
+        );
         invalidateSurfaceTopologyCallScope(client as object);
         // Re-resolve after the resync. The agent may have been evicted (its
         // surface vanished) or still point at a dead surface — either way,
         // refuse with a clear stale-ref error instead of misdelivering.
         let reresolved: typeof route | null;
         try {
-          reresolved = await engine.resolveAgentIoRoute(args.agent_id);
+          reresolved = await timeDeliveryPhase(args.timings, "enumerate", () =>
+            engine.resolveAgentIoRoute(args.agent_id),
+          );
         } catch {
           reresolved = null;
         }
@@ -12358,7 +12485,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // surface/command/key modes bypass this helper and remain available for
       // deliberate recovery.
       const assertAgentRouteHasTui = async (candidateRoute: typeof route) => {
-        const freshOccupant = await discovery.scanTarget(candidateRoute);
+        const freshOccupant = await timeDeliveryPhase(
+          args.timings,
+          "enumerate",
+          () => discovery.scanTarget(candidateRoute),
+        );
         if (
           freshOccupant &&
           !freshOccupant.read_error &&
@@ -12395,7 +12526,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           // Confirm against another target-scoped fresh read before refusing;
           // one parse alone can be transient, while a fleet-wide scan would
           // couple this route to unrelated pane churn.
-          const freshOccupant = await discovery.scanTarget(route);
+          const freshOccupant = await timeDeliveryPhase(
+            args.timings,
+            "enumerate",
+            () => discovery.scanTarget(route),
+          );
           if (isForeign(freshOccupant)) {
             throw new Error(
               `Agent "${args.agent_id}" (${expectedCli}) no longer occupies ` +
@@ -12465,13 +12600,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       // immediately before every chunk attempt and Return. Once any text has
       // landed, following a moved UUID would split one logical message across
       // terminals, so route changes fail closed instead.
-      route = await engine.resolveAgentIoRoute(args.agent_id);
+      route = await timeDeliveryPhase(args.timings, "enumerate", () =>
+        engine.resolveAgentIoRoute(args.agent_id),
+      );
       await assertAgentRouteHasTui(route);
       const deliveryRoute = route;
+      const routeElapsed = Math.max(0, Date.now() - routeStartedAt);
+      const enumerateElapsed = Math.max(
+        0,
+        (args.timings?.enumerate ?? 0) - enumerateStartedAt,
+      );
+      if (args.timings) {
+        args.timings.route += Math.max(0, routeElapsed - enumerateElapsed);
+      }
       const assertDeliveryRouteCurrent = async (): Promise<void> => {
         let current: typeof deliveryRoute;
         try {
-          current = await engine.resolveAgentIoRoute(args.agent_id);
+          current = await timeDeliveryPhase(args.timings, "enumerate", () =>
+            engine.resolveAgentIoRoute(args.agent_id),
+          );
         } catch {
           throw new Error(
             `Agent "${args.agent_id}" surface route changed during terminal ` +
@@ -12492,9 +12639,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
       };
 
+      const lockStartedAt = Date.now();
       return withSurfaceWrite(
         deliveryRoute.surface_id,
         async () => {
+          addDeliveryPhaseTiming(args.timings, "lock", lockStartedAt);
           await assertDeliveryRouteCurrent();
           const delivery = await executeDeliveryEngine({
             surface: deliveryRoute.surface_id,
@@ -12538,6 +12687,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ? BUSY_AGENT_SUBMIT_VERIFY_TIMEOUT_MS
               : shortPointerVerifyTimeoutMs,
             beforeMutation: assertDeliveryRouteCurrent,
+            timings: args.timings,
           });
           if (args.press_enter && delivery.submit_verified === true) {
             engine.markAgentWorking(args.agent_id);
@@ -16127,6 +16277,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               if (args.text === undefined) {
                 throw new Error("send_to mode=surface requires text");
               }
+              const deliveryId = randomUUID();
+              const timings = createDeliveryPhaseTimings();
               return legacyHandler("send_input")(
                 {
                   surface,
@@ -16138,6 +16290,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   rename_to_task: args.rename_to_task,
                   allow_long_inline: args.allow_long_inline,
                   _cmuxlayer_source_event: "send_to",
+                  _cmuxlayer_delivery_id: deliveryId,
+                  _cmuxlayer_timings: timings,
                 },
                 {},
               );
@@ -16588,6 +16742,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (!agentId) {
             throw new Error("send_to mode=agent requires agent_id or target");
           }
+          const timings = createDeliveryPhaseTimings();
           const targetAgent =
             engine.getAgentState(agentId) ?? registry.get(agentId);
           assertInteractiveMultilineInputAllowed({
@@ -16615,6 +16770,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 retry_count: duplicate.retry_count,
                 needs_attention: duplicate.needs_attention,
                 attention_reason: duplicate.attention_reason,
+                timings_ms: timings,
               }),
             };
             return okFormatted(
@@ -16650,6 +16806,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 submit_attempted: false,
                 submit_verified: receipt.submit_verified,
                 retry_count: receipt.retry_count,
+                timings_ms: timings,
                 WARNING: pausedTargetWarning(livePaused.source),
               }),
             };
@@ -16667,6 +16824,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               allow_busy: args.allow_busy,
               source_event: "send_to",
               delivery_id: deliveryId,
+              timings,
             });
           } catch (error) {
             // AIDEV-NOTE (F1): a RetryableDeliveryError is, by name and by the
@@ -16694,6 +16852,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   submit_attempted: false,
                   submit_verified: receipt.submit_verified,
                   retry_count: receipt.retry_count,
+                  timings_ms: timings,
                   WARNING: `Delivery is queued for retry, not delivered yet: ${error.message}`,
                 }),
               };
@@ -16739,6 +16898,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     : false,
                 submit_verified: failedReceipt.submit_verified,
                 retry_count: failedReceipt.retry_count,
+                timings_ms: timings,
               }),
             };
             throw error;
@@ -16801,6 +16961,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             submit_verified: delivery.submit_verified,
             submit_evidence: delivery.submit_evidence,
             retry_count: delivery.retry_count,
+            timings_ms: timings,
           });
           failedReceiptPayload = { ...publicReceipt };
           const evidence = await collectDeliveryEvidence(agentId);

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -113,6 +113,7 @@ class FakeClaudeSurfaceClient {
   readonly pane = "pane:1";
   readonly surface = "surface:agent";
   readonly title = "brainlayerClaude";
+  stableSurfaceIdentity: string | null = null;
   readonly sendCalls: string[] = [];
   readonly sendKeyCalls: string[] = [];
   readonly screenReads: string[] = [];
@@ -177,6 +178,9 @@ class FakeClaudeSurfaceClient {
       surfaces: [
         {
           ref: this.surface,
+          ...(this.stableSurfaceIdentity
+            ? { id: this.stableSurfaceIdentity }
+            : {}),
           title: this.title,
           type: "terminal",
           index: 0,
@@ -814,6 +818,112 @@ describe("enter reliability", () => {
 
     releaseLock();
     await held;
+  });
+
+  it("associates a recycled-ref surface receipt by stable UUID", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.stableSurfaceIdentity = "11111111-1111-4111-8111-111111111111";
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server, {
+      agent_id: "live-agent",
+      surface_uuid: client.stableSurfaceIdentity,
+      version: 1,
+    });
+    registerAgent(server, {
+      agent_id: "stale-agent",
+      surface_uuid: "22222222-2222-4222-8222-222222222222",
+      version: 99,
+    });
+
+    const result = await callTool(server, "send_to", {
+      mode: "surface",
+      surface: client.surface,
+      text: "stable receipt owner",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+    const waited = await callTool(server, "wait_for", {
+      delivery_id: parsed.delivery_id,
+      timeout_ms: 1_000,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parseResult(waited)).toMatchObject({
+      agent_id: "live-agent",
+      delivery_id: parsed.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+    });
+  });
+
+  it("returns a terminal typed receipt when surface mode does not press Enter", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      mode: "surface",
+      surface: client.surface,
+      text: "leave this in the composer",
+      press_enter: false,
+    });
+    const parsed = parseResult(result);
+    const waited = await callTool(server, "wait_for", {
+      delivery_id: parsed.delivery_id,
+      timeout_ms: 1_000,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      delivery: "typed",
+      delivery_state: "typed",
+      delivered: false,
+      terminal: true,
+      typed: true,
+      submit_attempted: false,
+    });
+    expect(parseResult(waited)).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      delivery_state: "typed",
+      terminal: true,
+      submit_verified: null,
+    });
+  });
+
+  it("registers background surface delivery IDs with wait_for", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await server._registeredTools.send_to.handler(
+      {
+        mode: "surface",
+        surface: client.surface,
+        text: "background receipt",
+        press_enter: true,
+        background: true,
+      },
+      {} as any,
+    );
+    const parsed = parseResult(result);
+    const waitedPromise = server._registeredTools.wait_for.handler(
+      { delivery_id: parsed.delivery_id, timeout_ms: 1_000 },
+      {} as any,
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    const waited = await waitedPromise;
+
+    expect(result.isError).not.toBe(true);
+    expect(parseResult(waited)).toMatchObject({
+      agent_id: "agent-1",
+      delivery_id: parsed.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+    });
   });
 
   it("bounds the first agent-mode send while the startup sweep holds the lifecycle lock", async () => {
@@ -1927,6 +2037,12 @@ describe("enter reliability", () => {
     );
 
     expect(parsed.ok).toBe(true);
+    expect(parsed.delivery_id).toBeUndefined();
+    expect(parsed.delivery).toBe("submitted");
+    expect(parsed.delivery_state).toBe("submitted");
+    expect(parsed.terminal).toBe(true);
+    expect(parsed.typed).toBe(true);
+    expect(parsed.submit_attempted).toBe(true);
     expect(parsed.submit_verified).toBeNull();
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -892,6 +892,43 @@ describe("enter reliability", () => {
     });
   });
 
+  it("resolves agent-mode composer-only delivery as terminal typed on the same ID", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.stableSurfaceIdentity = "11111111-1111-4111-8111-111111111111";
+    server = createReliabilityServer(client);
+    registerAgent(server, {
+      surface_uuid: client.stableSurfaceIdentity,
+    });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "leave this in the agent composer",
+      press_enter: false,
+    });
+    const parsed = parseResult(result);
+    const waited = await callTool(server, "wait_for", {
+      delivery_id: parsed.delivery_id,
+      timeout_ms: 1_000,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      delivery: "typed",
+      delivery_state: "typed",
+      terminal: true,
+      typed: true,
+      submit_attempted: false,
+      submit_verified: null,
+    });
+    expect(parseResult(waited)).toMatchObject({
+      agent_id: "agent-1",
+      delivery_id: parsed.delivery_id,
+      delivery_state: "typed",
+      terminal: true,
+      submit_verified: null,
+    });
+  });
+
   it("registers background surface delivery IDs with wait_for", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 1;
@@ -2038,12 +2075,13 @@ describe("enter reliability", () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.delivery_id).toBeUndefined();
-    expect(parsed.delivery).toBe("submitted");
-    expect(parsed.delivery_state).toBe("submitted");
+    expect(parsed.delivery).toBe("typed");
+    expect(parsed.delivery_state).toBe("typed");
     expect(parsed.terminal).toBe(true);
     expect(parsed.typed).toBe(true);
     expect(parsed.submit_attempted).toBe(true);
     expect(parsed.submit_verified).toBeNull();
+    expect(parsed.WARNING).toMatch(/NOT VERIFIED.*Return.*not verified/i);
     expect(parsed.retry_count).toBe(0);
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -816,6 +816,79 @@ describe("enter reliability", () => {
     await held;
   });
 
+  it("bounds the first agent-mode send while the startup sweep holds the lifecycle lock", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "idle" });
+    const engine = server._registeredTools["interact"]._engine;
+    let releaseLock!: () => void;
+    const held = engine.runLifecycleMutation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        }),
+      { label: "startup-sweep" },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    let settled = false;
+    const resultPromise = server._registeredTools.send_to
+      .handler(
+        {
+          agent_id: "agent-1",
+          text: "Read and follow /tmp/run5-first-send.md",
+          press_enter: true,
+        },
+        {} as any,
+      )
+      .then((result: any) => {
+        settled = true;
+        return result;
+      });
+    await vi.advanceTimersByTimeAsync(1_900);
+    const settledBeforeSweepRelease = settled;
+
+    releaseLock();
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await resultPromise;
+    await held;
+
+    expect(settledBeforeSweepRelease).toBe(true);
+    expect(result.isError).not.toBe(true);
+    expect(parseResult(result).submit_verified).toBe(true);
+  });
+
+  it.each([
+    ["agent", { agent_id: "agent-1" }],
+    ["surface", { mode: "surface", surface: "surface:agent" }],
+  ] as const)(
+    "returns lean phase timings for %s-mode send_to",
+    async (_mode, target) => {
+      const client = new FakeClaudeSurfaceClient();
+      client.requiredReturns = 1;
+      client.completionMode = "idle";
+      server = createReliabilityServer(client);
+      registerAgent(server, { state: "idle" });
+
+      const result = await callTool(server, "send_to", {
+        ...target,
+        text: "timed send",
+        press_enter: true,
+      });
+      const parsed = parseResult(result);
+
+      expect(parsed.timings_ms).toEqual({
+        route: expect.any(Number),
+        lock: expect.any(Number),
+        enumerate: expect.any(Number),
+        type: expect.any(Number),
+        verify: expect.any(Number),
+      });
+    },
+  );
+
   it("reports send_to input as still pending when the composer never clears", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.requiredReturns = 99;
@@ -1169,10 +1242,28 @@ describe("enter reliability", () => {
     expect(parsed.delivery).toBe("queued");
     expect(parsed.delivery_state).toBe("queued");
     expect(parsed.terminal).toBe(false);
+    expect(parsed.delivery_id).toEqual(expect.any(String));
     expect(parsed.submit_verified).toBeNull();
     expect(client.sendKeyCalls.filter((key) => key === "return")).toHaveLength(
       1,
     );
+
+    // Simulate Codex consuming its accepted follow-up, then let the real
+    // background verifier resolve the surface-mode receipt.
+    client.requiredReturns = 1;
+    await client.sendKey(client.surface, "return");
+    const engine = server._registeredTools["interact"]._engine;
+    await engine.verifyPendingDeliveries();
+    const waited = await callTool(server, "wait_for", {
+      delivery_id: parsed.delivery_id,
+      timeout_ms: 1_000,
+    });
+    expect(parseResult(waited)).toMatchObject({
+      delivery_id: parsed.delivery_id,
+      delivery_state: "submitted",
+      terminal: true,
+      submit_verified: true,
+    });
   }, 10_000);
 
   it("routes send_to_agent through the truthful queued receipt path", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -12871,14 +12871,14 @@ codex>
     expect(receipt).toMatchObject({
       delivery_id: expect.any(String),
       delivered: false,
-      terminal: false,
+      terminal: true,
       typed: true,
       submit_attempted: false,
       submit_verified: null,
       error: expect.stringContaining("post-delivery topology unavailable"),
     });
-    expect(receipt).not.toHaveProperty("delivery");
-    expect(receipt).not.toHaveProperty("delivery_state");
+    expect(receipt.delivery).toBe("typed");
+    expect(receipt.delivery_state).toBe("typed");
   });
 
   it("send_to omits evidence when a UUID-less row becomes foreign after delivery", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -850,7 +850,7 @@ describe("lean spawn tool responses", () => {
       title: "P5 live probe",
       cwd_receipt: {
         delivered: false,
-        terminal: false,
+        terminal: true,
         typed: true,
         submit_attempted: true,
         submit_verified: null,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3641,8 +3641,8 @@ describe("tool handler integration", () => {
       submit_attempted: true,
       submit_verified: null,
       retry_count: 0,
-      delivery: "submitted",
-      delivery_state: "submitted",
+      delivery: "typed",
+      delivery_state: "typed",
     });
     expect(receiptShape(keyResult)).toEqual({
       delivered: false,

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3221,6 +3221,7 @@ describe("tool handler integration", () => {
     stateMgr.writeState({
       agent_id: "bl-lead-1",
       surface_id: "surface:95",
+      surface_uuid: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       state: "idle",
       repo: "brainlayer",
       model: "Opus 4.8",
@@ -3318,7 +3319,8 @@ describe("tool handler integration", () => {
     );
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(data.delivered).toBe(false);
-    expect(data.terminal).toBe(false);
+    expect(data.terminal).toBe(true);
+    expect(data.delivery_state).toBe("typed");
     expect(data.typed).toBe(true);
     expect(data.submit_attempted).toBe(false);
     expect(data.surface).toBe("surface:95");
@@ -3342,7 +3344,8 @@ describe("tool handler integration", () => {
     );
     const data = result.structuredContent ?? JSON.parse(result.content[0].text);
     expect(data.delivered).toBe(false);
-    expect(data.terminal).toBe(false);
+    expect(data.terminal).toBe(true);
+    expect(data.delivery_state).toBe("typed");
     expect(data.typed).toBe(true);
     expect(data.submit_attempted).toBe(false);
     expect(data.surface).toBe("surface:unknown");
@@ -3419,6 +3422,7 @@ describe("tool handler integration", () => {
     stateMgr.writeState({
       agent_id: "codex-positive-1",
       surface_id: "surface:positive",
+      surface_uuid: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
       state: "idle",
       repo: "cmuxlayer",
       model: "GPT-5.5",
@@ -3632,11 +3636,13 @@ describe("tool handler integration", () => {
     expect(receiptShape(publicKeyResult)).toEqual(receiptShape(keyResult));
     expect(receiptShape(commandResult)).toEqual({
       delivered: false,
-      terminal: false,
+      terminal: true,
       typed: true,
       submit_attempted: true,
       submit_verified: null,
       retry_count: 0,
+      delivery: "submitted",
+      delivery_state: "submitted",
     });
     expect(receiptShape(keyResult)).toEqual({
       delivered: false,

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -266,7 +266,7 @@ describe("send_to consolidated modes", () => {
     expect(result.content[0].text).toContain("not submitted");
   });
 
-  it("returns a terminal unverified submission when raw surface Return was dispatched", async () => {
+  it("returns terminal typed truth when raw surface Return was unverified", async () => {
     const exec = makeExec();
     const server = createServer({
       exec,
@@ -290,8 +290,8 @@ describe("send_to consolidated modes", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_attempted).toBe(true);
     expect(parsed.submit_verified).toBeNull();
-    expect(parsed.delivery).toBe("submitted");
-    expect(parsed.delivery_state).toBe("submitted");
+    expect(parsed.delivery).toBe("typed");
+    expect(parsed.delivery_state).toBe("typed");
     expect(parsed.terminal).toBe(true);
     expect(parsed.delivered).toBe(false);
     expect(parsed.typed).toBe(true);

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -234,7 +234,7 @@ describe("send_to consolidated modes", () => {
     );
   });
 
-  it("does not claim a terminal submission when surface mode only types text", async () => {
+  it("returns a terminal typed state when surface mode only types text", async () => {
     const exec = makeExec();
     const server = createServer({
       exec,
@@ -257,16 +257,16 @@ describe("send_to consolidated modes", () => {
     expect(result.isError).toBeUndefined();
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_verified).toBeNull();
-    expect(parsed.delivery).not.toBe("submitted");
-    expect(parsed.delivery_state).not.toBe("submitted");
-    expect(parsed.terminal).not.toBe(true);
+    expect(parsed.delivery).toBe("typed");
+    expect(parsed.delivery_state).toBe("typed");
+    expect(parsed.terminal).toBe(true);
     expect(parsed.delivered).toBe(false);
     expect(parsed.typed).toBe(true);
     expect(result.content[0].text).toContain("typed into");
     expect(result.content[0].text).toContain("not submitted");
   });
 
-  it("does not claim a terminal submission when surface verification was skipped", async () => {
+  it("returns a terminal unverified submission when raw surface Return was dispatched", async () => {
     const exec = makeExec();
     const server = createServer({
       exec,
@@ -290,9 +290,9 @@ describe("send_to consolidated modes", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.submit_attempted).toBe(true);
     expect(parsed.submit_verified).toBeNull();
-    expect(parsed.delivery).not.toBe("submitted");
-    expect(parsed.delivery_state).not.toBe("submitted");
-    expect(parsed.terminal).not.toBe(true);
+    expect(parsed.delivery).toBe("submitted");
+    expect(parsed.delivery_state).toBe("submitted");
+    expect(parsed.terminal).toBe(true);
     expect(parsed.delivered).toBe(false);
     expect(parsed.typed).toBe(true);
     expect(result.content[0].text).toContain("submission attempted");
@@ -376,8 +376,9 @@ describe("consolidated compatibility", () => {
     expect(warn).not.toHaveBeenCalled();
     expect(parseResult(result)).toMatchObject({
       delivered: false,
-      terminal: false,
+      terminal: true,
       typed: true,
+      delivery_state: "typed",
     });
     const second = await server._registeredTools.send_input.handler(
       { surface: "surface:1", text: "legacy again", press_enter: false },


### PR DESCRIPTION
## Lead ruling — bounded fix

Exactly four items were changed:

1. Unmanaged raw Return now reports terminal `typed`, `submit_attempted:true`, `submit_verified:null`, and an explicit `NOT VERIFIED` warning. Unverified `submitted` is no longer admitted by the public receipt builder.
2. Agent-mode `press_enter:false` resolves the pre-registered delivery ID as terminal `typed`; immediate output and `wait_for(delivery_id)` agree.
3. The first-send benchmark uses an opt-in tokenized sweep barrier acknowledged only after the daemon sweep owns the lifecycle mutex. Reverted hot-path refresh: RED 3/3 at 4636.79, 4576.52, and 4609.70 ms. Head: GREEN 3/3 at 937.99, 981.42, and 955.04 ms.
4. Benchmark sockets use a short `~/.local/state/cmuxlayer/bench/b-*/` root; non-socket fixtures remain under `docs.local/scratch/run5r3`. A deliberately long checkout scratch path completed GREEN without `EADDRINUSE`.

## Verification at `4e33b837615feef6ffab96784875dc4e210c13a0`

- failing-first receipt lane: 2 expected failures before implementation; 2/2 passed after
- focused enter reliability: 53/53 passed
- full suite and pre-push hook: 145/145 files, 3,444 passed, 1 skipped
- `env -u CMUXLAYER_FORCE_INPROCESS bun run typecheck`: passed
- `CMUXLAYER_FORCE_INPROCESS=1 bun run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed
- local CodeRabbit was bounded to three minutes and returned no findings before timeout

The benchmark is an isolated fixture, not an installed-runtime or live-pane claim. This PR remains open and unmerged per the lead ruling.

— cmuxlayerCodex-61e67bf0 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-61e67bf0","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03b0d","ts":"2026-08-26T00:55:26Z"} -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct terminal “typed” delivery status for text entered without a verified submission.
  * Delivery receipts now include phase timing details for routing, locking, typing, verification, and related steps.
  * Improved delivery tracking for direct surface writes and stable surface identities.

* **Bug Fixes**
  * Delivery results now report successful submission only after verification.
  * Improved shutdown handling, timeout diagnostics, and cleanup during benchmark operations.

* **Tests**
  * Expanded coverage for delivery states, receipt ownership, timing metrics, startup behavior, and reliability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound first agent delivery latency via benchmark sweep hold
> - Introduces `holdBenchmarkSweepIfArmed` in `AgentEngine.runSweep` to pause lifecycle sweeps for up to 10 seconds when a benchmark hold file is armed, coordinating with the external benchmark daemon in [scripts/bench-daemon.mjs](https://github.com/EtanHey/cmuxlayer/pull/550/files#diff-9a2f627da9f66392eb44d26465a04a74bf3621166129eb444ffc33528f5381ec).
> - Adds the `"typed"` terminal delivery state for cases where text is entered but not submitted or not verified, replacing non-terminal or `delivered: true` outcomes in [src/server.ts](https://github.com/EtanHey/cmuxlayer/pull/550/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) and [src/agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/550/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5).
> - Tracks per-phase delivery durations (`timings_ms`) for route, lock, enumerate, type, and verify operations, exposing them in public receipts.
> - Adds `externally_managed` flag to `AgentDeliveryReceipt` so queued deliveries skip `AgentEngine.drainDeliveryQueue` auto-processing.
> - Risk: `delivered` now requires `delivery_state === "submitted"` and `submit_verified === true` in `buildPublicDeliveryReceipt`; callers expecting `delivered: true` for typed/unverified inputs will see `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e33b83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->