### PR TITLE
fix(launchd): prevent notifier broken-pipe failures

### DIFF
--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -343,7 +343,7 @@ notify_breach() {
     return 0
   fi
 
-  if post_error="$(curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
+  if post_error="$(curl -sS --fail --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
       -H 'Content-Type: application/json' \
       --data-binary "$payload" 2>&1 >/dev/null)"; then
     return 0

--- a/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/bin/cmux-memory-watchdog.sh
@@ -169,6 +169,14 @@ top_rss_offenders() {
   local limit="$CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT"
   local ps_output
 
+  if [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+    log "invalid top RSS limit: $limit"
+    return 1
+  fi
+  if (( 10#$limit == 0 )); then
+    return 0
+  fi
+
   if [[ -n "${CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE:-}" ]]; then
     ps_output="$(cat "$CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE")"
   else
@@ -186,7 +194,7 @@ top_rss_offenders() {
       print rss "\t" pid "\t" $0
     }' \
     | sort -rn \
-    | head -n "$limit" \
+    | sed -n "1,${limit}p" \
     | awk -F '\t' '{ printf "pid=%s rss_mb=%.0f command=%s\n", $2, $1 / 1024, $3 }'
 }
 
@@ -238,6 +246,9 @@ brain_store_breach() {
   local cmux_footprint_gb
   local compressor_gb
   local content
+  local payload
+  local send_error
+  local send_status
 
   cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
@@ -245,13 +256,24 @@ brain_store_breach() {
 
   if [[ ! -S "$CMUX_MEM_WATCHDOG_BRAINBAR_SOCK" ]]; then
     log "brainbar socket missing at $CMUX_MEM_WATCHDOG_BRAINBAR_SOCK"
-    return
+    return 0
   fi
 
-  jq -cn \
+  if ! payload="$(jq -cn \
     --arg content "$content" \
-    '{"jsonrpc":"2.0","id":"cmux-watchdog","method":"tools/call","params":{"name":"brain_store","arguments":{"content":$content,"project":"systems","tags":["cmux","watchdog","memory-leak"],"importance":8}}}' \
-    | socat - UNIX-CONNECT:"$CMUX_MEM_WATCHDOG_BRAINBAR_SOCK" >/dev/null
+    '{"jsonrpc":"2.0","id":"cmux-watchdog","method":"tools/call","params":{"name":"brain_store","arguments":{"content":$content,"project":"systems","tags":["cmux","watchdog","memory-leak"],"importance":8}}}')"; then
+    log "brainbar notification payload build failed"
+    return 0
+  fi
+
+  if send_error="$(socat - UNIX-CONNECT:"$CMUX_MEM_WATCHDOG_BRAINBAR_SOCK" \
+    <<<"$payload" 2>&1 >/dev/null)"; then
+    return 0
+  else
+    send_status="$?"
+    log "brainbar notification failed at $CMUX_MEM_WATCHDOG_BRAINBAR_SOCK (exit $send_status): ${send_error:-no error output}"
+    return 0
+  fi
 }
 
 notify_url_host_port() {
@@ -293,6 +315,9 @@ notify_breach() {
   local snapshot="$5"
   local cmux_footprint_gb
   local compressor_gb
+  local payload
+  local post_error
+  local post_status
 
   cmux_footprint_gb="$(bytes_to_gb "$cmux_footprint_bytes")"
   compressor_gb="$(bytes_to_gb "$vmstat_compressor_bytes_value")"
@@ -308,21 +333,29 @@ notify_breach() {
     return 0
   fi
 
-  jq -cn \
+  if ! payload="$(jq -cn \
     --arg title "cmux watchdog" \
     --arg body "cmux hit $cmux_footprint_gb GB phys_footprint / $compressor_gb GB compressed memory, tripped $tripped. Snapshot: $snapshot. Warning only; cmux was not terminated." \
     --arg source "$CMUX_MEM_WATCHDOG_SOURCE" \
     --arg priority "$CMUX_MEM_WATCHDOG_PRIORITY" \
-    '{title:$title,body:$body,source:$source,priority:$priority}' \
-    | curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
+    '{title:$title,body:$body,source:$source,priority:$priority}')"; then
+    log "notify payload build failed for $CMUX_MEM_WATCHDOG_NOTIFY_URL"
+    return 0
+  fi
+
+  if post_error="$(curl -sS --connect-timeout 1 --max-time 3 -X POST "$CMUX_MEM_WATCHDOG_NOTIFY_URL" \
       -H 'Content-Type: application/json' \
-      --data-binary @- >/dev/null 2>&1 || {
-        if ! notify_listener_available "$CMUX_MEM_WATCHDOG_NOTIFY_URL"; then
-          log "notify listener unavailable at $host:$port; skipping notification"
-        else
-          log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL"
-        fi
-      }
+      --data-binary "$payload" 2>&1 >/dev/null)"; then
+    return 0
+  else
+    post_status="$?"
+    if ! notify_listener_available "$CMUX_MEM_WATCHDOG_NOTIFY_URL"; then
+      log "notify listener unavailable at $host:$port; skipping notification after post failure (exit $post_status): ${post_error:-no error output}"
+    else
+      log "notify post failed at $CMUX_MEM_WATCHDOG_NOTIFY_URL (exit $post_status): ${post_error:-no error output}"
+    fi
+    return 0
+  fi
 }
 
 handle_breach() {

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -443,8 +443,34 @@ PY
   [[ -f "$brainbar_ready" && -S "$brainbar_sock" ]] \
     || fail "early-close BrainBar listener did not become ready"
 
+  cat >"$root_dir/bin/socat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+socket_path="${*: -1}"
+socket_path="${socket_path#UNIX-CONNECT:}"
+python3 -c '
+import socket
+import sys
+import time
+
+payload = sys.stdin.buffer.read()
+client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+client.connect(sys.argv[1])
+time.sleep(0.1)
+try:
+    client.sendall(payload)
+except (BrokenPipeError, ConnectionResetError) as error:
+    print(f"early-close socket send failed: {error}", file=sys.stderr)
+    sys.exit(1)
+finally:
+    client.close()
+' "$socket_path"
+EOF
+  chmod +x "$root_dir/bin/socat"
+
   export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
   export CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="$brainbar_sock"
+  export PATH="$root_dir/bin:$PATH"
   # Exceed the pipe buffer so jq is still producing when the peer closes.
   large_value="$(awk 'BEGIN { for (i = 0; i < 98304; i++) printf "x" }')"
 
@@ -489,7 +515,6 @@ exit 0
 EOF
   chmod +x "$root_dir/bin/nc"
   export CMUX_MEM_WATCHDOG_NOTIFY_URL="http://127.0.0.1:$notify_port/notify"
-  export PATH="$root_dir/bin:$PATH"
   if notify_breach 4242 footprint 1073741824 4294967296 "$large_value" \
     2>>"$stderr_log"; then
     notify_status=0

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -471,7 +471,8 @@ EOF
   export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
   export CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="$brainbar_sock"
   export PATH="$root_dir/bin:$PATH"
-  # Exceed the pipe buffer so jq is still producing when the peer closes.
+  # Keep the payload larger than a typical pipe buffer while the test transport
+  # fully drains stdin before attempting the deliberately closed socket.
   large_value="$(awk 'BEGIN { for (i = 0; i < 98304; i++) printf "x" }')"
 
   # shellcheck disable=SC1090
@@ -533,6 +534,84 @@ EOF
   rm -rf "$root_dir"
 )
 run_early_close_notifiers_case
+
+# Environment changes are intentionally isolated from the remaining cases.
+# shellcheck disable=SC2030,SC2031
+run_notify_http_error_case() (
+  local repo_root scratch_root root_dir stderr_log port_file server_pid port status
+  repo_root="$(cd "$ROOT_DIR/../.." && pwd)"
+  scratch_root="$repo_root/docs.local/scratch/hotfix-launchd"
+  mkdir -p "$scratch_root"
+  root_dir="$(mktemp -d "$scratch_root/http-error.XXXXXX")"
+  stderr_log="$root_dir/stderr.log"
+  port_file="$root_dir/notify.port"
+  mkdir -p "$root_dir/bin"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
+
+  python3 - "$port_file" <<'PY' &
+import socket
+import sys
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen(1)
+with open(sys.argv[1], "w") as port_file:
+    port_file.write(str(server.getsockname()[1]))
+connection, _ = server.accept()
+request = b""
+while b"\r\n\r\n" not in request:
+    request += connection.recv(4096)
+headers, body = request.split(b"\r\n\r\n", 1)
+content_length = 0
+for header in headers.split(b"\r\n"):
+    if header.lower().startswith(b"content-length:"):
+        content_length = int(header.split(b":", 1)[1].strip())
+while len(body) < content_length:
+    body += connection.recv(4096)
+connection.sendall(
+    b"HTTP/1.1 503 Service Unavailable\r\n"
+    b"Content-Length: 0\r\n"
+    b"Connection: close\r\n\r\n"
+)
+connection.close()
+server.close()
+PY
+  server_pid="$!"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$port_file" ]] && break
+    /bin/sleep 0.1
+  done
+  [[ -s "$port_file" ]] || fail "HTTP error listener did not become ready"
+  port="$(<"$port_file")"
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_NOTIFY_URL="http://127.0.0.1:$port/notify"
+  export PATH="$root_dir/bin:$PATH"
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  if notify_breach 4242 footprint 1073741824 4294967296 \
+    "$root_dir/snapshot.log" 2>"$stderr_log"; then
+    status=0
+  else
+    status="$?"
+  fi
+  wait "$server_pid"
+
+  assert_eq "0" "$status"
+  assert_file_contains "$stderr_log" "notify post failed"
+  assert_file_contains "$stderr_log" "exit 22"
+
+  printf 'PASS: watchdog logs HTTP error responses as warning-only notification failures\n'
+  rm -rf "$root_dir"
+)
+run_notify_http_error_case
 
 # Matcher coverage regression guard (2026-06-09): the PID matcher must catch
 # BOTH cmux bundles — stable "cmux.app" AND nightly "cmux NIGHTLY.app". The old

--- a/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
+++ b/launchd/cmux-memory-watchdog/tests/cmux-memory-watchdog.sh
@@ -244,7 +244,7 @@ run_case() {
     assert_file_contains "$log_dir/socat.log" "UNIX-CONNECT:$brainbar_sock"
     assert_file_contains "$log_dir/stderr.log" "breached memory thresholds"
     assert_file_missing_or_empty "$log_dir/kill.log"
-    snapshot="$(find "$log_dir" -type f -name '20*.log' | head -n 1)"
+    snapshot="$(find "$log_dir" -type f -name '20*.log' -print -quit)"
     if [[ -n "$expected_signals" ]]; then
       assert_file_contains "$snapshot" "breached_signals=$expected_signals"
     fi
@@ -400,6 +400,115 @@ EOF
 }
 run_notify_reprobe_after_post_failure_case
 
+# Environment changes are intentionally isolated from the remaining cases.
+# shellcheck disable=SC2030,SC2031
+run_early_close_notifiers_case() (
+  local repo_root scratch_root root_dir log_dir stderr_log
+  local brainbar_sock brainbar_ready brainbar_pid brainbar_status
+  local notify_port_file notify_pid notify_port notify_status large_value
+  repo_root="$(cd "$ROOT_DIR/../.." && pwd)"
+  scratch_root="$repo_root/docs.local/scratch/hotfix-launchd"
+  mkdir -p "$scratch_root"
+  root_dir="$(mktemp -d "$scratch_root/early-close.XXXXXX")"
+  log_dir="$root_dir/logs"
+  stderr_log="$log_dir/stderr.log"
+  mkdir -p "$root_dir/bin" "$log_dir"
+
+  cd "$repo_root"
+  brainbar_sock="${root_dir#"$repo_root/"}/brainbar.sock"
+  brainbar_ready="$root_dir/brainbar.ready"
+  python3 - "$brainbar_sock" "$brainbar_ready" <<'PY' &
+import os
+import socket
+import sys
+
+socket_path, ready_path = sys.argv[1:]
+try:
+    os.unlink(socket_path)
+except FileNotFoundError:
+    pass
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+server.listen(1)
+open(ready_path, "w").close()
+connection, _ = server.accept()
+connection.close()
+server.close()
+PY
+  brainbar_pid="$!"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -f "$brainbar_ready" && -S "$brainbar_sock" ]] && break
+    /bin/sleep 0.1
+  done
+  [[ -f "$brainbar_ready" && -S "$brainbar_sock" ]] \
+    || fail "early-close BrainBar listener did not become ready"
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_BRAINBAR_SOCK="$brainbar_sock"
+  # Exceed the pipe buffer so jq is still producing when the peer closes.
+  large_value="$(awk 'BEGIN { for (i = 0; i < 98304; i++) printf "x" }')"
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  if brain_store_breach 4242 1073741824 4294967296 \
+    "$root_dir/snapshot.log" "$large_value" footprint 2>>"$stderr_log"; then
+    brainbar_status=0
+  else
+    brainbar_status="$?"
+  fi
+  wait "$brainbar_pid"
+
+  notify_port_file="$root_dir/notify.port"
+  python3 - "$notify_port_file" <<'PY' &
+import socket
+import sys
+
+port_path = sys.argv[1]
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen(1)
+with open(port_path, "w") as port_file:
+    port_file.write(str(server.getsockname()[1]))
+connection, _ = server.accept()
+connection.close()
+server.close()
+PY
+  notify_pid="$!"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [[ -s "$notify_port_file" ]] && break
+    /bin/sleep 0.1
+  done
+  [[ -s "$notify_port_file" ]] || fail "early-close HTTP listener did not become ready"
+  notify_port="$(<"$notify_port_file")"
+
+  cat >"$root_dir/bin/nc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod +x "$root_dir/bin/nc"
+  export CMUX_MEM_WATCHDOG_NOTIFY_URL="http://127.0.0.1:$notify_port/notify"
+  export PATH="$root_dir/bin:$PATH"
+  if notify_breach 4242 footprint 1073741824 4294967296 "$large_value" \
+    2>>"$stderr_log"; then
+    notify_status=0
+  else
+    notify_status="$?"
+  fi
+  wait "$notify_pid"
+
+  assert_eq "0" "$brainbar_status"
+  assert_eq "0" "$notify_status"
+  assert_file_contains "$stderr_log" "brainbar notification failed"
+  assert_file_contains "$stderr_log" "notify post failed"
+  assert_file_not_contains "$stderr_log" "jq: error"
+
+  printf 'PASS: notifier transports are warning-only when peers close before reading\n'
+  rm -rf "$root_dir"
+)
+run_early_close_notifiers_case
+
 # Matcher coverage regression guard (2026-06-09): the PID matcher must catch
 # BOTH cmux bundles — stable "cmux.app" AND nightly "cmux NIGHTLY.app". The old
 # `cmux\.app` pattern silently skipped nightly, so a nightly-only fleet (the
