### PR TITLE
chore: release v0.4.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.64",
+  "version": "0.4.65",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Automated version-bump PR for cmuxlayer v0.4.65. The release tag is created only after required checks pass and this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field version bump in package metadata with no runtime or behavioral code changes.
> 
> **Overview**
> **Automated release bump** for `cmuxlayer`: updates `package.json` **version** from `0.4.64` to `0.4.65`. No source, dependency, or script changes in this diff—the tag ships after checks pass and this PR merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814a60dcc26b278eb72099911d95730519866f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.4.65
> Bumps the version field in [package.json](https://github.com/EtanHey/cmuxlayer/pull/561/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 0.4.64 to 0.4.65. This is a manifest-only release chore with no code changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 814a60d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.4.65.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->