### PR TITLE
docs: align public tool and release truth

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -24,7 +24,7 @@ enabled = true
   [analyzers.meta]
   dialect = "typescript"
   module_system = "es-modules"
-  environment = ["nodejs"]
+  environment = ["nodejs", "browser"]
   plugins = ["react"]
 
 [[analyzers]]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cmuxLayer
 
-**Your AI agents can't see each other's terminals.** One runs in tab 1, another in tab 2 — and you're the clipboard between them. cmuxLayer fixes that with a focused 10-tool public MCP surface for terminal workspaces.
+cmuxLayer exposes a 10-tool public MCP surface for controlling cmux terminal workspaces and managing CLI agents.
 
 <p align="center">
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
@@ -11,17 +11,16 @@
 [![MCP Tools](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
 [![Tests](https://img.shields.io/badge/tests-3023%20passing-brightgreen.svg)](#testing)
 
-## Quick Start
+## Quick start
 
 ```bash
 brew install etanhey/layers/cmuxlayer       # stable, pinned release
 brew install --HEAD etanhey/layers/cmuxlayer # or: dogfood the latest main
 ```
 
-This installs the `cmuxlayer` command (plus `cmuxlayer-app-server` /
-`cmuxlayer-proxy`). Requires [cmux](https://github.com/manaflow-ai/cmux) to be
-running. For how the golem fleet wires, versions, and dogfoods it — and the
-`CMUX_SOCKET_PATH` instance pin — see
+This installs the `cmuxlayer` command plus `cmuxlayer-app-server` and
+`cmuxlayer-proxy`. [cmux](https://github.com/manaflow-ai/cmux) must be running.
+For fleet wiring, versions, dogfooding, and the `CMUX_SOCKET_PATH` pin, see
 [docs/releases-and-brew.md](docs/releases-and-brew.md).
 
 Then set up this machine:
@@ -30,35 +29,31 @@ Then set up this machine:
 cmuxlayer init
 ```
 
-The wizard asks which repositories agents may be spawned in, whether cmuxlayer
-should call per-repo shell launcher functions or the agent CLIs directly, and
-whether agents run unattended or stop to ask for tool approval. It writes the
-config those answers produce (`~/.config/cmuxlayer/env.sh`, plus a launcher
-registry in launcher mode), which cmuxlayer reads at startup — so a GUI-launched
-MCP client gets the same configuration as a terminal one, without sourcing
-anything. It never rewrites an existing file without asking, and backs one up
-before it does.
-`--yes` with `--repo <name>=<path>` does the same non-interactively for scripted
-installs. Nothing else in cmuxlayer assumes a particular directory layout — see
+The wizard selects spawnable repositories, per-repo launchers or direct CLI
+launches, and approval behavior. It writes `~/.config/cmuxlayer/env.sh` and, in
+launcher mode, a launcher registry. cmuxlayer reads both at startup, including
+when an MCP client starts it from a GUI. The wizard asks before replacing a file
+and creates a backup first.
+
+For scripted installs, pass `--yes` with `--repo <name>=<path>`. cmuxlayer does
+not assume a fixed repository layout. See
 [docs/fresh-install.md](docs/fresh-install.md) for the walkthrough and
 [docs/registry-optional-spawn.md](docs/registry-optional-spawn.md) for how each
 lane behaves.
 
 ### Optional fleet sidebar
 
-The lane-grouped fleet view is opt-in. Install its fallback file with:
+Install the optional lane-grouped fleet view with:
 
 ```bash
 bun run install:fleet-sidebar
 ```
 
-cmuxLayer then refreshes `~/.config/cmux/sidebars/fleet.swift` from its
-reconciled live-agent snapshot. It does not change cmux settings or replace the
-stock sidebar. To activate it, right-click the sidebar toggle and choose
-`fleet`; choose the stock entry there whenever you want the fallback UI.
+cmuxLayer refreshes `~/.config/cmux/sidebars/fleet.swift` from its reconciled
+live-agent snapshot. It does not change cmux settings or replace the stock
+sidebar. Activate it from the sidebar toggle by choosing `fleet`.
 
-Development and screenshot QA use a separate picker entry and never publish to
-the live `fleet.swift` path:
+Development and screenshot QA use a separate picker entry:
 
 ```bash
 bun run install:fleet-sidebar:dev
@@ -100,15 +95,15 @@ When unset or blank, the signed 10-tool thin-core default applies. When set, the
 environment value overrides that default for the session. Unknown names are
 warned and ignored while valid names still load.
 
-Autonomous prompt resolution is experimental and disabled by default. With the
-default policy, cmuxlayer still detects prompt choosers, marks the agent
-`blocked_on_prompt`, and escalates without sending any key. Setting
+Autonomous prompt resolution is experimental and disabled by default.
+cmuxlayer detects prompt choosers, marks the agent `blocked_on_prompt`, and
+escalates without sending a key. Setting
 `CMUXLAYER_EXPERIMENTAL_PROMPT_AUTO_RESOLVE=1` restores the known-imperfect
 Escape-based resolver for isolated testing only; do not enable it for fleet use.
 
 > **Config locations:** Codex CLI / T3 Code `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) | Claude Code `.mcp.json` or `claude mcp add cmuxlayer -s user -- cmuxlayer` | Cursor `.cursor/mcp.json` | VS Code `.vscode/mcp.json` | Claude Desktop — see [MCP docs](https://modelcontextprotocol.io/quickstart/user) for platform-specific paths
 
-## What You Can Do
+## What you can do
 
 Tell your AI agent things like:
 
@@ -118,21 +113,21 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-Under the hood, cmuxLayer retains 45 internal tool definitions, but only 10 are registered and callable through MCP. The other 35 are not exposed through ToolSearch or any other MCP path. `reorder_surface` is the single approved deletion. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
+cmuxLayer retains 45 internal tool definitions; only 10 are registered and callable through MCP. The other 35 are not exposed through ToolSearch or any other MCP path. `reorder_surface` is the single approved deletion. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
-## Agent Routing Workflow
+## Agent routing workflow
 
 For managed agents, use the agent-first path: `list_agents` to find the target, `send_to` to deliver work by `agent_id`, then `wait_for` when you need completion. `send_to` also preserves the registry-independent escape hatch: use `mode:"surface"`, `mode:"command"`, or `mode:"key"` with a raw surface ref for shells, launch/resume commands, and stuck-pane recovery.
 
 See [Agent Routing and Handling Workflow](docs/agent-routing-and-handling.md) for the full operator playbook, including stuck surface recovery and safe `/mcp` menu reconnects.
 
-## MCP Tools (10 registered and callable)
+## MCP tools (10 registered and callable)
 
-All tools ship with [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for automatic safety policy enforcement.
+All public tools include [ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) that clients can use in safety policy.
 
 **Public MCP surface** — `spawn_agent` `report_to_parent` `send_to` `read_screen` `list_agents` `wait_for` `control_health` `close_surface` `update_surface` `list_surfaces`
 
-The other 35 internal definitions, including `interact`, are not callable. The detailed inventory below names 44 live definitions; the 45th source registration is a removed error-only tombstone and is intentionally omitted from operator guidance. This boundary is deliberately reversible while the project decides which low-frequency operations belong in MCP versus CLI/programmatic surfaces.
+The other 35 internal definitions, including `interact`, are not callable. The detailed inventory below names 44 live definitions; the 45th source registration is a removed error-only tombstone and is omitted from operator guidance.
 
 **Terminal control (16)** — `list_surfaces` `control_health` `select_workspace` `create_workspace` `delete_workspace` `new_split` `new_surface` `move_surface` `send_input` `send_command` `send_key` `read_screen` `rename_tab` `close_surface` `update_surface` `browser_surface`
 
@@ -208,7 +203,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 
 </details>
 
-## Supported Agents
+## Supported agents
 
 | CLI | Command | Auto-detected |
 |-----|---------|---------------|
@@ -216,6 +211,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 | Codex | `codex` | status, model, context % |
 | Gemini CLI | `gemini` | status, model, tokens, context % |
 | Cursor | `cursor agent` | status, model, tokens, context % |
+| Kiro CLI | `kiro-cli` | status |
 `read_screen` auto-detects agent type and parses metadata from terminal output.
 
 ## Architecture
@@ -230,7 +226,7 @@ AI Agent  ─── MCP ───>  cmuxLayer  ─── Unix socket ───> 
                          └── Metacomm WRITE — per-agent inbox file + Monitor dispatch
 ```
 
-The socket client connects to cmux via Unix socket. Auto-reconnects on disconnect, falls back to CLI subprocess if socket is unavailable.
+The socket client connects to cmux through a Unix socket. It reconnects after a disconnect and falls back to a CLI subprocess when the socket is unavailable.
 
 | Connection | Latency | Speedup |
 |------------|---------|---------|

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 | Codex | `codex` | status, model, context % |
 | Gemini CLI | `gemini` | status, model, tokens, context % |
 | Cursor | `cursor agent` | status, model, tokens, context % |
-| Kiro CLI | `kiro-cli` | status |
+| Kiro CLI | `kiro-cli` | spawn and lifecycle only; no Kiro-specific screen parser |
 `read_screen` auto-detects agent type and parses metadata from terminal output.
 
 ## Architecture

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -84,18 +84,18 @@ ID so distinct identities cannot collide after filename sanitization.
 
 ## Cutting a release (versioning, on the go)
 
-One command does the whole pipeline:
+The current tagged release is `0.4.65`. One command cuts the next version:
 
 ```bash
-~/Gits/cmuxlayer/scripts/release.sh 0.4.44                     # asks once before pushing
-~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --yes               # no prompt
-~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --dry-run           # print every step, change nothing
-~/Gits/cmuxlayer/scripts/release.sh 0.4.44 --require-contract  # a skipped real-cmux gate aborts
+~/Gits/cmuxlayer/scripts/release.sh X.Y.Z                     # asks once before pushing
+~/Gits/cmuxlayer/scripts/release.sh X.Y.Z --yes               # no prompt
+~/Gits/cmuxlayer/scripts/release.sh X.Y.Z --dry-run           # print every step, change nothing
+~/Gits/cmuxlayer/scripts/release.sh X.Y.Z --require-contract  # a skipped real-cmux gate aborts
 ```
 
 It will: verify a clean tree + green typecheck/tests, run the real-cmux
 contract gate, bump `package.json` on `wt/release-<version>`, open a PR, wait
-for both required contexts to register, watch them, re-check the exact PR head,
+for the required `perf-budget` and `test` contexts, re-check the exact PR head,
 and plain-merge with that head pinned. It fast-forwards the checkout back to
 `main` before tagging the resulting merge commit. Only then does it update the Homebrew formula's `url` + `sha256`, push
 the tap, **sync the tap clone Homebrew itself reads**, upgrade/verify the Mac
@@ -103,8 +103,8 @@ that cut the release, and run the reconnect sweep. Run the verification helper
 on each additional Mac:
 
 ```bash
-~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.44                # sync clone → upgrade → assert
-~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.44 --verify-only  # assert only; never upgrades
+~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.65                # sync clone → upgrade → assert
+~/Gits/cmuxlayer/scripts/release-verify.sh 0.4.65 --verify-only  # assert only; never upgrades
 ```
 
 ### The release receipt (stop trusting scrollback)
@@ -154,8 +154,8 @@ until locking lands.
 Read one directly:
 
 ```bash
-node ~/Gits/cmuxlayer/scripts/release-receipt.mjs show 0.4.44
-node ~/Gits/cmuxlayer/scripts/release-receipt.mjs path 0.4.44
+node ~/Gits/cmuxlayer/scripts/release-receipt.mjs show 0.4.65
+node ~/Gits/cmuxlayer/scripts/release-receipt.mjs path 0.4.65
 ```
 
 Receipt writes are never a gate: a failed receipt write warns and the release
@@ -238,16 +238,18 @@ pushed by then, so a missing brew or missing clone is recorded as
 Manual equivalent, if you prefer:
 
 1. `package.json` → bump `version`.
-2. Commit + open PR + merge to `main`.
-3. `git tag -a vX.Y.Z -m "..." <merge-sha> && git push origin vX.Y.Z`.
+2. Commit + open a bump PR, wait for required checks `perf-budget` and `test`,
+   confirm its head has not changed, then plain-merge to `main`.
+3. `git tag -a vX.Y.Z -m "..." <merge-sha> && git push origin vX.Y.Z`. The
+   tag target is the PR merge commit.
 4. `curl -fsSL https://github.com/EtanHey/cmuxlayer/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256`.
 5. In `~/Gits/homebrew-layers/Formula/cmuxlayer.rb` set `url` to the new tag and
    `sha256` to the value from step 4; `brew audit etanhey/layers/cmuxlayer`;
    commit + push.
 6. Sync the tap Homebrew reads:
    `git -C "$(brew --repository)/Library/Taps/etanhey/homebrew-layers" fetch origin && git -C "$(brew --repository)/Library/Taps/etanhey/homebrew-layers" reset --hard origin/main`.
-7. `brew upgrade etanhey/layers/cmuxlayer`.
-8. Assert `brew list --versions cmuxlayer` is exactly `cmuxlayer X.Y.Z`.
+7. Run `scripts/release-verify.sh X.Y.Z` on each Mac. Use `--verify-only` when
+   that Mac must not upgrade.
 
 The formula also carries a `head` block, so `--HEAD` installs always track
 `main` with **no** sha/tag bump — that is the on-the-go dogfood path.

--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -239,7 +239,8 @@ Manual equivalent, if you prefer:
 
 1. `package.json` → bump `version`.
 2. Commit + open a bump PR, wait for required checks `perf-budget` and `test`,
-   confirm its head has not changed, then plain-merge to `main`.
+   confirm its head has not changed, then run
+   `gh pr merge <PR> --merge --match-head-commit <confirmed-head-sha>`.
 3. `git tag -a vX.Y.Z -m "..." <merge-sha> && git push origin vX.Y.Z`. The
    tag target is the PR merge commit.
 4. `curl -fsSL https://github.com/EtanHey/cmuxlayer/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256`.

--- a/landing/index.html
+++ b/landing/index.html
@@ -1608,7 +1608,7 @@
 
         // Phase 7 — wait_for
         appendOrc('');
-        appendOrc(dim('\u250C\u2500') + ' ' + brg('wait_for') + '(' + cyn('ids') + '=' + amb('["opus-voice-a3f7", "sonnet-brain-c1d4"]') + ', ' + cyn('target') + '=' + amb('"done"') + ')');
+        appendOrc(dim('\u250C\u2500') + ' ' + brg('wait_for') + '(' + cyn('ids') + '=' + amb('["opus-voice-a3f7", "sonnet-brain-c1d4"]') + ', ' + cyn('target_state') + '=' + amb('"done"') + ')');
         await sleep(800);
         appendOrc(dim('\u2502') + '  ' + grn('\u2713') + ' ' + dim('opus-voice-a3f7:') + '  ' + grn('done') + ' ' + dim('(34s)'));
         await sleep(500);

--- a/landing/index.html
+++ b/landing/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>cmuxLayer — Terminal MCP for AI Agents</title>
-  <meta name="description" content="MCP server that gives AI agents programmatic control over terminal panes. 29 tools. Split, read, send, automate. One Unix socket.">
+  <meta name="description" content="MCP server with 10 public tools for controlling terminal panes and managing CLI agents through one Unix socket.">
   <meta property="og:title" content="cmuxLayer — Terminal MCP for AI Agents">
-  <meta property="og:description" content="29 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens. One Unix socket.">
+  <meta property="og:description" content="10 public MCP tools. 0.2ms socket latency. Spawn agents, send input, and read screens through one Unix socket.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://cmuxlayer.etanheyman.com">
   <meta name="twitter:card" content="summary">
@@ -1036,8 +1036,8 @@
         <span class="stat-label">socket latency</span>
       </div>
       <div class="stat-item">
-        <span class="stat-value">22</span>
-        <span class="stat-label">MCP tools</span>
+        <span class="stat-value">10</span>
+        <span class="stat-label">public MCP tools</span>
       </div>
       <div class="stat-item">
         <span class="stat-value">5</span>
@@ -1143,50 +1143,26 @@
       <h2 class="section-heading">Every operation is a tool call</h2>
 
       <div class="tools-group">
-        <div class="tools-group-label">Core &mdash; terminal operations</div>
-        <div class="tool-item reveal">
-          <span class="name">list_surfaces</span>
-          <span class="desc">Enumerate all surfaces across workspaces</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">new_split</span>
-          <span class="desc">Create terminal or browser splits in any direction</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">send_input</span>
-          <span class="desc">Type text into a surface as if from the keyboard</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">send_key</span>
-          <span class="desc">Send key combos &mdash; Enter, Ctrl-C, Escape, arrows</span>
-        </div>
+        <div class="tools-group-label">Terminal and control</div>
         <div class="tool-item reveal">
           <span class="name">read_screen</span>
-          <span class="desc">Capture visible terminal output with optional scrollback</span>
+          <span class="desc">Read terminal output with parsed agent status</span>
         </div>
         <div class="tool-item reveal">
-          <span class="name">rename_tab</span>
-          <span class="desc">Set the workspace tab title</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">notify</span>
-          <span class="desc">Push macOS notifications from any surface</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">set_status</span>
-          <span class="desc">Update sidebar status entries with icons and colors</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">set_progress</span>
-          <span class="desc">Show a progress bar with label in the sidebar</span>
+          <span class="name">control_health</span>
+          <span class="desc">Inspect socket, binary, process, and control-plane health</span>
         </div>
         <div class="tool-item reveal">
           <span class="name">close_surface</span>
-          <span class="desc">Close a terminal or browser surface</span>
+          <span class="desc">Close a surface or managed agent with live-agent guards</span>
         </div>
         <div class="tool-item reveal">
-          <span class="name">browser_surface</span>
-          <span class="desc">Open a scriptable browser alongside terminal panes</span>
+          <span class="name">update_surface</span>
+          <span class="desc">Rename or move a terminal surface</span>
+        </div>
+        <div class="tool-item reveal">
+          <span class="name">list_surfaces</span>
+          <span class="desc">List workspace, pane, and surface topology</span>
         </div>
       </div>
 
@@ -1196,43 +1172,23 @@
         <div class="tools-group-label">Agent lifecycle &mdash; spawn and monitor</div>
         <div class="tool-item reveal">
           <span class="name">spawn_agent</span>
-          <span class="desc">Launch a Claude, Codex, Gemini, or Cursor agent in a new pane</span>
+          <span class="desc">Launch a Claude, Codex, Gemini, Cursor, or Kiro agent in a pane</span>
         </div>
         <div class="tool-item reveal">
-          <span class="name">send_to_agent</span>
-          <span class="desc">Deliver a message to a running agent</span>
+          <span class="name">report_to_parent</span>
+          <span class="desc">Escalate a blocker to the direct parent agent</span>
         </div>
         <div class="tool-item reveal">
-          <span class="name">read_agent_output</span>
-          <span class="desc">Capture an agent's latest terminal output</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">get_agent_state</span>
-          <span class="desc">Check agent status: running, idle, waiting, done, error</span>
+          <span class="name">send_to</span>
+          <span class="desc">Send text, commands, or keys to an agent or surface</span>
         </div>
         <div class="tool-item reveal">
           <span class="name">list_agents</span>
-          <span class="desc">Enumerate all active agents across workspaces</span>
+          <span class="desc">List addressable agents with lifecycle state</span>
         </div>
         <div class="tool-item reveal">
           <span class="name">wait_for</span>
           <span class="desc">Block until an agent reaches a target state</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">wait_for_all</span>
-          <span class="desc">Block until multiple agents finish in parallel</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">stop_agent</span>
-          <span class="desc">Gracefully stop a running agent</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">kill</span>
-          <span class="desc">Force-kill an unresponsive agent process</span>
-        </div>
-        <div class="tool-item reveal">
-          <span class="name">interact</span>
-          <span class="desc">Send interactive input to an agent waiting for a response</span>
         </div>
       </div>
     </div>
@@ -1650,9 +1606,9 @@
         appendOrc(dim('\u2514\u2500') + ' ' + grn('done_signal: "CLAUDE_COUNTER: 7"'));
         await sleep(1000);
 
-        // Phase 7 — wait_for_all
+        // Phase 7 — wait_for
         appendOrc('');
-        appendOrc(dim('\u250C\u2500') + ' ' + brg('wait_for_all') + '(' + cyn('target') + '=' + amb('"done"') + ')');
+        appendOrc(dim('\u250C\u2500') + ' ' + brg('wait_for') + '(' + cyn('ids') + '=' + amb('["opus-voice-a3f7", "sonnet-brain-c1d4"]') + ', ' + cyn('target') + '=' + amb('"done"') + ')');
         await sleep(800);
         appendOrc(dim('\u2502') + '  ' + grn('\u2713') + ' ' + dim('opus-voice-a3f7:') + '  ' + grn('done') + ' ' + dim('(34s)'));
         await sleep(500);

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -26,11 +26,11 @@ export const metadata: Metadata = {
   alternates: { canonical: "/" },
   title: "cmuxLayer — Terminal MCP for AI Agents",
   description:
-    "MCP server that gives AI agents programmatic control over terminal panes. 29 tools. Split, read, send, automate. One Unix socket.",
+    "MCP server with 10 public tools for controlling terminal panes and managing CLI agents through one Unix socket.",
   openGraph: {
     title: "cmuxLayer — Terminal MCP for AI Agents",
     description:
-      "29 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens. One Unix socket.",
+      "10 public MCP tools. 0.2ms socket latency. Spawn agents, send input, and read screens through one Unix socket.",
     url: "https://cmuxlayer.etanheyman.com",
     siteName: "cmuxLayer",
     type: "website",
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "cmuxLayer — Terminal MCP for AI Agents",
     description:
-      "22 MCP tools. 0.2ms socket latency. Spawn agents, split panes, read screens.",
+      "10 public MCP tools. 0.2ms socket latency. Spawn agents, send input, and read screens.",
     images: ["/og.png"],
   },
   icons: {

--- a/site/components/animated-demo.tsx
+++ b/site/components/animated-demo.tsx
@@ -514,13 +514,17 @@ export function AnimatedDemo() {
     );
     await sleep(1000);
 
-    // Phase 7 — wait_for_all
+    // Phase 7 — wait_for
     appendOrc("");
     appendOrc(
       dim("\u250C\u2500") +
         " " +
-        brg("wait_for_all") +
+        brg("wait_for") +
         "(" +
+        cyn("ids") +
+        "=" +
+        amb('["opus-voice-a3f7", "sonnet-brain-c1d4"]') +
+        ", " +
         cyn("target") +
         "=" +
         amb('"done"') +

--- a/site/components/animated-demo.tsx
+++ b/site/components/animated-demo.tsx
@@ -525,7 +525,7 @@ export function AnimatedDemo() {
         "=" +
         amb('["opus-voice-a3f7", "sonnet-brain-c1d4"]') +
         ", " +
-        cyn("target") +
+        cyn("target_state") +
         "=" +
         amb('"done"') +
         ")",

--- a/site/components/hero.tsx
+++ b/site/components/hero.tsx
@@ -68,7 +68,7 @@ export function Hero() {
         </p>
 
         <p className="text-[13px] text-text-dim mb-10 relative hero-fade hero-fade-d1">
-          free &middot; open source &middot; 22 MCP tools
+          free &middot; open source &middot; 10 public MCP tools
         </p>
 
         <div className="flex items-center justify-center gap-3 mb-12 relative hero-fade hero-fade-d2 max-[480px]:flex-col">

--- a/site/components/stat-strip.tsx
+++ b/site/components/stat-strip.tsx
@@ -1,6 +1,6 @@
 const stats = [
   { value: "0.2ms", label: "socket latency" },
-  { value: "22", label: "MCP tools" },
+  { value: "10", label: "public MCP tools" },
   { value: "5", label: "agent CLIs" },
   { value: "326", label: "tests passing" },
 ];

--- a/site/components/tools.tsx
+++ b/site/components/tools.tsx
@@ -4,84 +4,45 @@ interface Tool {
 }
 
 const coreTools: Tool[] = [
-  { name: "list_surfaces", desc: "Enumerate all surfaces across workspaces" },
-  {
-    name: "new_split",
-    desc: "Create terminal or browser splits in any direction",
-  },
-  {
-    name: "send_input",
-    desc: "Type text into a surface as if from the keyboard",
-  },
-  {
-    name: "send_key",
-    desc: "Send key combos \u2014 Enter, Ctrl-C, Escape, arrows",
-  },
   {
     name: "read_screen",
-    desc: "Capture visible terminal output with optional scrollback",
-  },
-  { name: "rename_tab", desc: "Set the workspace tab title" },
-  { name: "notify", desc: "Push macOS notifications from any surface" },
-  {
-    name: "set_status",
-    desc: "Update sidebar status entries with icons and colors",
+    desc: "Read terminal output with parsed agent status",
   },
   {
-    name: "set_progress",
-    desc: "Show a progress bar with label in the sidebar",
+    name: "control_health",
+    desc: "Inspect socket, binary, process, and control-plane health",
   },
-  { name: "close_surface", desc: "Close a terminal or browser surface" },
   {
-    name: "browser_surface",
-    desc: "Open a scriptable browser alongside terminal panes",
+    name: "close_surface",
+    desc: "Close a surface or managed agent with live-agent guards",
   },
+  {
+    name: "update_surface",
+    desc: "Rename or move a terminal surface",
+  },
+  { name: "list_surfaces", desc: "List workspace, pane, and surface topology" },
 ];
 
 const agentTools: Tool[] = [
   {
     name: "spawn_agent",
-    desc: "Launch a Claude, Codex, Gemini, Cursor, or Kiro agent in a new pane",
+    desc: "Launch a Claude, Codex, Gemini, Cursor, or Kiro agent in a pane",
   },
   {
-    name: "send_to_agent",
-    desc: "Deliver a message to a running agent",
+    name: "report_to_parent",
+    desc: "Escalate a blocker to the direct parent agent",
   },
   {
-    name: "read_agent_output",
-    desc: "Capture an agent\u2019s latest terminal output",
-  },
-  {
-    name: "get_agent_state",
-    desc: "Check agent status: running, idle, waiting, done, error",
+    name: "send_to",
+    desc: "Send text, commands, or keys to an agent or surface",
   },
   {
     name: "list_agents",
-    desc: "Enumerate all active agents across workspaces",
+    desc: "List addressable agents with lifecycle state",
   },
   {
     name: "wait_for",
     desc: "Block until an agent reaches a target state",
-  },
-  {
-    name: "wait_for_all",
-    desc: "Block until multiple agents finish in parallel",
-  },
-  {
-    name: "stop_agent",
-    desc: "Gracefully stop a running agent",
-  },
-  {
-    name: "kill",
-    desc: "Force-kill an unresponsive agent process",
-  },
-  {
-    name: "my_agents",
-    desc: "Get all children of a parent agent with live screen status",
-  },
-  {
-    name: "interact",
-    desc: "Send interactive input to an agent waiting for a response",
   },
 ];
 
@@ -111,7 +72,7 @@ export function Tools() {
 
         <div className="max-w-[640px] mx-auto mb-12">
           <div className="text-xs uppercase tracking-[0.1em] text-text-dim mb-4 pl-0.5 font-medium">
-            Core &mdash; terminal operations
+            Terminal and control
           </div>
           {coreTools.map((tool) => (
             <ToolItem key={tool.name} tool={tool} />


### PR DESCRIPTION
## Summary

- Align README, site, static landing page, and GitHub About with the 10-tool public MCP surface. Source: `tests/tool-count-drift.test.ts` and `src/server.ts`.
- Preserve the 45 internal / 10 public / 35 deferred boundary in operator docs. Source: `tests/tool-count-drift.test.ts`.
- Document the current `0.4.65` release and PR-based release path. Source: `package.json` and `scripts/release.sh`.
- Include browser globals in DeepSource's JavaScript analyzer for the React site. Source: `.deepsource.toml` and `site/package.json`.
- Update supported harness copy to Claude, Codex, Gemini, Kiro, and Cursor. Source: `src/agent-types.ts`.

## Verification

- `CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1 bunx vitest run tests/tool-count-drift.test.ts`: 5 passed.
- `npm --prefix site run build`: production build passed; 4 static pages generated.
- Pre-push `scripts/run_tests.sh`: 152 files passed; 3,486 tests passed; 1 skipped.
- `git diff --check`: passed.
- Active ruleset `19248810`, queried with `gh api`: required contexts are `perf-budget` and `test`; DeepSource is advisory.

GitHub About changed from “42 tools” to “10 public MCP tools” and names all five supported harnesses; verified with `gh repo view EtanHey/cmuxlayer --json description`.

— cmuxlayerCodex-bef57d08 (worker) · codex/gpt-5.6-sol

<!-- agent-metadata: agent=cmuxlayerCodex-bef57d08 role=worker harness=codex model=gpt-5.6-sol session=01a03df6 timestamp=2026-08-26T12:36:39Z -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, static site, and analyzer config only; no MCP server or release script logic changes in this diff.
> 
> **Overview**
> Aligns **README**, **releases-and-brew**, the static **landing** page, and the Next.js **site** with the current **10-tool public MCP surface** (replacing outdated counts like 22/29 in metadata and hero copy).
> 
> **Docs and release ops:** README is tightened and documents **Kiro CLI** (spawn/lifecycle only). `docs/releases-and-brew.md` names **0.4.65** as the current tag, generalizes `release.sh` examples, and documents required PR checks **`perf-budget`** and **`test`** plus head-pinned merge before tagging.
> 
> **Marketing UI:** Tool sections on the site and landing now list only public tools (`control_health`, `close_surface`, `update_surface`, `list_surfaces`, `send_to`, `report_to_parent`, etc.) instead of a long internal inventory. Animated demos switch from **`wait_for_all`** to **`wait_for(ids, target_state)`**.
> 
> **Tooling:** `.deepsource.toml` adds **`browser`** to the JavaScript analyzer environment for the React site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52acb8fcfd3430faae9059e13313f8fd8d7bc218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align docs and site to 10 public MCP tools and release 0.4.65
> - Updates [README.md](https://github.com/EtanHey/cmuxlayer/pull/563/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [landing/index.html](https://github.com/EtanHey/cmuxlayer/pull/563/files#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3), and site components to show '10 public MCP tools' instead of 22, prunes internal-only tools from display lists, and replaces `wait_for_all(target="done")` with `wait_for(ids=[...], target_state="done")` in demo text
> - Revises [docs/releases-and-brew.md](https://github.com/EtanHey/cmuxlayer/pull/563/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) to reference release 0.4.65, require `perf-budget` and `test` CI contexts, and run `scripts/release-verify.sh X.Y.Z` on each Mac
> - Expands [.deepsource.toml](https://github.com/EtanHey/cmuxlayer/pull/563/files#diff-a8c050b1fb601cdd8ba1282e837bc0b553d4f83de74d151e52f415b4e1ed6d14) JavaScript/TypeScript analyzer environment to include `browser`
> - Risk: landing page and site no longer list internal tools (`send_input`, `send_key`, `wait_for_all`, `stop_agent`, `kill`, `interact`, etc.); any external references to those tool names on the public site are now gone
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52acb8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded setup guidance, Quick Start instructions, experimental prompt resolution details, MCP tool annotations, Kiro CLI support, and socket connection behavior.
  - Updated release procedures, version references, verification steps, and workflow check requirements.
- **Website Updates**
  - Refreshed landing-page messaging and metadata to reflect 10 public MCP tools.
  - Updated tool listings to highlight screen reading, terminal/control operations, and agent lifecycle actions.
  - Revised interactive demos to show waiting for multiple agents to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->