@@ -432,6 +541,8 @@ run_matcher_coverage() {
 }
 run_matcher_coverage
 
+# The preceding notifier case is a subshell, so its exports cannot affect this case.
+# shellcheck disable=SC2031
 run_ps_fallback_case() {
   local root_dir log_dir snapshot brainbar_sock brainbar_pid
   root_dir="$(mktemp -d)"
@@ -470,7 +581,7 @@ EOF
 
   assert_file_missing_or_empty "$log_dir/kill.log"
   assert_file_contains "$log_dir/socat.log" "UNIX-CONNECT:$brainbar_sock"
-  snapshot="$(find "$log_dir" -type f -name '20*.log' | head -n 1)"
+  snapshot="$(find "$log_dir" -type f -name '20*.log' -print -quit)"
   assert_file_contains "$snapshot" "breached_signals=footprint"
 
   printf 'PASS: watchdog falls back to ps command discovery when pgrep misses GUI apps\n'
@@ -518,7 +629,7 @@ EOF
   run_once
 
   assert_file_missing_or_empty "$log_dir/kill.log"
-  snapshot="$(find "$log_dir" -type f -name '20*.log' | head -n 1)"
+  snapshot="$(find "$log_dir" -type f -name '20*.log' -print -quit)"
   assert_file_contains "$snapshot" "[top_rss_offenders]"
   assert_file_contains "$snapshot" "command=python3.11"
   assert_file_contains "$snapshot" "command=ugrep"
@@ -527,6 +638,39 @@ EOF
   rm -rf "$root_dir"
 }
 run_top_rss_offenders_case
