### PR TITLE
fix: wake parents only for child report content

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6538,6 +6538,7 @@ export class AgentEngine {
           (subject) =>
             subject.user_killed !== true &&
             !subject.deletion_intent &&
+            !TERMINAL_STATES.has(subject.state) &&
             subject.parent_agent_id === watch.owner,
         );
       },

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -1659,6 +1659,7 @@ export class AgentEngine {
   private watchRegistryNow?: () => number;
   private watchNotify: WatchNotify;
   private watchSweepInFlight = false;
+  private childReportWatchPrunePending = false;
   /** Best-effort close-forensics ingest; null when disabled. */
   private closeForensicsRunner:
     | (() => CloseForensicsSweepResult | Promise<CloseForensicsSweepResult>)
@@ -1829,6 +1830,7 @@ export class AgentEngine {
     this.watchRegistryPath = opts?.watchRegistryPath;
     this.watchRegistryNow = opts?.watchRegistryNow;
     this.watchNotify = opts?.watchNotify ?? (async () => {});
+    this.childReportWatchPrunePending = Boolean(this.watchRegistryPath);
     // Default DISABLED: bare construction (tests, libraries) must never read the
     // real `~/.cmuxterm/events.jsonl`. Production entrypoints inject the real
     // runner (see app-server-runtime / server.ts createServer). `null` keeps it
@@ -6467,7 +6469,7 @@ export class AgentEngine {
         newlySurfacelessAgentIds.add(finalized.agent_id);
       }
     }
-    await this.pruneClosedChildReportWatches();
+    await this.retryClosedChildReportWatchPrune();
     const discovered = await discovery.scan(true);
     await this.registry.listMerged(discovery, {
       force: true,
@@ -6524,7 +6526,8 @@ export class AgentEngine {
     await removeWatches(
       (watch) => {
         const subject = watch.subject_agent_id
-          ? this.registry.get(watch.subject_agent_id)
+          ? (this.registry.get(watch.subject_agent_id) ??
+            this.stateMgr.readState(watch.subject_agent_id))
           : byReportPath.get(resolve(watch.target));
         if (!subject) return Boolean(watch.subject_agent_id);
         return (
@@ -6535,6 +6538,24 @@ export class AgentEngine {
       },
       { registryPath: this.watchRegistryPath },
     );
+  }
+
+  scheduleClosedChildReportWatchPrune(): void {
+    if (this.watchRegistryPath) this.childReportWatchPrunePending = true;
+  }
+
+  private async retryClosedChildReportWatchPrune(): Promise<void> {
+    if (!this.childReportWatchPrunePending) return;
+    try {
+      await this.pruneClosedChildReportWatches();
+      this.childReportWatchPrunePending = false;
+    } catch (error) {
+      this.sweepDebugLog(
+        `[cmuxlayer] child report watch prune deferred: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   private async purgeStartupTerminalAgents(
@@ -7724,7 +7745,10 @@ export class AgentEngine {
       // before normal terminal cleanup can act on a closed pane.
       await time("transcript_ms", () => this.retryDeferredTranscriptCaptures());
       if (this.shouldYieldSweep()) return;
-      await time("watches_ms", () => this.sweepWatchesBestEffort());
+      await time("watches_ms", async () => {
+        await this.retryClosedChildReportWatchPrune();
+        await this.sweepWatchesBestEffort();
+      });
       if (this.shouldYieldSweep()) return;
       if (mutationsAreSafe && this.assertSweepInputCurrent(sweepCtx)) {
         await time("terminal_purge_ms", () =>

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -121,6 +121,7 @@ import type { CloseForensicsSweepResult } from "./close-forensics.js";
 import {
   armWatch as armDeclaredWatch,
   readWatchRegistry,
+  removeWatches,
   sweepWatches,
   type WatchAgentObservation,
   type WatchNotify,
@@ -6466,6 +6467,7 @@ export class AgentEngine {
         newlySurfacelessAgentIds.add(finalized.agent_id);
       }
     }
+    await this.pruneClosedChildReportWatches();
     const discovered = await discovery.scan(true);
     await this.registry.listMerged(discovery, {
       force: true,
@@ -6501,6 +6503,38 @@ export class AgentEngine {
       // Sidebar/status publication is auxiliary. Boot placement may go live
       // once registry ingestion and the provenance-gated sweep have completed.
     }
+  }
+
+  /**
+   * A daemon restart must not re-arm report watches owned by children that are
+   * already closed or no longer belong to the recorded parent. New rows carry
+   * subject_agent_id; legacy rows are pruned only when their target exactly
+   * matches a persisted child's engine-issued report_path.
+   */
+  private async pruneClosedChildReportWatches(): Promise<void> {
+    if (!this.watchRegistryPath) return;
+    const agents = this.registry.list();
+    const byReportPath = new Map(
+      agents.flatMap((agent) =>
+        agent.report_path
+          ? [[resolve(agent.report_path), agent] as const]
+          : [],
+      ),
+    );
+    await removeWatches(
+      (watch) => {
+        const subject = watch.subject_agent_id
+          ? this.registry.get(watch.subject_agent_id)
+          : byReportPath.get(resolve(watch.target));
+        if (!subject) return Boolean(watch.subject_agent_id);
+        return (
+          subject.user_killed === true ||
+          subject.deletion_intent ||
+          subject.parent_agent_id !== watch.owner
+        );
+      },
+      { registryPath: this.watchRegistryPath },
+    );
   }
 
   private async purgeStartupTerminalAgents(

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6525,6 +6525,9 @@ export class AgentEngine {
     );
     await removeWatches(
       (watch) => {
+        if (watch.target_kind !== "file" || watch.change !== "content") {
+          return false;
+        }
         const subject = watch.subject_agent_id
           ? (this.registry.get(watch.subject_agent_id) ??
             this.stateMgr.readState(watch.subject_agent_id))
@@ -6546,10 +6549,11 @@ export class AgentEngine {
 
   private async retryClosedChildReportWatchPrune(): Promise<void> {
     if (!this.childReportWatchPrunePending) return;
+    this.childReportWatchPrunePending = false;
     try {
       await this.pruneClosedChildReportWatches();
-      this.childReportWatchPrunePending = false;
     } catch (error) {
+      this.childReportWatchPrunePending = true;
       this.sweepDebugLog(
         `[cmuxlayer] child report watch prune deferred: ${
           error instanceof Error ? error.message : String(error)

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6516,27 +6516,29 @@ export class AgentEngine {
   private async pruneClosedChildReportWatches(): Promise<void> {
     if (!this.watchRegistryPath) return;
     const agents = this.registry.list();
-    const byReportPath = new Map(
-      agents.flatMap((agent) =>
-        agent.report_path
-          ? [[resolve(agent.report_path), agent] as const]
-          : [],
-      ),
-    );
+    const byReportPath = new Map<string, AgentRecord[]>();
+    for (const agent of agents) {
+      if (!agent.report_path) continue;
+      const path = resolve(agent.report_path);
+      byReportPath.set(path, [...(byReportPath.get(path) ?? []), agent]);
+    }
     await removeWatches(
       (watch) => {
         if (watch.target_kind !== "file" || watch.change !== "content") {
           return false;
         }
-        const subject = watch.subject_agent_id
-          ? (this.registry.get(watch.subject_agent_id) ??
-            this.stateMgr.readState(watch.subject_agent_id))
-          : byReportPath.get(resolve(watch.target));
-        if (!subject) return Boolean(watch.subject_agent_id);
-        return (
-          subject.user_killed === true ||
-          subject.deletion_intent ||
-          subject.parent_agent_id !== watch.owner
+        const subjects = watch.subject_agent_id
+          ? [
+              this.registry.get(watch.subject_agent_id) ??
+                this.stateMgr.readState(watch.subject_agent_id),
+            ].filter((subject): subject is AgentRecord => Boolean(subject))
+          : (byReportPath.get(resolve(watch.target)) ?? []);
+        if (subjects.length === 0) return Boolean(watch.subject_agent_id);
+        return !subjects.some(
+          (subject) =>
+            subject.user_killed !== true &&
+            !subject.deletion_intent &&
+            subject.parent_agent_id === watch.owner,
         );
       },
       { registryPath: this.watchRegistryPath },

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,8 @@ import {
 import {
   WATCH_AGENT_PREDICATES,
   readWatchRegistry,
+  removeWatches,
+  scopeWatchToSubject,
   WatchArmError,
   type WatchNotify,
   type WatchSpec,
@@ -10881,6 +10883,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               WARNING: remedy,
             });
           }
+          await removeWatches(
+            (watch) => watch.subject_agent_id === args.agent_id,
+            {
+              registryPath:
+                opts?.watchRegistryPath ??
+                join(context.stateDir, "watch-specs.json"),
+            },
+          );
           if (!boundSurface) {
             const data = {
               ...stopContent,
@@ -12212,6 +12222,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 externalDelivered = false;
               }
             }
+            if (event.subject_agent_id) {
+              const subject =
+                registry.get(event.subject_agent_id) ??
+                stateMgr.readState(event.subject_agent_id);
+              if (
+                !subject ||
+                subject.parent_agent_id !== event.owner ||
+                subject.user_killed === true ||
+                subject.deletion_intent
+              ) {
+                return true;
+              }
+            }
             const owner =
               registry.get(event.owner) ?? stateMgr.readState(event.owner);
             if (owner && lifecycleAgentInputDeliverer) {
@@ -12996,24 +13019,40 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
     const armParentReportWatch = async (
       parentAgentId: string,
+      childAgentId: string,
       coordination: { report_path: string; done_marker: string },
     ): Promise<string | null> => {
       try {
+        const child =
+          registry.get(childAgentId) ?? stateMgr.readState(childAgentId);
+        if (!child || child.parent_agent_id !== parentAgentId) {
+          return `Report watch was not armed: ${childAgentId} is not a direct child of ${parentAgentId}`;
+        }
         const reportPath = resolve(coordination.report_path);
         const existing = readWatchRegistry({
           registryPath: watchRegistryPath,
         }).watches.find(
           (watch) =>
             watch.owner === parentAgentId &&
+            (!watch.subject_agent_id ||
+              watch.subject_agent_id === childAgentId) &&
             watch.target === reportPath &&
             watch.change === "content" &&
             watch.state !== "failed",
         );
-        if (existing) return null;
+        if (existing) {
+          if (!existing.subject_agent_id) {
+            await scopeWatchToSubject(existing.watch_id, childAgentId, {
+              registryPath: watchRegistryPath,
+            });
+          }
+          return null;
+        }
         await mkdir(dirname(reportPath), { recursive: true });
         await appendFile(reportPath, "", "utf8");
         await engine.armWatch({
           owner: parentAgentId,
+          subject_agent_id: childAgentId,
           target: reportPath,
           change: "content",
           deadline: Number.MAX_SAFE_INTEGER,
@@ -13577,6 +13616,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             const reportWatchWarning = result.parent_agent_id
               ? await armParentReportWatch(
                   result.parent_agent_id,
+                  result.agent_id,
                   resumeCoordination,
                 )
               : null;
@@ -14036,6 +14076,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (result.parent_agent_id) {
             const reportWatchWarning = await armParentReportWatch(
               result.parent_agent_id,
+              result.agent_id,
               coordination,
             );
             if (reportWatchWarning) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4121,6 +4121,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   }) => Promise<void> = async () => {};
   let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
   let lifecycleScheduleChildReportWatchPrune: (() => void) | null = null;
+  const pruneChildReportWatchesFor = (agentId: string): void => {
+    lifecycleScheduleChildReportWatchPrune?.();
+    removeWatches((watch) => watch.subject_agent_id === agentId, {
+      registryPath:
+        opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
+    }).catch((error) => {
+      console.error(
+        `[cmuxlayer] deferred child watch cleanup for ${agentId}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+  };
   let lifecycleRefreshManagedMetadata:
     ((agentId?: string) => Promise<void>) | null = null;
   let lifecycleHealthEngine: AgentEngine | null = null;
@@ -10884,20 +10896,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               WARNING: remedy,
             });
           }
-          lifecycleScheduleChildReportWatchPrune?.();
-          removeWatches(
-            (watch) => watch.subject_agent_id === args.agent_id,
-            {
-              registryPath:
-                opts?.watchRegistryPath ??
-                join(context.stateDir, "watch-specs.json"),
-            },
-          ).catch((error) => {
-            console.error(
-              `[cmuxlayer] close_surface deferred child watch cleanup for ${args.agent_id}:`,
-              error instanceof Error ? error.message : String(error),
-            );
-          });
           const watchCleanup = {
             watch_cleanup: lifecycleScheduleChildReportWatchPrune
               ? ("scheduled" as const)
@@ -11319,6 +11317,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               const stopped = stateMgr.transition(record.agent_id, "done");
               context.lifecycleRegistry?.set(record.agent_id, stopped);
             }
+            pruneChildReportWatchesFor(record.agent_id);
           } catch (error) {
             if (
               error instanceof Error &&
@@ -16402,6 +16401,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 route.workspace_id ?? undefined,
               ),
           });
+          pruneChildReportWatchesFor(args.agent_id);
           const state = engine.getAgentState(args.agent_id);
           appendCloseEvent({
             event: "stop_agent",
@@ -17782,6 +17782,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     route.workspace_id ?? undefined,
                   ),
               });
+              pruneChildReportWatchesFor(agentId);
               killed.push(agentId);
               appendCloseEvent({
                 event: "kill",

--- a/src/server.ts
+++ b/src/server.ts
@@ -13122,6 +13122,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           message: `report_path ${reportPath} is already reserved by another child spawn; each child requires a distinct report path`,
         };
       }
+      const existingLiveChild = stateMgr.listStates().find(
+        (candidate) =>
+          candidate.agent_id !== childAgentId &&
+          candidate.parent_agent_id === parentAgentId &&
+          candidate.report_path !== null &&
+          candidate.report_path !== undefined &&
+          resolve(candidate.report_path) === reportPath &&
+          candidate.user_killed !== true &&
+          !candidate.deletion_intent &&
+          !TERMINAL_AGENT_STATES.has(candidate.state),
+      );
+      if (existingLiveChild) {
+        return {
+          ok: false,
+          message: `report_path ${reportPath} is already assigned to live child ${existingLiveChild.agent_id}; each child requires a distinct report path`,
+        };
+      }
       const existingReportWatch = readWatchRegistry({
         registryPath: watchRegistryPath,
       }).watches.find(

--- a/src/server.ts
+++ b/src/server.ts
@@ -10885,7 +10885,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             });
           }
           lifecycleScheduleChildReportWatchPrune?.();
-          void removeWatches(
+          removeWatches(
             (watch) => watch.subject_agent_id === args.agent_id,
             {
               registryPath:
@@ -13829,6 +13829,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const effectiveParentAgentId = callerIsWorker
             ? callerAgent!.agent_id
             : (args.parent_agent_id ?? callerAgent?.agent_id);
+          if (effectiveParentAgentId && args.report_path) {
+            const requestedReportPath = resolve(args.report_path.trim());
+            const existingReportWatch = readWatchRegistry({
+              registryPath: watchRegistryPath,
+            }).watches.find(
+              (watch) =>
+                watch.owner === effectiveParentAgentId &&
+                watch.target === requestedReportPath &&
+                watch.change === "content" &&
+                watch.state !== "failed",
+            );
+            if (existingReportWatch) {
+              return err(
+                new Error(
+                  `report_path ${requestedReportPath} is already assigned to child ${existingReportWatch.subject_agent_id ?? "through an existing report watch"}; each child requires a distinct report path`,
+                ),
+                { error_code: "REPORT_PATH_IN_USE" },
+              );
+            }
+          }
           const effectiveRole = callerIsWorker ? "worker" : normalizedRole.role;
           const workerCallerWarning = callerIsWorker
             ? `Worker caller ${callerAgent!.agent_id} forced child role to worker and recorded itself as parent; worker-spawned agents cannot claim orchestrator placement.`

--- a/src/server.ts
+++ b/src/server.ts
@@ -12230,18 +12230,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           watchRegistryPath,
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
-            if (event.subject_agent_id) {
+            const subjectStillBelongsToOwner = (): boolean => {
+              if (!event.subject_agent_id) return true;
               const subject =
                 registry.get(event.subject_agent_id) ??
                 stateMgr.readState(event.subject_agent_id);
-              if (
-                !subject ||
-                subject.parent_agent_id !== event.owner ||
-                subject.user_killed === true ||
-                subject.deletion_intent
-              ) {
-                return true;
-              }
+              return Boolean(
+                subject &&
+                  subject.parent_agent_id === event.owner &&
+                  subject.user_killed !== true &&
+                  !subject.deletion_intent,
+              );
+            };
+            if (!subjectStillBelongsToOwner()) {
+              return true;
             }
             let externalDelivered = true;
             if (event.reason !== "predicate_matched" && opts?.watchNotify) {
@@ -12250,6 +12252,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               } catch {
                 externalDelivered = false;
               }
+            }
+            if (!subjectStillBelongsToOwner()) {
+              return true;
             }
             const owner =
               registry.get(event.owner) ?? stateMgr.readState(event.owner);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4120,6 +4120,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     model?: string;
   }) => Promise<void> = async () => {};
   let lifecycleEnsureRegistered: (() => Promise<void>) | null = null;
+  let lifecycleScheduleChildReportWatchPrune: (() => void) | null = null;
   let lifecycleRefreshManagedMetadata:
     ((agentId?: string) => Promise<void>) | null = null;
   let lifecycleHealthEngine: AgentEngine | null = null;
@@ -10883,17 +10884,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               WARNING: remedy,
             });
           }
-          await removeWatches(
+          lifecycleScheduleChildReportWatchPrune?.();
+          void removeWatches(
             (watch) => watch.subject_agent_id === args.agent_id,
             {
               registryPath:
                 opts?.watchRegistryPath ??
                 join(context.stateDir, "watch-specs.json"),
             },
-          );
+          ).catch((error) => {
+            console.error(
+              `[cmuxlayer] close_surface deferred child watch cleanup for ${args.agent_id}:`,
+              error instanceof Error ? error.message : String(error),
+            );
+          });
+          const watchCleanup = {
+            watch_cleanup: lifecycleScheduleChildReportWatchPrune
+              ? ("scheduled" as const)
+              : ("best_effort" as const),
+          };
           if (!boundSurface) {
             const data = {
               ...stopContent,
+              ...watchCleanup,
               scope: "agent",
               agent_stopped: true,
               surface_closed: false,
@@ -10926,6 +10939,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ),
               {
                 ...stopContent,
+                ...watchCleanup,
                 scope: "agent",
                 agent_stopped: true,
                 surface: boundSurface,
@@ -10937,6 +10951,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           if (boundSurfaceAfterStop === null) {
             const data = {
               ...stopContent,
+              ...watchCleanup,
               scope: "agent",
               agent_stopped: true,
               surface: boundSurface,
@@ -10978,6 +10993,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               ),
               {
                 ...stopContent,
+                ...watchCleanup,
                 scope: "agent",
                 agent_stopped: true,
                 surface: boundSurface,
@@ -10991,6 +11007,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const surfaceClosed = closeContent.surface_closed === true;
           const data = {
             ...stopContent,
+            ...watchCleanup,
             scope: "agent",
             agent_stopped: true,
             surface: boundSurface,
@@ -12214,14 +12231,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           watchRegistryPath,
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
-            let externalDelivered = true;
-            if (event.reason !== "predicate_matched" && opts?.watchNotify) {
-              try {
-                externalDelivered = (await opts.watchNotify(event)) !== false;
-              } catch {
-                externalDelivered = false;
-              }
-            }
             if (event.subject_agent_id) {
               const subject =
                 registry.get(event.subject_agent_id) ??
@@ -12233,6 +12242,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 subject.deletion_intent
               ) {
                 return true;
+              }
+            }
+            let externalDelivered = true;
+            if (event.reason !== "predicate_matched" && opts?.watchNotify) {
+              try {
+                externalDelivered = (await opts.watchNotify(event)) !== false;
+              } catch {
+                externalDelivered = false;
               }
             }
             const owner =
@@ -12360,6 +12377,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     };
     context.lifecycleSweepEngine = engine;
     lifecycleHealthEngine = engine;
+    lifecycleScheduleChildReportWatchPrune = () =>
+      engine.scheduleClosedChildReportWatchPrune();
     // F1: closure, harvestability and the health report all resolve state
     // through the same live probe the caller/delivery paths use.
     engine.setLiveStateResolver(liveAgentStateProbe.current);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3654,6 +3654,7 @@ export interface CmuxServerContext {
   /** Lifecycle-lock truth for `control_health`, published by the live engine. */
   lifecycleLockStateProvider: (() => LifecycleLockState) | null;
   lifecycleSweepEngine: AgentEngine | null;
+  parentReportPathReservations: Set<string>;
   lifecycleAgentInputDeliverer: LifecycleAgentInputDeliverer | null;
   lifecycleAgentInputDelivererReadyListeners: Set<() => void>;
   setLifecycleAgentInputDeliverer(
@@ -3804,6 +3805,7 @@ export function createServerContext(
     lifecycleStartLastTimeoutAt: null,
     lifecycleLockStateProvider: null,
     lifecycleSweepEngine: null,
+    parentReportPathReservations: new Set(),
     lifecycleAgentInputDeliverer: null,
     lifecycleAgentInputDelivererReadyListeners: new Set(),
     setLifecycleAgentInputDeliverer(deliverer) {
@@ -3829,6 +3831,7 @@ export function createServerContext(
         context.controlHealthTimer = null;
       }
       context.lifecycleSweepEngine = null;
+      context.parentReportPathReservations.clear();
       context.lifecycleAgentInputDeliverer = null;
       context.lifecycleAgentInputDelivererReadyListeners.clear();
       context.originalLaunchCommandsBySurface.clear();
@@ -13092,7 +13095,41 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return `Report watch was not armed for ${coordination.report_path}: ${detail}`;
       }
     };
-    const parentReportPathReservations = new Set<string>();
+    const parentReportPathReservations = context.parentReportPathReservations;
+    const reserveParentReportPath = (
+      parentAgentId: string,
+      reportPath: string,
+      childAgentId?: string,
+    ):
+      | { ok: true; key: string }
+      | { ok: false; message: string } => {
+      const key = JSON.stringify([parentAgentId, reportPath]);
+      if (parentReportPathReservations.has(key)) {
+        return {
+          ok: false,
+          message: `report_path ${reportPath} is already reserved by another child spawn; each child requires a distinct report path`,
+        };
+      }
+      const existingReportWatch = readWatchRegistry({
+        registryPath: watchRegistryPath,
+      }).watches.find(
+        (watch) =>
+          watch.owner === parentAgentId &&
+          watch.target === reportPath &&
+          watch.change === "content" &&
+          watch.state !== "failed" &&
+          (childAgentId === undefined ||
+            watch.subject_agent_id !== childAgentId),
+      );
+      if (existingReportWatch) {
+        return {
+          ok: false,
+          message: `report_path ${reportPath} is already assigned to child ${existingReportWatch.subject_agent_id ?? "through an existing report watch"}; each child requires a distinct report path`,
+        };
+      }
+      parentReportPathReservations.add(key);
+      return { ok: true, key };
+    };
 
     server.tool(
       "report_to_parent",
@@ -13568,6 +13605,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (!existing) {
               return err(new Error(`Agent not found: ${args.resume_agent_id}`));
             }
+            const resumeCoordination = issueSpawnCoordination(
+              existing.agent_id,
+              args.report_path,
+            );
+            if (existing.parent_agent_id) {
+              const reservation = reserveParentReportPath(
+                existing.parent_agent_id,
+                resolve(resumeCoordination.report_path),
+                existing.agent_id,
+              );
+              if (!reservation.ok) {
+                return err(new Error(reservation.message), {
+                  error_code: "REPORT_PATH_IN_USE",
+                });
+              }
+              reportPathReservationKey = reservation.key;
+            }
             const workspace = await canonicalWorkspaceRef(
               args.workspace ?? existing.workspace_id ?? undefined,
             );
@@ -13613,10 +13667,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             // the most incident-prone path in this repo -- the exact thing this
             // PR exists to move work OFF. That sliver stays open on #462.
             const resumeMonitorBoot = ensureMonitorBoot(result.agent_id);
-            const resumeCoordination = issueSpawnCoordination(
-              result.agent_id,
-              args.report_path,
-            );
             const resumeContract = buildBootContractInjection(
               result.agent_id,
               resumeMonitorBoot,
@@ -13843,36 +13893,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : (args.parent_agent_id ?? callerAgent?.agent_id);
           if (effectiveParentAgentId && args.report_path) {
             const requestedReportPath = resolve(args.report_path.trim());
-            reportPathReservationKey = JSON.stringify([
+            const reservation = reserveParentReportPath(
               effectiveParentAgentId,
               requestedReportPath,
-            ]);
-            if (parentReportPathReservations.has(reportPathReservationKey)) {
-              return err(
-                new Error(
-                  `report_path ${requestedReportPath} is already reserved by another child spawn; each child requires a distinct report path`,
-                ),
-                { error_code: "REPORT_PATH_IN_USE" },
-              );
-            }
-            const existingReportWatch = readWatchRegistry({
-              registryPath: watchRegistryPath,
-            }).watches.find(
-              (watch) =>
-                watch.owner === effectiveParentAgentId &&
-                watch.target === requestedReportPath &&
-                watch.change === "content" &&
-                watch.state !== "failed",
             );
-            if (existingReportWatch) {
+            if (!reservation.ok) {
               return err(
-                new Error(
-                  `report_path ${requestedReportPath} is already assigned to child ${existingReportWatch.subject_agent_id ?? "through an existing report watch"}; each child requires a distinct report path`,
-                ),
+                new Error(reservation.message),
                 { error_code: "REPORT_PATH_IN_USE" },
               );
             }
-            parentReportPathReservations.add(reportPathReservationKey);
+            reportPathReservationKey = reservation.key;
           }
           const effectiveRole = callerIsWorker ? "worker" : normalizedRole.role;
           const workerCallerWarning = callerIsWorker

--- a/src/server.ts
+++ b/src/server.ts
@@ -13081,6 +13081,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         return `Report watch was not armed for ${coordination.report_path}: ${detail}`;
       }
     };
+    const parentReportPathReservations = new Set<string>();
 
     server.tool(
       "report_to_parent",
@@ -13504,6 +13505,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (args) => {
         const creation = new CreatedIdentityScope();
+        let reportPathReservationKey: string | null = null;
         try {
           // P11 finding 2: reject a relative override BEFORE anything launches.
           // The zod .refine() covers real MCP calls; this covers direct handler
@@ -13830,6 +13832,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : (args.parent_agent_id ?? callerAgent?.agent_id);
           if (effectiveParentAgentId && args.report_path) {
             const requestedReportPath = resolve(args.report_path.trim());
+            reportPathReservationKey = JSON.stringify([
+              effectiveParentAgentId,
+              requestedReportPath,
+            ]);
+            if (parentReportPathReservations.has(reportPathReservationKey)) {
+              return err(
+                new Error(
+                  `report_path ${requestedReportPath} is already reserved by another child spawn; each child requires a distinct report path`,
+                ),
+                { error_code: "REPORT_PATH_IN_USE" },
+              );
+            }
             const existingReportWatch = readWatchRegistry({
               registryPath: watchRegistryPath,
             }).watches.find(
@@ -13847,6 +13861,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 { error_code: "REPORT_PATH_IN_USE" },
               );
             }
+            parentReportPathReservations.add(reportPathReservationKey);
           }
           const effectiveRole = callerIsWorker ? "worker" : normalizedRole.role;
           const workerCallerWarning = callerIsWorker
@@ -14425,6 +14440,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             return err(caught, surfaceGonePayload(caught));
           }
           return err(caught);
+        } finally {
+          if (reportPathReservationKey) {
+            parentReportPathReservations.delete(reportPathReservationKey);
+          }
         }
       },
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -13119,7 +13119,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           watch.change === "content" &&
           watch.state !== "failed" &&
           (childAgentId === undefined ||
-            watch.subject_agent_id !== childAgentId),
+            (watch.subject_agent_id !== undefined &&
+              watch.subject_agent_id !== childAgentId)),
       );
       if (existingReportWatch) {
         return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4123,10 +4123,16 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   let lifecycleScheduleChildReportWatchPrune: (() => void) | null = null;
   const pruneChildReportWatchesFor = (agentId: string): void => {
     lifecycleScheduleChildReportWatchPrune?.();
-    removeWatches((watch) => watch.subject_agent_id === agentId, {
-      registryPath:
-        opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
-    }).catch((error) => {
+    removeWatches(
+      (watch) =>
+        watch.subject_agent_id === agentId &&
+        watch.target_kind === "file" &&
+        watch.change === "content",
+      {
+        registryPath:
+          opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
+      },
+    ).catch((error) => {
       console.error(
         `[cmuxlayer] deferred child watch cleanup for ${agentId}:`,
         error instanceof Error ? error.message : String(error),

--- a/src/server.ts
+++ b/src/server.ts
@@ -4127,10 +4127,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const pruneChildReportWatchesFor = (agentId: string): void => {
     lifecycleScheduleChildReportWatchPrune?.();
     removeWatches(
-      (watch) =>
-        watch.subject_agent_id === agentId &&
-        watch.target_kind === "file" &&
-        watch.change === "content",
+      (watch) => {
+        if (
+          watch.subject_agent_id !== agentId ||
+          watch.target_kind !== "file" ||
+          watch.change !== "content"
+        ) {
+          return false;
+        }
+        const current = stateMgr.readState(agentId);
+        return (
+          !current ||
+          current.user_killed === true ||
+          current.deletion_intent ||
+          TERMINAL_AGENT_STATES.has(current.state)
+        );
+      },
       {
         registryPath:
           opts?.watchRegistryPath ?? join(context.stateDir, "watch-specs.json"),
@@ -13882,6 +13894,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             ? await readFile(bootPromptPath, "utf8")
             : null;
 
+          if (args.parent_agent_id && args.report_path) {
+            const earlyReservation = reserveParentReportPath(
+              args.parent_agent_id,
+              resolve(args.report_path.trim()),
+            );
+            if (!earlyReservation.ok) {
+              return err(new Error(earlyReservation.message), {
+                error_code: "REPORT_PATH_IN_USE",
+              });
+            }
+            reportPathReservationKey = earlyReservation.key;
+          }
           await refreshManagedMetadataBestEffort(args.parent_agent_id);
           await refreshManagedMetadataBestEffort();
           const callerAgent = resolveCurrentCallerAgent();
@@ -13894,17 +13918,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             : (args.parent_agent_id ?? callerAgent?.agent_id);
           if (effectiveParentAgentId && args.report_path) {
             const requestedReportPath = resolve(args.report_path.trim());
-            const reservation = reserveParentReportPath(
+            const effectiveReservationKey = JSON.stringify([
               effectiveParentAgentId,
               requestedReportPath,
-            );
-            if (!reservation.ok) {
-              return err(
-                new Error(reservation.message),
-                { error_code: "REPORT_PATH_IN_USE" },
-              );
+            ]);
+            if (
+              reportPathReservationKey &&
+              reportPathReservationKey !== effectiveReservationKey
+            ) {
+              parentReportPathReservations.delete(reportPathReservationKey);
+              reportPathReservationKey = null;
             }
-            reportPathReservationKey = reservation.key;
+            if (!reportPathReservationKey) {
+              const reservation = reserveParentReportPath(
+                effectiveParentAgentId,
+                requestedReportPath,
+              );
+              if (!reservation.ok) {
+                return err(new Error(reservation.message), {
+                  error_code: "REPORT_PATH_IN_USE",
+                });
+              }
+              reportPathReservationKey = reservation.key;
+            }
           }
           const effectiveRole = callerIsWorker ? "worker" : normalizedRole.role;
           const workerCallerWarning = callerIsWorker

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -455,6 +455,15 @@ function contentFingerprint(
   return createHash("sha256").update(content).digest("hex");
 }
 
+function storedContentDigest(
+  fingerprint: string | undefined,
+): string | undefined {
+  const legacy = fingerprint?.match(
+    /^([a-f\d]{64}):[^:]+:[^:]+:[^:]+:[^:]+$/i,
+  );
+  return legacy?.[1] ?? fingerprint;
+}
+
 function assertSpec(
   spec: WatchSpec,
   opts: WatchRegistryOptions,
@@ -814,7 +823,7 @@ export async function sweepWatches(
         record.target_kind === "file"
           ? record.change === "content"
             ? typeof observedValue === "string" &&
-              observedValue !== record.fingerprint
+              observedValue !== storedContentDigest(record.fingerprint)
             : typeof observedValue === "number" &&
               observedValue > (record.watermark ?? 0)
           : observedValue === record.predicate;
@@ -873,6 +882,9 @@ export async function sweepWatches(
         ...heartbeat,
         missing_since_at_ms: undefined,
         observed_value: observedValue,
+        ...(record.change === "content" && typeof observedValue === "string"
+          ? { fingerprint: observedValue }
+          : {}),
       };
     });
     if (registry.watches.length > 0) {

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -577,12 +577,11 @@ export async function armWatch(
   }
   const source: WatchObservedSource =
     checked.targetKind === "file" ? "process" : "screen";
+  const subjectAgentId = cleanString(spec.subject_agent_id);
   const record: WatchRecord = {
     watch_id: randomUUID(),
     owner: checked.owner,
-    ...(cleanString(spec.subject_agent_id)
-      ? { subject_agent_id: cleanString(spec.subject_agent_id)! }
-      : {}),
+    ...(subjectAgentId ? { subject_agent_id: subjectAgentId } : {}),
     target,
     ...(checked.predicate ? { predicate: checked.predicate } : {}),
     ...(checked.marker ? { marker: checked.marker } : {}),
@@ -606,7 +605,7 @@ export async function armWatch(
   return record;
 }
 
-export async function removeWatches(
+export function removeWatches(
   predicate: (watch: WatchRecord) => boolean,
   opts: WatchRegistryOptions = {},
 ): Promise<number> {
@@ -624,13 +623,13 @@ export async function removeWatches(
   });
 }
 
-export async function scopeWatchToSubject(
+export function scopeWatchToSubject(
   watchId: string,
   subjectAgentId: string,
   opts: WatchRegistryOptions = {},
 ): Promise<boolean> {
   const subject = cleanString(subjectAgentId);
-  if (!subject) return false;
+  if (!subject) return Promise.resolve(false);
   const path = registryPathFor(opts);
   return withWriteLock(path, () => {
     const registry = readRegistryState(path);

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -32,6 +32,8 @@ export interface WatchObserved<T> {
 
 export interface WatchSpec {
   owner: string;
+  /** Managed child whose lifecycle owns this watch. */
+  subject_agent_id?: string;
   target: string;
   predicate?: WatchAgentPredicate;
   marker?: string;
@@ -47,6 +49,7 @@ export interface WatchRecord extends WatchSpec {
   target_kind: "file" | "agent";
   watermark?: number;
   fingerprint?: string;
+  missing_since_at_ms?: number;
   armed_at_ms: number;
   last_heartbeat_at_ms: number;
   liveness_source: string;
@@ -76,6 +79,7 @@ export type WatchNotificationReason =
 export interface WatchNotification {
   watch_id: string;
   owner: string;
+  subject_agent_id?: string;
   target: string;
   target_kind: "file" | "agent";
   reason: WatchNotificationReason;
@@ -153,6 +157,7 @@ const WRITE_LOCK_STALE_MS = 30_000;
 const WRITE_LOCK_RETRY_MS = 5;
 const NOTIFY_RETRY_BASE_MS = 1_000;
 const NOTIFY_RETRY_MAX_MS = 60_000;
+const FILE_MISSING_DEBOUNCE_MS = 2_000;
 
 interface WatchRegistryState {
   version: unknown;
@@ -229,6 +234,18 @@ function isWatchRecord(value: unknown): value is WatchRecord {
     return false;
   }
   if (value.fingerprint !== undefined && typeof value.fingerprint !== "string") {
+    return false;
+  }
+  if (
+    value.subject_agent_id !== undefined &&
+    typeof value.subject_agent_id !== "string"
+  ) {
+    return false;
+  }
+  if (
+    value.missing_since_at_ms !== undefined &&
+    !isFiniteNumber(value.missing_since_at_ms)
+  ) {
     return false;
   }
   if (
@@ -435,8 +452,7 @@ function contentFingerprint(
     content = io.read(path);
     after = io.stat(path);
   }
-  const digest = createHash("sha256").update(content).digest("hex");
-  return [digest, after.mtimeNs, after.ctimeNs, after.ino, after.size].join(":");
+  return createHash("sha256").update(content).digest("hex");
 }
 
 function assertSpec(
@@ -564,6 +580,9 @@ export async function armWatch(
   const record: WatchRecord = {
     watch_id: randomUUID(),
     owner: checked.owner,
+    ...(cleanString(spec.subject_agent_id)
+      ? { subject_agent_id: cleanString(spec.subject_agent_id)! }
+      : {}),
     target,
     ...(checked.predicate ? { predicate: checked.predicate } : {}),
     ...(checked.marker ? { marker: checked.marker } : {}),
@@ -587,6 +606,45 @@ export async function armWatch(
   return record;
 }
 
+export async function removeWatches(
+  predicate: (watch: WatchRecord) => boolean,
+  opts: WatchRegistryOptions = {},
+): Promise<number> {
+  const path = registryPathFor(opts);
+  return withWriteLock(path, () => {
+    const registry = readRegistryState(path);
+    let removed = 0;
+    const rows = registry.rows.filter((row) => {
+      if (!isWatchRecord(row) || !predicate(row)) return true;
+      removed += 1;
+      return false;
+    });
+    if (removed > 0) writeRegistry(path, registry.version, rows);
+    return removed;
+  });
+}
+
+export async function scopeWatchToSubject(
+  watchId: string,
+  subjectAgentId: string,
+  opts: WatchRegistryOptions = {},
+): Promise<boolean> {
+  const subject = cleanString(subjectAgentId);
+  if (!subject) return false;
+  const path = registryPathFor(opts);
+  return withWriteLock(path, () => {
+    const registry = readRegistryState(path);
+    let updated = false;
+    const rows = registry.rows.map((row) => {
+      if (!isWatchRecord(row) || row.watch_id !== watchId) return row;
+      updated = true;
+      return { ...row, subject_agent_id: subject };
+    });
+    if (updated) writeRegistry(path, registry.version, rows);
+    return updated;
+  });
+}
+
 function notificationFor(
   record: WatchRecord,
   reason: WatchNotificationReason,
@@ -596,6 +654,9 @@ function notificationFor(
   return {
     watch_id: record.watch_id,
     owner: record.owner,
+    ...(record.subject_agent_id
+      ? { subject_agent_id: record.subject_agent_id }
+      : {}),
     target: record.target,
     target_kind: record.target_kind,
     reason,
@@ -696,6 +757,17 @@ export async function sweepWatches(
       >;
 
       if (!exists) {
+        if (record.target_kind === "file") {
+          const missingSince = record.missing_since_at_ms ?? observedAt;
+          if (observedAt - missingSince < FILE_MISSING_DEBOUNCE_MS) {
+            result.armed.push(record.watch_id);
+            return {
+              ...record,
+              ...heartbeat,
+              missing_since_at_ms: missingSince,
+            };
+          }
+        }
         const reason: WatchNotificationReason =
           record.target_kind === "agent" ? "consumer_died" : "target_missing";
         const notification = notificationFor(record, reason, observedAt);
@@ -797,7 +869,12 @@ export async function sweepWatches(
       }
 
       result.armed.push(record.watch_id);
-      return { ...record, ...heartbeat, observed_value: observedValue };
+      return {
+        ...record,
+        ...heartbeat,
+        missing_since_at_ms: undefined,
+        observed_value: observedValue,
+      };
     });
     if (registry.watches.length > 0) {
       writeRegistry(path, registry.version, watches);

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -497,6 +497,55 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ).toEqual([]);
   });
 
+  it.each(["stop_agent", "kill", "close_surface"] as const)(
+    "drops a child-scoped report watch after %s terminates the child",
+    async (toolName) => {
+      await server._registeredTools.list_agents.handler({}, {} as never);
+      const engine = server._registeredTools.interact._engine;
+      const reportPath = join(inboxDir, toolName, "report.md");
+      const child: AgentRecord = {
+        ...parentRecord(),
+        agent_id: `terminated-by-${toolName}`,
+        surface_id: "surface:new",
+        surface_uuid: null,
+        state: "done",
+        parent_agent_id: "lead-parent",
+        spawn_depth: 1,
+        role: "worker",
+        report_path: reportPath,
+      };
+      mkdirSync(join(inboxDir, toolName), { recursive: true });
+      writeFileSync(reportPath, "done\n", "utf8");
+      engine.stateMgr.writeState(child);
+      engine.getRegistry().set(child.agent_id, child);
+      await engine.armWatch({
+        owner: "lead-parent",
+        subject_agent_id: child.agent_id,
+        target: reportPath,
+        change: "content",
+        deadline: Number.MAX_SAFE_INTEGER,
+      });
+
+      const args =
+        toolName === "stop_agent"
+          ? { agent_id: child.agent_id, force: true }
+          : toolName === "kill"
+            ? { target: child.agent_id, force: true }
+            : { scope: "surface", surface: child.surface_id, force: true };
+      const result = await server._registeredTools[toolName].handler(
+        args,
+        {} as never,
+      );
+
+      expect(result.isError, JSON.stringify(result)).not.toBe(true);
+      await vi.waitFor(() =>
+        expect(
+          readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+        ).toEqual([]),
+      );
+    },
+  );
+
   it("closes the pane and schedules watch cleanup when the registry lock is contended", async () => {
     await server.close();
     const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -738,6 +787,82 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         state: "armed",
       }),
     ]);
+  });
+
+  it("leaves non-report subject watches alone when pruning a closed child", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "closed-child-with-marker-watch",
+      state: "done",
+      user_killed: true,
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+    };
+    const target = join(inboxDir, child.agent_id, "marker.md");
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(target, "working\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target,
+      marker: "DONE_MARKER",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    engine.scheduleClosedChildReportWatchPrune();
+    await engine.runSweep();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        subject_agent_id: child.agent_id,
+        marker: "DONE_MARKER",
+        state: "armed",
+      }),
+    ]);
+  });
+
+  it("preserves a prune request scheduled while the previous prune is in flight", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const controlled = engine as unknown as {
+      pruneClosedChildReportWatches: () => Promise<void>;
+      retryClosedChildReportWatchPrune: () => Promise<void>;
+    };
+    let releaseFirstPrune: (() => void) | undefined;
+    const prune = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseFirstPrune = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    controlled.pruneClosedChildReportWatches = prune;
+
+    engine.scheduleClosedChildReportWatchPrune();
+    const firstRetry = controlled.retryClosedChildReportWatchPrune();
+    await vi.waitFor(() => expect(prune).toHaveBeenCalledOnce());
+    engine.scheduleClosedChildReportWatchPrune();
+    releaseFirstPrune?.();
+    await firstRetry;
+    await controlled.retryClosedChildReportWatchPrune();
+
+    expect(prune).toHaveBeenCalledTimes(2);
   });
 
   it("does not wake a lead for another parent's child report", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -645,6 +645,70 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     }
   });
 
+  it("keeps a report watch when the child resumes before deferred cleanup acquires the lock", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const reportPath = join(inboxDir, "resumed-during-cleanup", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "resumed-during-cleanup",
+      surface_id: "surface:new",
+      state: "done",
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+      user_killed: true,
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const lockPath = `${watchRegistryPath}.lock`;
+    mkdirSync(lockPath);
+    vi.useFakeTimers({ now: 10_000 });
+
+    try {
+      const closeResult = await server._registeredTools.close_surface.handler(
+        { scope: "agent", agent_id: child.agent_id, force: true },
+        {} as never,
+      );
+      expect(closeResult.isError, JSON.stringify(closeResult)).not.toBe(true);
+
+      const resumed = {
+        ...child,
+        state: "ready" as const,
+        user_killed: false,
+        deletion_intent: false,
+      };
+      engine.stateMgr.writeState(resumed);
+      engine.getRegistry().set(resumed.agent_id, resumed);
+      rmSync(lockPath, { recursive: true, force: true });
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toEqual([
+        expect.objectContaining({
+          subject_agent_id: child.agent_id,
+          target: reportPath,
+          change: "content",
+          state: "armed",
+        }),
+      ]);
+    } finally {
+      rmSync(lockPath, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
   it("drops persisted closed-child report watches before the first daemon sweep", async () => {
     await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
@@ -1501,6 +1565,8 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const existingChildUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const spawnedChildUuid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    let holdNextSplit = false;
+    let releaseSplit: (() => void) | null = null;
     const baseExec = makeExec(
       "Claude Code\nWhat can I help you with?\n❯ ",
       "parent-pane",
@@ -1523,6 +1589,11 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     );
     exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
       if (args.includes("new-split")) {
+        if (holdNextSplit) {
+          await new Promise<void>((resolve) => {
+            releaseSplit = resolve;
+          });
+        }
         return {
           stdout: JSON.stringify({
             workspace: "workspace:1",
@@ -1596,21 +1667,30 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       "concurrent-shared-report.md",
     );
     const beforeConcurrent = splitCalls();
-    const concurrent = await Promise.all([
-      spawn({
+    holdNextSplit = true;
+    const winningSpawn = spawn({
+      parent_agent_id: parent.agent_id,
+      report_path: concurrentOverride,
+    });
+    await vi.waitFor(() => expect(splitCalls()).toBe(beforeConcurrent + 1));
+    const rejectedSpawn = spawn(
+      {
         parent_agent_id: parent.agent_id,
         report_path: concurrentOverride,
-      }),
-      spawn(
-        {
-          parent_agent_id: parent.agent_id,
-          report_path: concurrentOverride,
-        },
-        siblingServer,
-      ),
-    ]);
+      },
+      siblingServer,
+    );
+    await Promise.resolve();
+    holdNextSplit = false;
+    releaseSplit?.();
+    const concurrent = await Promise.all([winningSpawn, rejectedSpawn]);
+    // This fixture's one successful spawn uses two new-split calls: placement
+    // and launch. A third call would prove that the rejected socket launched.
     expect(splitCalls() - beforeConcurrent).toBe(2);
     expect(concurrent.map((result) => result.ok).sort()).toEqual([false, true]);
+    expect(
+      concurrent.find((result) => result.ok === false)?.error_code,
+    ).toBe("REPORT_PATH_IN_USE");
     await siblingServer.close();
   });
 });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -309,7 +309,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(detail.done_marker).toBe(parsed.done_marker);
   });
 
-  it("wakes the parent for every report revision even when the terminal marker is unchanged", async () => {
+  it("wakes the parent once per distinct report content", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -368,6 +368,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(readWatchRegistry({ registryPath: watchRegistryPath }).watches).toEqual([
       expect.objectContaining({
         owner: parent.agent_id,
+        subject_agent_id: child.agent_id,
         target: child.report_path,
         change: "content",
         state: "armed",
@@ -434,7 +435,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
           (arg) => arg.includes("[report]") && arg.includes(child.report_path),
         ),
       ),
-    ).toBe(true);
+    ).toBe(false);
 
     expect(readWatchRegistry({ registryPath: watchRegistryPath }).watches).toEqual([
       expect.objectContaining({
@@ -445,6 +446,144 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         notification_pending: false,
       }),
     ]);
+  });
+
+  it("drops a child-scoped report watch when close_surface closes the agent", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as any);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord();
+    const reportPath = join(inboxDir, "closed-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "closed-child",
+      surface_id: "surface:already-gone",
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      user_killed: true,
+      report_path: reportPath,
+      task_summary: "closed child fixture",
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(parent);
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(parent.agent_id, parent);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    const closeResult = await server._registeredTools.close_surface.handler(
+      { scope: "agent", agent_id: child.agent_id, force: true },
+      {} as any,
+    );
+
+    expect(closeResult.isError, JSON.stringify(closeResult)).not.toBe(true);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([]);
+  });
+
+  it("drops persisted closed-child report watches before the first daemon sweep", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as any);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord();
+    const reportPath = join(inboxDir, "closed-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "closed-child",
+      surface_id: "surface:closed-child",
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      user_killed: true,
+      report_path: reportPath,
+      task_summary: "closed child fixture",
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(parent);
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(parent.agent_id, parent);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: parent.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toHaveLength(1);
+
+    await server.close();
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as any);
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([]);
+  });
+
+  it("does not wake a lead for another parent's child report", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as any);
+    const engine = server._registeredTools.interact._engine;
+    const owner = parentRecord();
+    const foreignParent: AgentRecord = {
+      ...parentRecord("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+      agent_id: "foreign-parent",
+      surface_id: "surface:foreign-parent",
+    };
+    const reportPath = join(inboxDir, "foreign-child", "report.md");
+    const foreignChild: AgentRecord = {
+      ...parentRecord("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+      agent_id: "foreign-child",
+      surface_id: "surface:foreign-child",
+      parent_agent_id: foreignParent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+      task_summary: "foreign child fixture",
+    };
+    mkdirSync(join(inboxDir, foreignChild.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [owner, foreignParent, foreignChild]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: owner.agent_id,
+      subject_agent_id: foreignChild.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    writeFileSync(reportPath, "after\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+
+    const wakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
+    expect(
+      wakeCalls.some(([, args]: [string, string[]]) =>
+        args.some((arg) => arg.includes("[report]")),
+      ),
+    ).toBe(false);
   });
 
   it("does not describe a missing report target as a done marker and preserves the reason-aware notifier", async () => {
@@ -458,6 +597,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       [],
       parentUuid,
     );
+    let watchNow = 1_000;
     server = createServer(
       withTestSurfaceObserver({
         exec,
@@ -465,6 +605,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         disableSpawnPreflight: true,
         inboxBaseDir: inboxDir,
         watchRegistryPath,
+        watchRegistryNow: () => watchNow,
         watchNotify: externalNotify,
       }),
     );
@@ -483,6 +624,12 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     });
 
     rmSync(reportPath);
+    await engine.sweepWatchesBestEffort();
+
+    expect(sentText(exec)).not.toContain("target missing");
+    expect(externalNotify).not.toHaveBeenCalled();
+
+    watchNow = 3_000;
     await engine.sweepWatchesBestEffort();
 
     expect(sentText(exec)).not.toContain("done marker observed");

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -525,6 +525,15 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         change: "content",
         deadline: Number.MAX_SAFE_INTEGER,
       });
+      const markerPath = join(inboxDir, toolName, "marker.md");
+      writeFileSync(markerPath, "working\n", "utf8");
+      await engine.armWatch({
+        owner: "lead-parent",
+        subject_agent_id: child.agent_id,
+        target: markerPath,
+        marker: "DONE_MARKER",
+        deadline: Number.MAX_SAFE_INTEGER,
+      });
 
       const args =
         toolName === "stop_agent"
@@ -541,7 +550,14 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       await vi.waitFor(() =>
         expect(
           readWatchRegistry({ registryPath: watchRegistryPath }).watches,
-        ).toEqual([]),
+        ).toEqual([
+          expect.objectContaining({
+            subject_agent_id: child.agent_id,
+            target: markerPath,
+            marker: "DONE_MARKER",
+            state: "armed",
+          }),
+        ]),
       );
     },
   );

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -835,6 +835,55 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ]);
   });
 
+  it("retains a legacy shared-path watch when any matching direct child is live", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const target = join(inboxDir, "legacy-shared", "report.md");
+    const liveChild: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "legacy-live-child",
+      parent_agent_id: "lead-live",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: target,
+    };
+    const closedChild: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "legacy-closed-child",
+      state: "done",
+      user_killed: true,
+      parent_agent_id: "lead-closed",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: target,
+    };
+    mkdirSync(join(inboxDir, "legacy-shared"), { recursive: true });
+    writeFileSync(target, "working\n", "utf8");
+    engine.stateMgr.writeState(liveChild);
+    engine.stateMgr.writeState(closedChild);
+    engine.getRegistry().set(liveChild.agent_id, liveChild);
+    engine.getRegistry().set(closedChild.agent_id, closedChild);
+    await engine.armWatch({
+      owner: liveChild.parent_agent_id,
+      target,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    engine.scheduleClosedChildReportWatchPrune();
+    await engine.runSweep();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        owner: liveChild.parent_agent_id,
+        target,
+        state: "armed",
+      }),
+    ]);
+  });
+
   it("preserves a prune request scheduled while the previous prune is in flight", async () => {
     await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
@@ -1000,7 +1049,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       ],
       parentUuid,
     );
-    exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+    exec = vi.fn().mockImplementation((cmd, args: string[]) => {
       if (args.includes("new-split")) {
         return {
           stdout: JSON.stringify({
@@ -1457,5 +1506,24 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,
     ).toHaveLength(1);
+
+    const concurrentOverride = join(
+      inboxDir,
+      "collab",
+      "concurrent-shared-report.md",
+    );
+    const beforeConcurrent = splitCalls();
+    const concurrent = await Promise.all([
+      spawn({
+        parent_agent_id: parent.agent_id,
+        report_path: concurrentOverride,
+      }),
+      spawn({
+        parent_agent_id: parent.agent_id,
+        report_path: concurrentOverride,
+      }),
+    ]);
+    expect(splitCalls() - beforeConcurrent).toBe(2);
+    expect(concurrent.map((result) => result.ok).sort()).toEqual([false, true]);
   });
 });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -20,7 +20,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer } from "../src/server.js";
+import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
 import { withTestSurfaceObserver } from "./helpers/test-surface-observer.js";
 import { runWithCallerContext } from "../src/caller-context.js";
@@ -279,8 +279,11 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     rmSync(inboxDir, { recursive: true, force: true });
   });
 
-  async function spawn(extra: Record<string, unknown> = {}) {
-    const tool = server._registeredTools["spawn_agent"];
+  async function spawn(
+    extra: Record<string, unknown> = {},
+    targetServer = server,
+  ) {
+    const tool = targetServer._registeredTools["spawn_agent"];
     const result = await runWithCallerContext({ workspaceId: "workspace:1" }, () =>
       tool.handler(
         {
@@ -1008,14 +1011,11 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       report_path: reportPath,
       task_summary: "reparent race fixture",
     };
-    let engine: ReturnType<
-      typeof createServer
-    >["_registeredTools"]["interact"]["_engine"];
-    const externalNotify = vi.fn().mockImplementation(async () => {
+    const externalNotify = vi.fn().mockImplementation(() => {
       const reparented = { ...child, parent_agent_id: nextParent.agent_id };
       engine.stateMgr.writeState(reparented);
       engine.getRegistry().set(reparented.agent_id, reparented);
-      return true;
+      return Promise.resolve(true);
     });
     server = createServer(
       withTestSurfaceObserver({
@@ -1027,7 +1027,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         watchNotify: externalNotify,
       }),
     );
-    engine = server._registeredTools.interact._engine;
+    const engine = server._registeredTools.interact._engine;
     mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
     writeFileSync(reportPath, "before\n", "utf8");
     for (const record of [owner, nextParent, child]) {
@@ -1537,15 +1537,16 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       }
       return baseExec(cmd, args);
     });
-    server = createServer(
-      withTestSurfaceObserver({
-        exec,
-        stateDir: STATE_DIR,
-        disableSpawnPreflight: true,
-        inboxBaseDir: inboxDir,
-        watchRegistryPath,
-      }),
-    );
+    const serverOptions = withTestSurfaceObserver({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+      watchRegistryPath,
+    });
+    const context = createServerContext(serverOptions);
+    server = createServer({ ...serverOptions, context });
+    const siblingServer = createServer({ ...serverOptions, context });
     const parent = parentRecord(parentUuid);
     const existingChild: AgentRecord = {
       ...parentRecord(existingChildUuid),
@@ -1600,12 +1601,16 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         parent_agent_id: parent.agent_id,
         report_path: concurrentOverride,
       }),
-      spawn({
-        parent_agent_id: parent.agent_id,
-        report_path: concurrentOverride,
-      }),
+      spawn(
+        {
+          parent_agent_id: parent.agent_id,
+          report_path: concurrentOverride,
+        },
+        siblingServer,
+      ),
     ]);
     expect(splitCalls() - beforeConcurrent).toBe(2);
     expect(concurrent.map((result) => result.ok).sort()).toEqual([false, true]);
+    await siblingServer.close();
   });
 });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -471,7 +471,9 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       parent_agent_id: parent.agent_id,
       spawn_depth: 1,
       role: "worker",
-      user_killed: true,
+      // stopAgent is a no-op for an already-terminal child, so deferred
+      // cleanup must not rely on user_killed being set by the stop path.
+      user_killed: false,
       report_path: reportPath,
       task_summary: "closed child fixture",
     };
@@ -870,6 +872,40 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         state: "armed",
       }),
     ]);
+  });
+
+  it("prunes a terminal child's report watch when stop left user_killed unset", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const target = join(inboxDir, "terminal-child-without-stop-flag", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "terminal-child-without-stop-flag",
+      state: "done",
+      user_killed: false,
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: target,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(target, "done\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    engine.scheduleClosedChildReportWatchPrune();
+    await engine.runSweep();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([]);
   });
 
   it("leaves non-report subject watches alone when pruning a closed child", async () => {
@@ -1629,20 +1665,10 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     };
     const stateMgr = new StateManager(STATE_DIR);
     stateMgr.writeState(parent);
-    stateMgr.writeState(existingChild);
     const override = join(inboxDir, "collab", "shared-report.md");
+    stateMgr.writeState({ ...existingChild, report_path: override });
     mkdirSync(join(inboxDir, "collab"), { recursive: true });
     writeFileSync(override, "", "utf8");
-    await armWatch(
-      {
-        owner: parent.agent_id,
-        subject_agent_id: existingChild.agent_id,
-        target: override,
-        change: "content",
-        deadline: Number.MAX_SAFE_INTEGER,
-      },
-      { registryPath: watchRegistryPath },
-    );
     const splitCalls = () =>
       (exec as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
         ([, args]: [string, string[]]) => args.includes("new-split"),
@@ -1659,7 +1685,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(splitCalls()).toBe(before);
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,
-    ).toHaveLength(1);
+    ).toHaveLength(0);
 
     const concurrentOverride = join(
       inboxDir,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -156,6 +156,12 @@ function makeExec(
         stderr: "",
       };
     }
+    if (args.includes("close-surface")) {
+      const surfaceRef = String(args[args.indexOf("--surface") + 1] ?? "");
+      const surfaceIndex = surfaces.findIndex(({ ref }) => ref === surfaceRef);
+      if (surfaceIndex >= 0) surfaces.splice(surfaceIndex, 1);
+      return { stdout: "{}", stderr: "" };
+    }
     if (args.includes("send-key") && args.includes("return")) {
       if (promptPending) {
         setScreenText("Claude Code\n✻ Working\n", promptSurface);
@@ -284,7 +290,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
           prompt: "task",
           ...extra,
         },
-        {} as any,
+        {} as never,
       ),
     );
     return result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -303,7 +309,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
   it("persists the contract on the record, so the consumer reads what was issued", async () => {
     const parsed = await spawn();
     const getState = server._registeredTools["get_agent_state"];
-    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as any);
+    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as never);
     const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
     expect(detail.report_path).toBe(parsed.report_path);
     expect(detail.done_marker).toBe(parsed.done_marker);
@@ -387,7 +393,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         watchNotify: unavailableExternalNotify,
       }),
     );
-    await server._registeredTools.list_agents.handler({}, {} as any);
+    await server._registeredTools.list_agents.handler({}, {} as never);
     engine = server._registeredTools.interact._engine;
     const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
     writeFileSync(
@@ -449,7 +455,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
   });
 
   it("drops a child-scoped report watch when close_surface closes the agent", async () => {
-    await server._registeredTools.list_agents.handler({}, {} as any);
+    await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
     const parent = parentRecord();
     const reportPath = join(inboxDir, "closed-child", "report.md");
@@ -481,7 +487,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
 
     const closeResult = await server._registeredTools.close_surface.handler(
       { scope: "agent", agent_id: child.agent_id, force: true },
-      {} as any,
+      {} as never,
     );
 
     expect(closeResult.isError, JSON.stringify(closeResult)).not.toBe(true);
@@ -490,8 +496,88 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ).toEqual([]);
   });
 
+  it("closes the pane and schedules watch cleanup when the registry lock is contended", async () => {
+    await server.close();
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "child-pane",
+      undefined,
+      [],
+      childUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const reportPath = join(inboxDir, "locked-close-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(childUuid),
+      agent_id: "locked-close-child",
+      surface_id: "surface:new",
+      state: "done",
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+      user_killed: true,
+      report_path: reportPath,
+      task_summary: "locked close child fixture",
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    const lockPath = `${watchRegistryPath}.lock`;
+    mkdirSync(lockPath);
+    vi.useFakeTimers({ now: 10_000 });
+    try {
+      const closePromise = server._registeredTools.close_surface.handler(
+        { scope: "agent", agent_id: child.agent_id, force: true },
+        {} as never,
+      );
+      await vi.advanceTimersByTimeAsync(5_001);
+      const closeResult = await closePromise;
+
+      expect(closeResult.isError, JSON.stringify(closeResult)).not.toBe(true);
+      expect(closeResult.structuredContent).toMatchObject({
+        surface_closed: true,
+        watch_cleanup: "scheduled",
+      });
+      expect(
+        (exec as ReturnType<typeof vi.fn>).mock.calls.some(
+          ([, args]: [string, string[]]) => args.includes("close-surface"),
+        ),
+      ).toBe(true);
+
+      rmSync(lockPath, { recursive: true, force: true });
+      await vi.advanceTimersByTimeAsync(10);
+      await engine.runSweep();
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toEqual([]);
+    } finally {
+      rmSync(lockPath, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
   it("drops persisted closed-child report watches before the first daemon sweep", async () => {
-    await server._registeredTools.list_agents.handler({}, {} as any);
+    await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
     const parent = parentRecord();
     const reportPath = join(inboxDir, "closed-child", "report.md");
@@ -533,15 +619,140 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         watchRegistryPath,
       }),
     );
-    await server._registeredTools.list_agents.handler({}, {} as any);
+    await server._registeredTools.list_agents.handler({}, {} as never);
 
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,
     ).toEqual([]);
   });
 
+  it("keeps lifecycle initialization live and retries startup pruning after lock contention", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord();
+    const reportPath = join(inboxDir, "locked-startup-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "locked-startup-child",
+      surface_id: "surface:closed-child",
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      user_killed: true,
+      report_path: reportPath,
+      task_summary: "locked startup child fixture",
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(parent);
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(parent.agent_id, parent);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    await server.close();
+
+    const lockPath = `${watchRegistryPath}.lock`;
+    mkdirSync(lockPath);
+    vi.useFakeTimers({ now: 10_000 });
+    try {
+      server = createServer(
+        withTestSurfaceObserver({
+          exec,
+          stateDir: STATE_DIR,
+          disableSpawnPreflight: true,
+          inboxBaseDir: inboxDir,
+          watchRegistryPath,
+        }),
+      );
+      const listPromise = server._registeredTools.list_agents.handler(
+        {},
+        {} as never,
+      );
+      await vi.advanceTimersByTimeAsync(5_001);
+      const listResult = await listPromise;
+
+      expect(listResult.isError, JSON.stringify(listResult)).not.toBe(true);
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toHaveLength(1);
+
+      rmSync(lockPath, { recursive: true, force: true });
+      await server._registeredTools.interact._engine.runSweep();
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toEqual([]);
+    } finally {
+      rmSync(lockPath, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains a valid subject watch when retry sees only persisted child state", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord();
+    const reportPath = join(inboxDir, "persisted-only-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "persisted-only-child",
+      surface_id: "surface:persisted-only-child",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+      task_summary: "persisted-only child fixture",
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "working\n", "utf8");
+    engine.stateMgr.writeState(parent);
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(parent.agent_id, parent);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    engine.getRegistry().remove(child.agent_id);
+    engine.scheduleClosedChildReportWatchPrune();
+    await engine.runSweep();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        owner: parent.agent_id,
+        subject_agent_id: child.agent_id,
+        target: reportPath,
+        state: "armed",
+      }),
+    ]);
+  });
+
   it("does not wake a lead for another parent's child report", async () => {
-    await server._registeredTools.list_agents.handler({}, {} as any);
+    await server.close();
+    const externalNotify = vi.fn().mockResolvedValue(true);
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchNotify: externalNotify,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
     const owner = parentRecord();
     const foreignParent: AgentRecord = {
@@ -584,6 +795,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         args.some((arg) => arg.includes("[report]")),
       ),
     ).toBe(false);
+    expect(externalNotify).not.toHaveBeenCalled();
   });
 
   it("does not describe a missing report target as a done marker and preserves the reason-aware notifier", async () => {
@@ -821,7 +1033,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
               role: "worker",
               prompt: "task",
             },
-            {} as any,
+            {} as never,
           );
           return result.structuredContent ?? JSON.parse(result.content[0].text);
         },
@@ -913,7 +1125,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
               role: "worker",
               prompt: "task",
             },
-            {} as any,
+            {} as never,
           ),
       );
       const raw =
@@ -998,7 +1210,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
               prompt: "task",
               report_path: "reports/worker.md",
             },
-            {} as any,
+            {} as never,
           ),
       );
       const parsed =
@@ -1022,7 +1234,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const parsed = await spawn({ report_path: override });
     expect(parsed.report_path).toBe(override);
     const getState = server._registeredTools["get_agent_state"];
-    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as any);
+    const state = await getState.handler({ agent_id: parsed.agent_id }, {} as never);
     const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
     expect(detail.report_path).toBe(override);
   });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -900,7 +900,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
             releaseFirstPrune = resolve;
           }),
       )
-      .mockResolvedValue(undefined);
+      .mockResolvedValue();
     controlled.pruneClosedChildReportWatches = prune;
 
     engine.scheduleClosedChildReportWatchPrune();
@@ -971,6 +971,72 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       ),
     ).toBe(false);
     expect(externalNotify).not.toHaveBeenCalled();
+  });
+
+  it("does not wake the former parent when a child is reparented during external notification", async () => {
+    await server.close();
+    const owner = parentRecord();
+    const nextParent: AgentRecord = {
+      ...parentRecord("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+      agent_id: "next-parent",
+      surface_id: "surface:next-parent",
+    };
+    const reportPath = join(inboxDir, "reparented-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+      agent_id: "reparented-child",
+      surface_id: "surface:reparented-child",
+      parent_agent_id: owner.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+      task_summary: "reparent race fixture",
+    };
+    let engine: ReturnType<
+      typeof createServer
+    >["_registeredTools"]["interact"]["_engine"];
+    const externalNotify = vi.fn().mockImplementation(async () => {
+      const reparented = { ...child, parent_agent_id: nextParent.agent_id };
+      engine.stateMgr.writeState(reparented);
+      engine.getRegistry().set(reparented.agent_id, reparented);
+      return true;
+    });
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchNotify: externalNotify,
+      }),
+    );
+    engine = server._registeredTools.interact._engine;
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [owner, nextParent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: owner.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    writeFileSync(reportPath, "after\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+
+    expect(externalNotify).toHaveBeenCalledOnce();
+    const wakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
+    expect(
+      wakeCalls.some(([, args]: [string, string[]]) =>
+        args.some((arg) => arg.includes("[report]")),
+      ),
+    ).toBe(false);
   });
 
   it("does not describe a missing report target as a done marker and preserves the reason-aware notifier", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -33,8 +33,9 @@ import {
   issueCoordinationContract,
 } from "../src/coordination-paths.js";
 import { recommendedMonitorCommand } from "../src/inbox.js";
-import { readWatchRegistry } from "../src/watch-spec.js";
+import { armWatch, readWatchRegistry } from "../src/watch-spec.js";
 import type { AgentRecord } from "../src/agent-types.js";
+import { StateManager } from "../src/state-manager.js";
 
 const STATE_DIR = join(tmpdir(), "cmux-agents-test-p11-spawn");
 
@@ -1237,5 +1238,99 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const state = await getState.handler({ agent_id: parsed.agent_id }, {} as never);
     const detail = state.structuredContent ?? JSON.parse(state.content[0].text);
     expect(detail.report_path).toBe(override);
+  });
+
+  it("rejects a shared explicit report_path before launching a second child", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const existingChildUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const spawnedChildUuid = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const baseExec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: existingChildUuid,
+          ref: "surface:existing",
+          title: "existing-child",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+        {
+          id: spawnedChildUuid,
+          ref: "surface:spawned",
+          title: "spawned-child",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    exec = vi.fn().mockImplementation(async (cmd, args: string[]) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:spawned",
+            surface_id: spawnedChildUuid,
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    const parent = parentRecord(parentUuid);
+    const existingChild: AgentRecord = {
+      ...parentRecord(existingChildUuid),
+      agent_id: "existing-child",
+      surface_id: "surface:existing",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+    };
+    const stateMgr = new StateManager(STATE_DIR);
+    stateMgr.writeState(parent);
+    stateMgr.writeState(existingChild);
+    const override = join(inboxDir, "collab", "shared-report.md");
+    mkdirSync(join(inboxDir, "collab"), { recursive: true });
+    writeFileSync(override, "", "utf8");
+    await armWatch(
+      {
+        owner: parent.agent_id,
+        subject_agent_id: existingChild.agent_id,
+        target: override,
+        change: "content",
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: watchRegistryPath },
+    );
+    const splitCalls = () =>
+      (exec as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([, args]: [string, string[]]) => args.includes("new-split"),
+      ).length;
+    const before = splitCalls();
+
+    const second = await spawn({
+      parent_agent_id: parent.agent_id,
+      report_path: override,
+    });
+
+    expect(second.ok).toBe(false);
+    expect(String(second.error)).toMatch(/report_path.*already.*child/i);
+    expect(splitCalls()).toBe(before);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toHaveLength(1);
   });
 });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2604,6 +2604,85 @@ describe("agent lifecycle tool handlers", () => {
     }
   });
 
+  it("rejects a resumed agent's report path when a live sibling owns it", async () => {
+    const agentId = "cmuxlayerCodex-resume-path-collision";
+    const siblingId = "cmuxlayerCodex-live-sibling";
+    const parentId = "cmuxlayerClaude-resume-collision-parent";
+    const resumeInboxDir = mkdtempSync(join(tmpdir(), "resume-path-collision-"));
+    const watchRegistryPath = join(resumeInboxDir, "watch-specs.json");
+    const sharedReportPath = join(resumeInboxDir, "shared", "report.md");
+    const stateMgr = new StateManager(TEST_DIR);
+    for (const record of [
+      makeServerAgentRecord({
+        agent_id: parentId,
+        role: "orchestrator",
+        state: "ready",
+        surface_id: "surface:parent",
+      }),
+      makeServerAgentRecord({
+        agent_id: agentId,
+        state: "done",
+        surface_id: "surface:old",
+        cli_session_id: "019d9aa5-93c0-7a52-9c47-9be1f7625f3e",
+        parent_agent_id: parentId,
+        spawn_depth: 1,
+      }),
+      makeServerAgentRecord({
+        agent_id: siblingId,
+        state: "ready",
+        surface_id: "surface:sibling",
+        parent_agent_id: parentId,
+        spawn_depth: 1,
+      }),
+    ]) {
+      stateMgr.writeState(record);
+    }
+    mkdirSync(join(resumeInboxDir, "shared"), { recursive: true });
+    writeFileSync(sharedReportPath, "working\n", "utf8");
+    await armWatch(
+      {
+        owner: parentId,
+        subject_agent_id: siblingId,
+        target: sharedReportPath,
+        change: "content",
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: watchRegistryPath },
+    );
+    const exec = makeLifecycleExec();
+    const server = createTrackedServer({
+      exec,
+      stateDir: TEST_DIR,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+      inboxBaseDir: resumeInboxDir,
+      watchRegistryPath,
+    });
+    await serverContexts.at(-1)?.lifecycleStartPromise;
+    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const splitCalls = () =>
+      exec.mock.calls.filter(([, args]) => args.includes("new-split")).length;
+    const before = splitCalls();
+
+    try {
+      const result = await spawn.handler(
+        { resume_agent_id: agentId, report_path: sharedReportPath },
+        {} as any,
+      );
+      const parsed = parseToolResult(result) as Record<string, unknown>;
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error_code).toBe("REPORT_PATH_IN_USE");
+      expect(String(parsed.error)).toMatch(/already assigned.*sibling/i);
+      expect(splitCalls()).toBe(before);
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+      ).toHaveLength(1);
+    } finally {
+      rmSync(resumeInboxDir, { recursive: true, force: true });
+    }
+  });
+
   it("spawn_agent accepts placement as the canonical role-placement argument", async () => {
     const server = createLifecycleServer(makeLifecycleExec());
     const spawn = (server as any)._registeredTools["spawn_agent"];

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -15,6 +15,7 @@ import {
   WatchArmError,
   armWatch,
   readWatchRegistry,
+  removeWatches,
   sweepWatches,
 } from "../src/watch-spec.js";
 
@@ -102,6 +103,107 @@ describe("WatchSpec arm contract", () => {
     expect(changed.fired).toEqual([armed.watch_id]);
     expect(unchanged.fired).toEqual([]);
     expect(notify).toHaveBeenCalledOnce();
+  });
+
+  it("does not wake when only file metadata changes", async () => {
+    const target = join(TEST_DIR, "metadata-only.md");
+    writeFileSync(target, "same report", "utf8");
+    let revision = 1n;
+    const contentFingerprintIo = {
+      stat: () => ({
+        mtimeNs: revision,
+        ctimeNs: revision,
+        ino: revision,
+        size: 11n,
+      }),
+      read: () => Buffer.from("same report"),
+    };
+    const notify = vi.fn().mockResolvedValue(true);
+    await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        change: "content",
+        deadline: 60_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000, contentFingerprintIo },
+    );
+
+    revision = 2n;
+    const result = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+      contentFingerprintIo,
+    });
+
+    expect(result.fired).toEqual([]);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("debounces delete then identical rewrite without a missing or changed wake", async () => {
+    const target = join(TEST_DIR, "atomic-rewrite.md");
+    writeFileSync(target, "same report", "utf8");
+    const notify = vi.fn().mockResolvedValue(true);
+    await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        change: "content",
+        deadline: 60_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    rmSync(target);
+    const missing = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 1_500,
+      notify,
+    });
+    writeFileSync(target, "same report", "utf8");
+    const restored = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+
+    expect(missing.failed).toEqual([]);
+    expect(restored.fired).toEqual([]);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("removes scoped watches before a closed child can wake its parent", async () => {
+    const target = join(TEST_DIR, "closed-child.md");
+    writeFileSync(target, "before", "utf8");
+    const notify = vi.fn().mockResolvedValue(true);
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        subject_agent_id: "worker-a",
+        target,
+        change: "content",
+        deadline: 60_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    await removeWatches(
+      (watch) => watch.subject_agent_id === "worker-a",
+      { registryPath: registryPath() },
+    );
+    writeFileSync(target, "after", "utf8");
+    const result = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+
+    expect(result.fired).not.toContain(armed.watch_id);
+    expect(readWatchRegistry({ registryPath: registryPath() }).watches).toEqual(
+      [],
+    );
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it("rejects an agent watch without an independent observation provider", async () => {

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -141,6 +141,46 @@ describe("WatchSpec arm contract", () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
+  it("migrates a legacy revision-suffixed content fingerprint without waking", async () => {
+    const target = join(TEST_DIR, "legacy-fingerprint.md");
+    writeFileSync(target, "same report", "utf8");
+    const notify = vi.fn().mockResolvedValue(true);
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        change: "content",
+        deadline: 60_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    const registry = readWatchRegistry({ registryPath: registryPath() });
+    writeFileSync(
+      registryPath(),
+      JSON.stringify({
+        ...registry,
+        watches: registry.watches.map((watch) => ({
+          ...watch,
+          fingerprint: `${watch.fingerprint}:1:2:3:4`,
+        })),
+      }),
+      "utf8",
+    );
+
+    const result = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+
+    expect(result.fired).toEqual([]);
+    expect(notify).not.toHaveBeenCalled();
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0]
+        ?.fingerprint,
+    ).toBe(armed.fingerprint);
+  });
+
   it("debounces delete then identical rewrite without a missing or changed wake", async () => {
     const target = join(TEST_DIR, "atomic-rewrite.md");
     writeFileSync(target, "same report", "utf8");


### PR DESCRIPTION
## Scope

Run 8 PR A only: asks 1–4. Asks 5–11 are intentionally excluded.

The live root cause was the persisted registry at `~/.golems-zikaron/watch-specs.json`: each spawned child left a parent-owned watch on its `report.md`; closing the child did not remove it, and daemon startup re-armed every stale row. The immediate incident was mitigated separately by manually pruning 35 dead rows and restarting the daemon.

## Fix

- Bind each report watch to its child with `subject_agent_id`, and reject foreign-parent subjects before wake delivery.
- Fingerprint file content with SHA-256, so metadata-only writes and identical rewrites do not notify.
- Remove child watches when `close_surface` tombstones the child.
- Before the first daemon sweep, remove missing, parent-mismatched, and deliberately closed/tombstoned child report watches; safely recognize legacy rows by the persisted child's exact `report_path`.
- Debounce a missing target for two seconds, allowing delete-and-identical-rewrite sequences to settle without a false wake.

## Review round 2

- Startup pruning is best-effort and independently retryable: a contended watch lock no longer rejects or poisons lifecycle initialization, and the next sweep retries it.
- Subject validity is checked before the external notifier and every parent-facing side effect.
- `close_surface(scope=agent)` schedules watch cleanup without awaiting the registry lock, so auxiliary cleanup cannot strand the pane; the retry is visible as `watch_cleanup: scheduled`.
- Explicit-subject pruning falls back from the in-memory registry to persisted agent state, preserving valid watches through an in-memory eviction.
- Legacy revision-suffixed content fingerprints migrate to SHA-256-only storage without firing a false upgrade wake.
- A second sibling using the same explicit report path is rejected before pane launch, preserving one child per report watch.
- Report-watch pruning is selector-scoped, so child-bound marker and agent-predicate watches are not removed.
- A prune request scheduled while another prune is in flight remains pending for the next retry.
- Immediate best-effort cleanup now covers `close_surface` in both scopes, `stop_agent`, and `kill` through one shared helper.
- Legacy shared report paths consider every matching child and retain an owner's watch when any matching direct child is live.
- Same-parent explicit report paths are reserved synchronously across concurrent spawns, closing the preflight-to-arm race.
- Subject ownership is revalidated after the awaited external notifier and immediately before parent delivery, closing the stop/reparent race.
- Immediate termination cleanup is report-content scoped, preserving unrelated child-bound marker and predicate watches.
- Explicit report-path reservations are daemon-context scoped across socket connections, and resume applies the same pre-mutation uniqueness gate while preserving legacy own-watch migration.
- Deferred close cleanup re-reads persisted agent state while holding the watch-registry lock, so a child resumed before the delayed cleanup runs keeps its watch.
- Report-path reservation also consults persisted live child records, so a missing or failed watch row cannot let a sibling reuse the same path.
- Deferred pruning treats terminal child state as closed even when a no-op stop left `user_killed` unset.
- Earlier changed-code DeepSource findings were removed; later style-only findings, the forced-in-process cross-process reservation gap, and a separate stale in-memory subject risk in engine-wide scheduled pruning were answered as deferred at the bounded final-round boundary for the Codex reviewer to decide.

## Evidence

- Unchanged/metadata-only write: 0 wakes.
- Delete then identical rewrite inside the debounce window: 0 wakes and no missing notification.
- Genuine content change: exactly 1 wake; another identical rewrite: 0 additional wakes.
- Foreign-parent child report: 0 parent wakes and 0 external notifications.
- `close_surface`: matching persisted watch removed.
- Daemon startup: stale legacy closed-child report watch removed before the first sweep.
- Contended startup lock: lifecycle initialization succeeds; a later sweep retries and removes the stale watch.
- Contended close lock: the pane closes and cleanup is reported/scheduled; a later sweep removes the watch.
- Persisted-only valid child: explicit-subject retry retains the watch.
- Legacy persisted fingerprint on unchanged content: 0 wakes; fingerprint migrated in place.
- Shared explicit sibling report path: rejected before `new-split`; one watch remains.
- All four managed-agent termination paths remove the child's report watch; non-report watches remain armed; an in-flight schedule is retried.
- Legacy shared-path mixed liveness retains the live owner's watch; concurrent same-path spawns launch exactly one child.
- A child reparented while external notification is in flight produces 0 former-parent wakes.
- Stop, kill, and both close paths remove the report watch while retaining a child-bound marker watch.
- Concurrent same-path spawns through separate servers sharing one daemon context launch exactly one child; resume rejects a sibling-owned path before `new-split`.
- A child resumed while close cleanup waits on the watch lock retains its report watch after the deferred cleanup completes.
- The cross-server concurrency fixture holds the winning spawn in flight while the losing socket attempts the same reservation; only the winner's placement and launch `new-split` calls occur, and the loser returns `REPORT_PATH_IN_USE` before any third split.
- A persisted live sibling reserves its report path without any watch row; a terminal child with `user_killed:false` is still pruned by the deferred sweep.
- Focused final watch-contract suite: 32 passed.
- TypeScript checks: normal and `CMUXLAYER_FORCE_INPROCESS=1` passed.
- Harness replay: 66/66 passed.
- Full pre-push suite at `4cb11d2b7b981e822a027fc9ab6655333e019320`: 152 files passed; 3,507 passed, 1 skipped.
- Performance gate: green (RSS reduction 35.59%; all latency/request-size gates passed).

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03df0","ts":"2026-08-26T15:22:33Z"} -->
