### PR TITLE
chore: release v0.4.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.63",
+  "version": "0.4.64",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Version bump for v0.4.64 (run 6: perf-budget CI, attested baseline, D123). Routed through a PR because the default-branch ruleset now requires `perf-budget` + `test` and refuses direct pushes (the gate working; rowed D128). After merge the lead tags v0.4.64 on the merge commit and bumps the formula.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no code or dependency updates.
> 
> **Overview**
> **Bumps the published package version** from `0.4.63` to `0.4.64` in `package.json` only.
> 
> No runtime, API, or dependency changes in this diff—it is a release bookkeeping PR (merge is expected to be followed by tagging and formula bump per the release process).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b009894658682bc56f85e7ca87ea63e724dfe2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version to 0.4.64
> Updates the `version` field in [package.json](https://github.com/EtanHey/cmuxlayer/pull/556/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 0.4.63 to 0.4.64.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b00989.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->