+
+run_top_rss_limit_validation_case() (
+  local root_dir output status stderr_log
+  root_dir="$(mktemp -d)"
+  stderr_log="$root_dir/stderr.log"
+  cat >"$root_dir/top-ps.fixture" <<'EOF'
+  PID   RSS COMM
+ 9001 2097152 python3.11
+EOF
+
+  export CMUX_MEM_WATCHDOG_SOURCE_ONLY=1
+  export CMUX_MEM_WATCHDOG_PS_TOP_FIXTURE="$root_dir/top-ps.fixture"
+  export CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT=0
+  # shellcheck disable=SC1090
+  source "$SCRIPT_PATH"
+  if output="$(top_rss_offenders 2>"$stderr_log")"; then
+    status=0
+  else
+    status="$?"
+  fi
+  assert_eq "0" "$status"
+  assert_eq "" "$output"
+
+  CMUX_MEM_WATCHDOG_TOP_RSS_LIMIT=invalid
+  if top_rss_offenders 2>"$stderr_log"; then
+    fail "invalid watchdog top-RSS limit unexpectedly succeeded"
+  fi
+  assert_file_contains "$stderr_log" "invalid top RSS limit"
+
+  printf 'PASS: watchdog top RSS limit accepts zero and rejects invalid values\n'
+  rm -rf "$root_dir"
+)
+run_top_rss_limit_validation_case
 
 run_installer_plist_lint_case() {
   local root_dir rendered

--- a/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/bin/cmux-ram-sampler.sh
@@ -496,6 +496,15 @@ nearcrash_reason() {
 }
 
 top_rss_offenders_json() {
+  if [[ ! "$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT" =~ ^[0-9]+$ ]]; then
+    log "invalid top RSS limit: $CMUX_RAM_SAMPLER_TOP_RSS_LIMIT"
+    return 1
+  fi
+  if (( 10#$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT == 0 )); then
+    printf '[]\n'
+    return 0
+  fi
+
   ps -axo pid=,rss=,command= 2>/dev/null | awk -v limit="$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT" '
     NF >= 3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {
       pid = $1
@@ -504,7 +513,7 @@ top_rss_offenders_json() {
       $2 = ""
       sub(/^[[:space:]]+/, "", $0)
       printf "%s\t%s\t%s\n", rss, pid, $0
-    }' | sort -rn | head -n "$CMUX_RAM_SAMPLER_TOP_RSS_LIMIT" | jq -Rs '
+    }' | sort -rn | sed -n "1,${CMUX_RAM_SAMPLER_TOP_RSS_LIMIT}p" | jq -Rs '
       split("\n")[:-1]
       | map(split("\t") | {pid:(.[1]|tonumber),rss_mb:((.[0]|tonumber / 1024)|floor),command:.[2]})'
 }

--- a/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
+++ b/launchd/cmux-ram-sampler/tests/cmux-ram-sampler.sh
@@ -782,6 +782,40 @@ run_plist_case() {
   printf 'PASS: sampler launchd plist is armable with expected structure\n'
 }
 
+run_top_rss_limit_validation_case() (
+  local root_dir output status stderr_log
+  root_dir="$(mktemp -d)"
+  stderr_log="$root_dir/stderr.log"
+  mkdir -p "$root_dir/bin"
+  cat >"$root_dir/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '9001 2097152 python3.11\n'
+EOF
+  chmod +x "$root_dir/bin/ps"
+
+  export CMUX_RAM_SAMPLER_SOURCE_ONLY=1
+  export CMUX_RAM_SAMPLER_TOP_RSS_LIMIT=0
+  export PATH="$root_dir/bin:$PATH"
+  source_sampler
+  if output="$(top_rss_offenders_json 2>"$stderr_log")"; then
+    status=0
+  else
+    status="$?"
+  fi
+  assert_eq "0" "$status"
+  assert_eq "[]" "$output"
+
+  CMUX_RAM_SAMPLER_TOP_RSS_LIMIT=invalid
+  if top_rss_offenders_json 2>"$stderr_log"; then
+    fail "invalid sampler top-RSS limit unexpectedly succeeded"
+  fi
+  assert_file_contains "$stderr_log" "invalid top RSS limit"
+
+  printf 'PASS: sampler top RSS limit accepts zero and rejects invalid values\n'
+  rm -rf "$root_dir"
+)
+
 run_vmstat_page_size_case
 run_routine_high_records_without_alert_case
 run_nearcrash_routed_alert_edge_case
@@ -798,3 +832,4 @@ run_plist_case
 run_prediction_case
 run_sampling_case
 run_ps_fallback_sampling_case
+run_top_rss_limit_validation_case


### PR DESCRIPTION
## Summary
- build BrainBar and HTTP notification JSON completely before opening a closable transport reader
- make the test harness fully consume notifier input before simulating an early-closing peer
- detect UNIX transport and HTTP 4xx/5xx failures explicitly, log the exact failure, and return zero only through the documented warning-only branch
- replace launchd producer-to-closable-reader pipelines with full-reading `sed` and direct `find -quit` paths
- preserve zero-limit top-RSS behavior and reject invalid limits

## Local RED proof

Before the production fix, the deterministic early-close test was RED:

```text
FAIL: expected '0', got '1'
socat[...] E write(...): Broken pipe
```

The local rightmost failing stage was `socat` (exit 1); main CI run 32947241895 exposed the same cause through the upstream `jq` writer (exit 2).

The review edge cases were independently RED before their fixes:

```text
FAIL: expected '', got 'pid=9001 rss_mb=2048 command=python3.11'
FAIL: expected '[]', got '[ ... python3.11 ... ]'
FAIL: expected 'notify post failed' in .../stderr.log
```

The final RED is from a real local HTTP 503 response before `curl --fail` was added.

## Local GREEN proof

```text
PASS: notifier transports are warning-only when peers close before reading
PASS: watchdog logs HTTP error responses as warning-only notification failures
PASS: watchdog top RSS limit accepts zero and rejects invalid values
PASS: sampler top RSS limit accepts zero and rejects invalid values
FIVE_RUNS_GREEN iterations=5 suites_per_iteration=4 total_suite_runs=20
```

Final improvement gates:

```text
launcher registry absent: typecheck exit 0; 152/152 files, 3484 passed, 1 skipped
launcher registry present: typecheck exit 0; 152/152 files, 3484 passed, 1 skipped
pre-push exact-head suite: 152/152 files, 3484 passed, 1 skipped
ShellCheck: exit 0, no findings
daemon performance budget: GREEN (38.78% reduction)
```

A local CodeRabbit review returned 0 findings before the final HTTP-response follow-up. The subsequent review was rate-limited; the repository's red/blue fallback was completed against the final diff with no HIGH/MEDIUM findings. This is recorded as a skipped fresh automated review, not as review-green.

No `launchctl`, install, benchmark edit, `|| true`, or blanket suppression was used.

## Exact-head CI

Head: `40fdf27c88f65e8c08d1bf833cf675d23b803b8e`

- [launchd-units: PASS (15s)](https://github.com/EtanHey/cmuxlayer/actions/runs/32953754271/job/98130770396)
- [full test: PASS (4m1s)](https://github.com/EtanHey/cmuxlayer/actions/runs/32953754271/job/98130770397)
- [perf-budget: PASS (1m1s)](https://github.com/EtanHey/cmuxlayer/actions/runs/32953754271/job/98130770676)
- launcher-parity absent/present: PASS
- build-site and Macroscope correctness: PASS

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03d2b","ts":"2026-08-26T09:39:14Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational shell scripts only; notification failures are intentionally swallowed (return 0) so launchd jobs keep running, with broader logging on delivery errors.
> 
> **Overview**
> Fixes launchd memory tooling that could exit non-zero when BrainBar/HTTP peers closed early or when `jq`/`socat`/`curl` ran in fragile pipelines.
> 
> **cmux-memory-watchdog** now builds notification JSON in variables before `socat` or `curl --fail`, logs transport/HTTP failures (including exit status), and always returns success so breach handling stays warn-only. **Top RSS** collection validates numeric limits (zero disables output; invalid values error), and `head -n` is replaced with `sed` so limit `0` does not still emit rows.
> 
> **cmux-ram-sampler** gets the same top-RSS limit validation and `sed` cap for `top_rss_offenders_json`.
> 
> Tests add early-close BrainBar/HTTP scenarios, HTTP 503 notify failure logging, limit-validation cases, and use `find … -print -quit` for snapshot discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fdf27c88f65e8c08d1bf833cf675d23b803b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken-pipe failures in `brain_store_breach` and `notify_breach` notifiers
> - `brain_store_breach` and `notify_breach` build JSON payloads first, then send via `socat` or `curl --fail`. Transport and payload failures are now logged and return success instead of propagating errors.
> - `top_rss_offenders` and `top_rss_offenders_json` validate their limit variables as non-negative integers, returning success on zero. Replaces `head -n` with `sed -n` to avoid broken pipes.
> - Behavioral Change: Notifiers return `0` on missing socket, payload build failure, or send failure instead of nonzero. `top_rss_offenders` exits `1` for non-numeric limits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40fdf27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory monitoring reliability when collecting and reporting top RSS processes.
  - RSS limits are now validated consistently; setting the limit to zero disables RSS collection, while invalid values are rejected.
  - BrainBar and HTTP notifications now remain warn-only when delivery fails, preventing monitoring tasks from stopping unexpectedly.
  - Improved handling of unavailable notification listeners and reporting of delivery errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
