### PR TITLE
fix: harden run 8 wake delivery and receipts

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -19,7 +19,7 @@ import {
   resolveClosureState,
   type ClosureState,
 } from "./coordination-paths.js";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { StateManager } from "./state-manager.js";
 import { isSafeShellToken, sanitizeTerminalInput } from "./sanitize.js";
@@ -240,6 +240,7 @@ import {
 } from "./cmux-transport-self-heal.js";
 import {
   DEFAULT_CHANNEL_MARKER_RETENTION_MS,
+  agentDir,
   dispatchOnce,
   readInbox,
   reapOrphanedPendingChannelMarkers,
@@ -6522,23 +6523,71 @@ export class AgentEngine {
       const path = resolve(agent.report_path);
       byReportPath.set(path, [...(byReportPath.get(path) ?? []), agent]);
     }
+    const rearmedLiveSubjects = new Set<string>();
+    const persistedWatches = readWatchRegistry({
+      registryPath: this.watchRegistryPath,
+    }).watches;
+    const rearmedSubjectIds = new Set(
+      persistedWatches.flatMap((watch) =>
+        watch.change === "content" &&
+        watch.notification_delivered_at_ms !== undefined &&
+        watch.subject_agent_id
+          ? [watch.subject_agent_id]
+          : [],
+      ),
+    );
+    await Promise.all(
+      [...rearmedSubjectIds].map(async (subjectAgentId) => {
+        const subject =
+          this.registry.get(subjectAgentId) ??
+          this.stateMgr.readState(subjectAgentId);
+        if (
+          subject &&
+          subject.user_killed !== true &&
+          !subject.deletion_intent &&
+          (await this.registry.isSurfaceAlive(subject))
+        ) {
+          rearmedLiveSubjects.add(subjectAgentId);
+        }
+      }),
+    );
+    const channelBaseDir = resolve(
+      dirname(agentDir("__cmuxlayer_channel_probe__", this.inboxOpts)),
+    );
     await removeWatches(
       (watch) => {
         if (watch.target_kind !== "file" || watch.change !== "content") {
           return false;
         }
-        const subjects = watch.subject_agent_id
+        if (watch.notification_pending) return false;
+        let subjects = watch.subject_agent_id
           ? [
               this.registry.get(watch.subject_agent_id) ??
                 this.stateMgr.readState(watch.subject_agent_id),
             ].filter((subject): subject is AgentRecord => Boolean(subject))
           : (byReportPath.get(resolve(watch.target)) ?? []);
+        if (subjects.length === 0 && !watch.subject_agent_id) {
+          const targetDir = resolve(dirname(watch.target));
+          const targetLooksEngineIssued =
+            basename(watch.target) === "report.md" &&
+            resolve(dirname(targetDir)) === channelBaseDir;
+          if (targetLooksEngineIssued) {
+            const inferredAgentId = basename(targetDir);
+            const inferred =
+              this.registry.get(inferredAgentId) ??
+              this.stateMgr.readState(inferredAgentId);
+            if (inferred) subjects = [inferred];
+            else if (!existsSync(targetDir)) return true;
+          }
+        }
         if (subjects.length === 0) return Boolean(watch.subject_agent_id);
         return !subjects.some(
           (subject) =>
             subject.user_killed !== true &&
             !subject.deletion_intent &&
-            !TERMINAL_STATES.has(subject.state) &&
+            (!TERMINAL_STATES.has(subject.state) ||
+              (watch.notification_delivered_at_ms !== undefined &&
+                rearmedLiveSubjects.has(subject.agent_id))) &&
             subject.parent_agent_id === watch.owner,
         );
       },
@@ -8080,6 +8129,11 @@ export class AgentEngine {
         now: this.watchRegistryNow,
         agentObservation: this.watchAgentObservation,
         notify: this.watchNotify,
+        onNotificationExhausted: ({ notification, attempts, reason }) => {
+          this.sweepDebugLog(
+            `[cmuxlayer] watch notification exhausted: watch=${notification.watch_id} owner=${notification.owner} attempts=${attempts} reason=${reason}`,
+          );
+        },
       });
     } catch {
       // Declared watches are retried on the next lifecycle sweep.
@@ -9236,6 +9290,11 @@ export class AgentEngine {
         now: this.watchRegistryNow,
         agentObservation: this.watchAgentObservation,
         notify: this.watchNotify,
+        onNotificationExhausted: ({ notification, attempts, reason }) => {
+          this.sweepDebugLog(
+            `[cmuxlayer] watch notification exhausted: watch=${notification.watch_id} owner=${notification.owner} attempts=${attempts} reason=${reason}`,
+          );
+        },
       });
       const current = readWatchRegistry({
         registryPath: this.watchRegistryPath,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6523,21 +6523,49 @@ export class AgentEngine {
       const path = resolve(agent.report_path);
       byReportPath.set(path, [...(byReportPath.get(path) ?? []), agent]);
     }
-    const rearmedLiveSubjects = new Set<string>();
     const persistedWatches = readWatchRegistry({
       registryPath: this.watchRegistryPath,
     }).watches;
-    const rearmedSubjectIds = new Set(
-      persistedWatches.flatMap((watch) =>
-        watch.change === "content" &&
-        watch.notification_delivered_at_ms !== undefined &&
-        watch.subject_agent_id
-          ? [watch.subject_agent_id]
-          : [],
-      ),
+    const persistedWatchSnapshots = new Map(
+      persistedWatches.map((watch) => [watch.watch_id, JSON.stringify(watch)]),
     );
+    const subjectIdsByWatch = new Map<string, string[]>();
+    const missingLegacyChannelWatchIds = new Set<string>();
+    const channelBaseDir = resolve(
+      dirname(agentDir("__cmuxlayer_channel_probe__", this.inboxOpts)),
+    );
+    for (const watch of persistedWatches) {
+      if (watch.target_kind !== "file" || watch.change !== "content") continue;
+      let subjects = watch.subject_agent_id
+        ? [
+            this.registry.get(watch.subject_agent_id) ??
+              this.stateMgr.readState(watch.subject_agent_id),
+          ].filter((subject): subject is AgentRecord => Boolean(subject))
+        : (byReportPath.get(resolve(watch.target)) ?? []);
+      if (subjects.length === 0 && !watch.subject_agent_id) {
+        const targetDir = resolve(dirname(watch.target));
+        const targetLooksEngineIssued =
+          basename(watch.target) === "report.md" &&
+          resolve(dirname(targetDir)) === channelBaseDir;
+        if (targetLooksEngineIssued) {
+          const inferredAgentId = basename(targetDir);
+          const inferred =
+            this.registry.get(inferredAgentId) ??
+            this.stateMgr.readState(inferredAgentId);
+          if (inferred) subjects = [inferred];
+          else if (!existsSync(targetDir)) {
+            missingLegacyChannelWatchIds.add(watch.watch_id);
+          }
+        }
+      }
+      subjectIdsByWatch.set(watch.watch_id, [
+        ...new Set(subjects.map((subject) => subject.agent_id)),
+      ]);
+    }
+    const liveSubjectIds = new Set<string>();
+    const candidateSubjectIds = new Set([...subjectIdsByWatch.values()].flat());
     await Promise.all(
-      [...rearmedSubjectIds].map(async (subjectAgentId) => {
+      [...candidateSubjectIds].map(async (subjectAgentId) => {
         const subject =
           this.registry.get(subjectAgentId) ??
           this.stateMgr.readState(subjectAgentId);
@@ -6547,12 +6575,9 @@ export class AgentEngine {
           !subject.deletion_intent &&
           (await this.registry.isSurfaceAlive(subject))
         ) {
-          rearmedLiveSubjects.add(subjectAgentId);
+          liveSubjectIds.add(subjectAgentId);
         }
       }),
-    );
-    const channelBaseDir = resolve(
-      dirname(agentDir("__cmuxlayer_channel_probe__", this.inboxOpts)),
     );
     await removeWatches(
       (watch) => {
@@ -6560,25 +6585,26 @@ export class AgentEngine {
           return false;
         }
         if (watch.notification_pending) return false;
-        let subjects = watch.subject_agent_id
-          ? [
-              this.registry.get(watch.subject_agent_id) ??
-                this.stateMgr.readState(watch.subject_agent_id),
-            ].filter((subject): subject is AgentRecord => Boolean(subject))
-          : (byReportPath.get(resolve(watch.target)) ?? []);
-        if (subjects.length === 0 && !watch.subject_agent_id) {
-          const targetDir = resolve(dirname(watch.target));
-          const targetLooksEngineIssued =
-            basename(watch.target) === "report.md" &&
-            resolve(dirname(targetDir)) === channelBaseDir;
-          if (targetLooksEngineIssued) {
-            const inferredAgentId = basename(targetDir);
-            const inferred =
-              this.registry.get(inferredAgentId) ??
-              this.stateMgr.readState(inferredAgentId);
-            if (inferred) subjects = [inferred];
-            else if (!existsSync(targetDir)) return true;
-          }
+        // The predicate runs under the watch-registry write lock. If a sweep
+        // re-armed or otherwise changed this row after our liveness snapshot,
+        // retain it and let the next prune evaluate the fresh revision.
+        if (
+          persistedWatchSnapshots.get(watch.watch_id) !== JSON.stringify(watch)
+        ) {
+          return false;
+        }
+        const subjects = (subjectIdsByWatch.get(watch.watch_id) ?? [])
+          .map(
+            (subjectAgentId) =>
+              this.registry.get(subjectAgentId) ??
+              this.stateMgr.readState(subjectAgentId),
+          )
+          .filter((subject): subject is AgentRecord => Boolean(subject));
+        if (
+          subjects.length === 0 &&
+          missingLegacyChannelWatchIds.has(watch.watch_id)
+        ) {
+          return true;
         }
         if (subjects.length === 0) return Boolean(watch.subject_agent_id);
         return !subjects.some(
@@ -6586,8 +6612,7 @@ export class AgentEngine {
             subject.user_killed !== true &&
             !subject.deletion_intent &&
             (!TERMINAL_STATES.has(subject.state) ||
-              (watch.notification_delivered_at_ms !== undefined &&
-                rearmedLiveSubjects.has(subject.agent_id))) &&
+              liveSubjectIds.has(subject.agent_id)) &&
             subject.parent_agent_id === watch.owner,
         );
       },

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -624,7 +624,7 @@ export function evaluateAgentHealth(
   }
 
   const issueSeverities = deriveIssueSeverities(issueCodes, {
-    screenActive,
+    screenActive: screenActive || screenConfirmedState === "ready",
     autoDiscovered,
     lacksManagedPlacement: lacksManagedPlacement(agent),
     panePtyDead,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -314,6 +314,13 @@ function isWithinInboxMonitorBootGrace(
   return now - firstSeenAt <= AGENT_HEALTH_INBOX_MONITOR_BOOT_GRACE_MS;
 }
 
+function hasActiveScreenEvidence(
+  screenActive: boolean,
+  screenConfirmedState: AgentState | undefined,
+): boolean {
+  return screenActive || screenConfirmedState === "ready";
+}
+
 export function evaluateAgentHealth(
   agent: AgentRecord,
   input: AgentHealthInput = {},
@@ -624,7 +631,7 @@ export function evaluateAgentHealth(
   }
 
   const issueSeverities = deriveIssueSeverities(issueCodes, {
-    screenActive: screenActive || screenConfirmedState === "ready",
+    screenActive: hasActiveScreenEvidence(screenActive, screenConfirmedState),
     autoDiscovered,
     lacksManagedPlacement: lacksManagedPlacement(agent),
     panePtyDead,

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -261,7 +261,7 @@ export class CmuxSocketClient {
       return await this.call("window.list");
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.listWindows();
+        return this.cliFallbackPinned("list_windows")!.listWindows();
       }
       throw e;
     }
@@ -280,7 +280,9 @@ export class CmuxSocketClient {
       await this.call("workspace.select", { workspace_id: workspace });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.selectWorkspace(workspace);
+        return this.cliFallbackPinned("select_workspace")!.selectWorkspace(
+          workspace,
+        );
       }
       throw e;
     }
@@ -297,7 +299,10 @@ export class CmuxSocketClient {
       });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.focusSurface(surface, opts);
+        return this.cliFallbackPinned("focus_surface")!.focusSurface(
+          surface,
+          opts,
+        );
       }
       throw e;
     }
@@ -320,7 +325,9 @@ export class CmuxSocketClient {
       };
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.createWorkspace(title);
+        return this.cliFallbackPinned("create_workspace")!.createWorkspace(
+          title,
+        );
       }
       throw e;
     }
@@ -331,7 +338,9 @@ export class CmuxSocketClient {
       await this.call("workspace.close", { workspace_id: workspace });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.deleteWorkspace(workspace);
+        return this.cliFallbackPinned("delete_workspace")!.deleteWorkspace(
+          workspace,
+        );
       }
       throw e;
     }
@@ -442,7 +451,7 @@ export class CmuxSocketClient {
           "unsupported_focus_option",
         );
       }
-      return this.cliFallbackPinned()!.newSplit(direction, opts);
+      return this.cliFallbackPinned("new_split")!.newSplit(direction, opts);
     }
 
     if (opts?.type === "browser") {
@@ -467,7 +476,10 @@ export class CmuxSocketClient {
         return this.mapSplitResult(result, "browser");
       } catch (e) {
         if (this.isMethodNotFound(e) && this.cliFallback) {
-          return this.cliFallbackPinned()!.newSplit(direction, opts);
+          return this.cliFallbackPinned("new_split")!.newSplit(
+            direction,
+            opts,
+          );
         }
         throw e;
       }
@@ -500,7 +512,7 @@ export class CmuxSocketClient {
       return this.mapSplitResult(result, "terminal");
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.newSplit(direction, opts);
+        return this.cliFallbackPinned("new_split")!.newSplit(direction, opts);
       }
       throw e;
     }
@@ -518,7 +530,7 @@ export class CmuxSocketClient {
         "new-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned()!.newSurface(opts);
+    return this.cliFallbackPinned("new_surface")!.newSurface(opts);
   }
 
   async moveSurface(opts: {
@@ -535,7 +547,7 @@ export class CmuxSocketClient {
         "move-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned()!.moveSurface(opts);
+    return this.cliFallbackPinned("move_surface")!.moveSurface(opts);
   }
 
   async reorderSurface(opts: {
@@ -549,7 +561,7 @@ export class CmuxSocketClient {
         "reorder-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned()!.reorderSurface(opts);
+    return this.cliFallbackPinned("reorder_surface")!.reorderSurface(opts);
   }
 
   async send(
@@ -572,7 +584,7 @@ export class CmuxSocketClient {
     text: string,
     opts?: { workspace?: string },
   ): Promise<void> {
-    const cliFallback = this.cliFallbackPinned();
+    const cliFallback = this.cliFallbackPinned("paste_text");
     if (cliFallback) {
       return cliFallback.pasteText(surface, text, opts);
     }
@@ -759,7 +771,10 @@ export class CmuxSocketClient {
       await this.call("surface.close", params);
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned()!.closeSurface(surface, opts);
+        return this.cliFallbackPinned("close_surface")!.closeSurface(
+          surface,
+          opts,
+        );
       }
       throw e;
     }

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -225,6 +225,14 @@ export class CmuxSocketClient {
     return this.cliFallback;
   }
 
+  private requiredCliFallback(source: string): CmuxClient {
+    const fallback = this.cliFallbackPinned(source);
+    if (!fallback) {
+      throw new CmuxSocketError(`CLI fallback is unavailable for ${source}`);
+    }
+    return fallback;
+  }
+
   private async reconnectTransport(originalError: unknown): Promise<void> {
     if (!this.reconnecting) {
       this.reconnecting = (async () => {
@@ -261,7 +269,7 @@ export class CmuxSocketClient {
       return await this.call("window.list");
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("list_windows")!.listWindows();
+        return this.requiredCliFallback("list_windows").listWindows();
       }
       throw e;
     }
@@ -280,7 +288,7 @@ export class CmuxSocketClient {
       await this.call("workspace.select", { workspace_id: workspace });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("select_workspace")!.selectWorkspace(
+        return this.requiredCliFallback("select_workspace").selectWorkspace(
           workspace,
         );
       }
@@ -299,7 +307,7 @@ export class CmuxSocketClient {
       });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("focus_surface")!.focusSurface(
+        return this.requiredCliFallback("focus_surface").focusSurface(
           surface,
           opts,
         );
@@ -325,7 +333,7 @@ export class CmuxSocketClient {
       };
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("create_workspace")!.createWorkspace(
+        return this.requiredCliFallback("create_workspace").createWorkspace(
           title,
         );
       }
@@ -338,7 +346,7 @@ export class CmuxSocketClient {
       await this.call("workspace.close", { workspace_id: workspace });
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("delete_workspace")!.deleteWorkspace(
+        return this.requiredCliFallback("delete_workspace").deleteWorkspace(
           workspace,
         );
       }
@@ -451,7 +459,7 @@ export class CmuxSocketClient {
           "unsupported_focus_option",
         );
       }
-      return this.cliFallbackPinned("new_split")!.newSplit(direction, opts);
+      return this.requiredCliFallback("new_split").newSplit(direction, opts);
     }
 
     if (opts?.type === "browser") {
@@ -476,7 +484,7 @@ export class CmuxSocketClient {
         return this.mapSplitResult(result, "browser");
       } catch (e) {
         if (this.isMethodNotFound(e) && this.cliFallback) {
-          return this.cliFallbackPinned("new_split")!.newSplit(
+          return this.requiredCliFallback("new_split").newSplit(
             direction,
             opts,
           );
@@ -512,7 +520,7 @@ export class CmuxSocketClient {
       return this.mapSplitResult(result, "terminal");
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("new_split")!.newSplit(direction, opts);
+        return this.requiredCliFallback("new_split").newSplit(direction, opts);
       }
       throw e;
     }
@@ -530,7 +538,7 @@ export class CmuxSocketClient {
         "new-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned("new_surface")!.newSurface(opts);
+    return this.requiredCliFallback("new_surface").newSurface(opts);
   }
 
   async moveSurface(opts: {
@@ -547,7 +555,7 @@ export class CmuxSocketClient {
         "move-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned("move_surface")!.moveSurface(opts);
+    return this.requiredCliFallback("move_surface").moveSurface(opts);
   }
 
   async reorderSurface(opts: {
@@ -561,7 +569,7 @@ export class CmuxSocketClient {
         "reorder-surface is only available through the CLI fallback",
       );
     }
-    return this.cliFallbackPinned("reorder_surface")!.reorderSurface(opts);
+    return this.requiredCliFallback("reorder_surface").reorderSurface(opts);
   }
 
   async send(
@@ -771,7 +779,7 @@ export class CmuxSocketClient {
       await this.call("surface.close", params);
     } catch (e) {
       if (this.isMethodNotFound(e) && this.cliFallback) {
-        return this.cliFallbackPinned("close_surface")!.closeSurface(
+        return this.requiredCliFallback("close_surface").closeSurface(
           surface,
           opts,
         );

--- a/src/server.ts
+++ b/src/server.ts
@@ -705,7 +705,7 @@ const PUBLIC_TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, z.ZodTypeAny>> = {
       notified_agent_id: z.string().optional(),
       route: z.enum(["direct", "fallback"]).optional(),
       durable: z.boolean().optional(),
-      delivery: z.enum(["submitted", "queued"]).optional(),
+      delivery: z.enum(["submitted", "queued", "refused"]).optional(),
       delivery_id: z.string().optional(),
       error_code: z.string().optional(),
     })
@@ -1279,12 +1279,16 @@ class DeliverySafetyGateError extends Error {
 
   constructor(
     readonly error_code:
-      "blocked_by_interactive_prompt" | "blocked_by_permission_prompt",
+      | "blocked_by_interactive_prompt"
+      | "blocked_by_permission_prompt"
+      | "blocked_by_foreign_draft",
     readonly screen: ParsedScreenResult,
   ) {
     super(
       error_code === "blocked_by_permission_prompt"
         ? "delivery blocked by active permission prompt"
+        : error_code === "blocked_by_foreign_draft"
+          ? "target composer already holds text this delivery did not write; refused before typing"
         : "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
     );
     this.name = "DeliverySafetyGateError";
@@ -5436,21 +5440,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // the first keystroke -- a refused send is recoverable, a submitted draft
     // is not.
     //
-    // RETRYABLE, not terminal (T2 B1a): the same screen is produced by this
-    // delivery's OWN unflushed prior message (the queued_followup shape), and
-    // the guard cannot tell that from a human draft. For both, the right
-    // answer is "wait for the composer to flush", which the v2 queue already
-    // expresses -- and #467's bounded queue lifetime guarantees the caller
-    // still gets a terminal answer if it never does. A terminal `failed` here
-    // would be this PR's own disease: a verdict the engine did not observe.
+    // Refusal is terminal for this caller: the pre-type snapshot proves the
+    // requested bytes cannot be appended safely. Queuing that refusal reports
+    // `accepted:true` even though the guard deliberately performed no pane
+    // mutation, and can later submit text the caller never authorized.
     if (
       opts.draftGuardText !== undefined &&
       composerHoldsForeignDraft(snapshot.text, opts.draftGuardText)
     ) {
-      throw new RetryableDeliveryError(
-        "target composer already holds text this delivery did not write; " +
-          "refused to type (typing + Return would submit or mutate it). " +
-          "Delivery stays queued until the composer is clear.",
+      throw new DeliverySafetyGateError(
+        "blocked_by_foreign_draft",
+        snapshot.parsed,
       );
     }
 
@@ -12351,6 +12351,33 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (!subjectStillBelongsToOwner()) {
               return true;
             }
+            const liveOwnerCandidates = [
+              ...registry.list(),
+              ...stateMgr.listStates(),
+            ].filter(
+              (candidate, index, rows) =>
+                rows.findIndex(
+                  (row) => row.agent_id === candidate.agent_id,
+                ) === index &&
+                candidate.user_killed !== true &&
+                !candidate.deletion_intent &&
+                !TERMINAL_AGENT_STATES.has(candidate.state),
+            );
+            const owner =
+              liveOwnerCandidates.find(
+                (candidate) => candidate.agent_id === event.owner,
+              ) ??
+              liveOwnerCandidates.find(
+                (candidate) => candidate.seat_id?.trim() === event.owner,
+              ) ??
+              (() => {
+                const prefixMatches = liveOwnerCandidates.filter((candidate) =>
+                  candidate.agent_id.startsWith(`${event.owner}-`),
+                );
+                return prefixMatches.length === 1
+                  ? prefixMatches[0]
+                  : undefined;
+              })();
             let externalDelivered = true;
             if (event.reason !== "predicate_matched" && opts?.watchNotify) {
               try {
@@ -12362,8 +12389,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             if (!subjectStillBelongsToOwner()) {
               return true;
             }
-            const owner =
-              registry.get(event.owner) ?? stateMgr.readState(event.owner);
+            if (!owner) {
+              return {
+                delivered: false,
+                retryable: false,
+                reason: "owner_not_live",
+              };
+            }
             if (owner && lifecycleAgentInputDeliverer) {
               const text = (() => {
                 if (
@@ -13043,8 +13075,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         | "queued"
         | "queued_followup"
         | "rescued"
-        | "pending_verify";
+        | "pending_verify"
+        | "refused";
       delivery_id?: string;
+      wake_error_code?: string;
     }> => {
       const pointer = formatInboxPing(
         message,
@@ -13071,6 +13105,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery_id: deliveryId,
         });
       } catch (error) {
+        if (
+          error instanceof DeliverySafetyGateError &&
+          error.error_code === "blocked_by_foreign_draft"
+        ) {
+          return {
+            delivery: "refused",
+            wake_error_code: error.error_code,
+          };
+        }
         if (
           error instanceof RetryableDeliveryError ||
           (error instanceof Error && /\bis busy\b/.test(error.message))
@@ -16751,7 +16794,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               const deliveryId = randomUUID();
               const timings = createDeliveryPhaseTimings();
-              return legacyHandler("send_input")(
+              const result = await legacyHandler("send_input")(
                 {
                   surface,
                   workspace: args.workspace,
@@ -16767,6 +16810,26 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 },
                 {},
               );
+              if (
+                !result ||
+                typeof result !== "object" ||
+                !("structuredContent" in result) ||
+                !result.structuredContent ||
+                typeof result.structuredContent !== "object"
+              ) {
+                return result;
+              }
+              const structuredContent = {
+                ...(result.structuredContent as Record<string, unknown>),
+                timings_ms:
+                  (result.structuredContent as Record<string, unknown>)
+                    .timings_ms ?? timings,
+              };
+              return {
+                ...result,
+                content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+                structuredContent,
+              };
             }
             if (mode === "command") {
               const command = args.command ?? args.text;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1023,6 +1023,23 @@ function createDeliveryPhaseTimings(): DeliveryPhaseTimings {
   return { route: 0, lock: 0, lock_hold: 0, enumerate: 0, type: 0, verify: 0 };
 }
 
+function withSurfaceDeliveryTimings(
+  result: ToolReturn,
+  timings: DeliveryPhaseTimings,
+): ToolReturn {
+  const payload = result.structuredContent;
+  if (!payload) return result;
+  const structuredContent = {
+    ...payload,
+    timings_ms: payload.timings_ms ?? timings,
+  };
+  return {
+    ...result,
+    content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+    structuredContent,
+  };
+}
+
 function addDeliveryPhaseTiming(
   timings: DeliveryPhaseTimings | undefined,
   phase: DeliveryPhase,
@@ -16793,42 +16810,25 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
               const deliveryId = randomUUID();
               const timings = createDeliveryPhaseTimings();
-              const result = await legacyHandler("send_input")(
-                {
-                  surface,
-                  workspace: args.workspace,
-                  text: args.text,
-                  chunk_size: args.chunk_size,
-                  background: args.background,
-                  press_enter: args.press_enter,
-                  rename_to_task: args.rename_to_task,
-                  allow_long_inline: args.allow_long_inline,
-                  _cmuxlayer_source_event: "send_to",
-                  _cmuxlayer_delivery_id: deliveryId,
-                  _cmuxlayer_timings: timings,
-                },
-                {},
+              return withSurfaceDeliveryTimings(
+                await legacyHandler("send_input")(
+                  {
+                    surface,
+                    workspace: args.workspace,
+                    text: args.text,
+                    chunk_size: args.chunk_size,
+                    background: args.background,
+                    press_enter: args.press_enter,
+                    rename_to_task: args.rename_to_task,
+                    allow_long_inline: args.allow_long_inline,
+                    _cmuxlayer_source_event: "send_to",
+                    _cmuxlayer_delivery_id: deliveryId,
+                    _cmuxlayer_timings: timings,
+                  },
+                  {},
+                ),
+                timings,
               );
-              if (
-                !result ||
-                typeof result !== "object" ||
-                !("structuredContent" in result) ||
-                !result.structuredContent ||
-                typeof result.structuredContent !== "object"
-              ) {
-                return result;
-              }
-              const structuredContent = {
-                ...(result.structuredContent as Record<string, unknown>),
-                timings_ms:
-                  (result.structuredContent as Record<string, unknown>)
-                    .timings_ms ?? timings,
-              };
-              return {
-                ...result,
-                content: [{ type: "text", text: JSON.stringify(structuredContent) }],
-                structuredContent,
-              };
             }
             if (mode === "command") {
               const command = args.command ?? args.text;

--- a/src/server.ts
+++ b/src/server.ts
@@ -12424,6 +12424,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               };
             }
             if (owner && lifecycleAgentInputDeliverer) {
+              const externalFallbackAfterLocalFailure = async () => {
+                if (
+                  event.reason !== "predicate_matched" ||
+                  !opts?.watchNotify
+                ) {
+                  return false;
+                }
+                if (!subjectStillBelongsToOwner()) return true;
+                try {
+                  return (await opts.watchNotify(event)) !== false;
+                } catch {
+                  return false;
+                }
+              };
               const text = (() => {
                 if (
                   event.reason === "predicate_matched" ||
@@ -12455,11 +12469,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 const ownerDelivered =
                   delivery.delivery === "submitted" ||
                   delivery.delivery === "queued";
-                return ownerDelivered;
+                return ownerDelivered
+                  ? true
+                  : externalFallbackAfterLocalFailure();
               } catch {
-                // Keep notification_pending=true. A later lifecycle sweep uses
-                // the parent's refreshed route after a session restart.
-                return false;
+                return externalFallbackAfterLocalFailure();
               }
             }
             if (event.reason !== "predicate_matched") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12389,6 +12389,17 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return true;
             }
             if (!owner) {
+              if (event.reason === "predicate_matched" && opts?.watchNotify) {
+                try {
+                  externalDelivered =
+                    (await opts.watchNotify(event)) !== false;
+                } catch {
+                  externalDelivered = false;
+                }
+              }
+              if (opts?.watchNotify && externalDelivered) {
+                return true;
+              }
               return {
                 delivered: false,
                 retryable: false,
@@ -13074,10 +13085,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         | "queued"
         | "queued_followup"
         | "rescued"
-        | "pending_verify"
-        | "refused";
+        | "pending_verify";
       delivery_id?: string;
-      wake_error_code?: string;
     }> => {
       const pointer = formatInboxPing(
         message,
@@ -13104,15 +13113,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery_id: deliveryId,
         });
       } catch (error) {
-        if (
-          error instanceof DeliverySafetyGateError &&
-          error.error_code === "blocked_by_foreign_draft"
-        ) {
-          return {
-            delivery: "refused",
-            wake_error_code: error.error_code,
-          };
-        }
         if (
           error instanceof RetryableDeliveryError ||
           (error instanceof Error && /\bis busy\b/.test(error.message))

--- a/src/server.ts
+++ b/src/server.ts
@@ -12360,8 +12360,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   (row) => row.agent_id === candidate.agent_id,
                 ) === index &&
                 candidate.user_killed !== true &&
-                !candidate.deletion_intent &&
-                !TERMINAL_AGENT_STATES.has(candidate.state),
+                !candidate.deletion_intent,
             );
             const owner =
               liveOwnerCandidates.find(

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -276,6 +276,24 @@ function hasValidNotificationMetadata(
   );
 }
 
+function hasValidTerminalMetadata(value: Record<string, unknown>): boolean {
+  if (
+    value.terminal_at_ms !== undefined &&
+    !isFiniteNumber(value.terminal_at_ms)
+  ) {
+    return false;
+  }
+  if (
+    value.terminal_reason !== undefined &&
+    !isWatchNotificationReason(value.terminal_reason)
+  ) {
+    return false;
+  }
+  return (
+    value.state === "armed" || isWatchNotificationReason(value.terminal_reason)
+  );
+}
+
 function isWatchRecord(value: unknown): value is WatchRecord {
   if (!isRecord(value) || !isRecord(value.liveness)) return false;
   if (
@@ -325,25 +343,8 @@ function isWatchRecord(value: unknown): value is WatchRecord {
   ) {
     return false;
   }
-  if (
-    value.terminal_at_ms !== undefined &&
-    !isFiniteNumber(value.terminal_at_ms)
-  ) {
-    return false;
-  }
+  if (!hasValidTerminalMetadata(value)) return false;
   if (!hasValidNotificationMetadata(value)) return false;
-  if (
-    value.terminal_reason !== undefined &&
-    !isWatchNotificationReason(value.terminal_reason)
-  ) {
-    return false;
-  }
-  if (
-    value.state !== "armed" &&
-    !isWatchNotificationReason(value.terminal_reason)
-  ) {
-    return false;
-  }
   if (value.target_kind === "file") {
     const hasMarker = Boolean(cleanString(value.marker));
     const hasChange = value.change === "content";

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -63,6 +63,8 @@ export interface WatchRecord extends WatchSpec {
   notification_attempts?: number;
   notification_next_attempt_at_ms?: number;
   notification_delivered_at_ms?: number;
+  notification_exhausted_at_ms?: number;
+  notification_exhausted_reason?: string;
 }
 
 export interface WatchRegistryFile {
@@ -111,6 +113,18 @@ export type WatchNotify = (
   event: WatchNotification,
 ) => Promise<unknown> | unknown;
 
+export interface WatchNotifyTerminalFailure {
+  delivered: false;
+  retryable: false;
+  reason: string;
+}
+
+export interface WatchNotificationExhausted {
+  notification: WatchNotification;
+  attempts: number;
+  reason: string;
+}
+
 export interface WatchAgentObservation {
   exists: boolean;
   state: string | null;
@@ -149,6 +163,9 @@ export interface WatchContentFingerprintIo {
 
 export interface WatchSweepOptions extends WatchRegistryOptions {
   notify?: WatchNotify;
+  onNotificationExhausted?: (
+    exhausted: WatchNotificationExhausted,
+  ) => Promise<unknown> | unknown;
 }
 
 export interface WatchSweepResult {
@@ -179,6 +196,7 @@ const WRITE_LOCK_STALE_MS = 30_000;
 const WRITE_LOCK_RETRY_MS = 5;
 const NOTIFY_RETRY_BASE_MS = 1_000;
 const NOTIFY_RETRY_MAX_MS = 60_000;
+const NOTIFY_RETRY_LIMIT = 8;
 const FILE_MISSING_DEBOUNCE_MS = 2_000;
 
 interface WatchRegistryState {
@@ -315,6 +333,18 @@ function isWatchRecord(value: unknown): value is WatchRecord {
   if (
     value.notification_delivered_at_ms !== undefined &&
     !isFiniteNumber(value.notification_delivered_at_ms)
+  ) {
+    return false;
+  }
+  if (
+    value.notification_exhausted_at_ms !== undefined &&
+    !isFiniteNumber(value.notification_exhausted_at_ms)
+  ) {
+    return false;
+  }
+  if (
+    value.notification_exhausted_reason !== undefined &&
+    !cleanString(value.notification_exhausted_reason)
   ) {
     return false;
   }
@@ -1117,11 +1147,23 @@ export async function sweepWatches(
 
   for (const notification of notifications) {
     let delivered = false;
+    let terminalFailureReason: string | null = null;
     try {
-      delivered = (await opts.notify?.(notification)) !== false;
+      const outcome = await opts.notify?.(notification);
+      if (
+        isRecord(outcome) &&
+        outcome.delivered === false &&
+        outcome.retryable === false &&
+        cleanString(outcome.reason)
+      ) {
+        terminalFailureReason = cleanString(outcome.reason);
+      } else {
+        delivered = outcome !== false;
+      }
     } catch {
       delivered = false;
     }
+    let exhausted: WatchNotificationExhausted | null = null;
     await withWriteLock(path, () => {
       const registry = readRegistryState(path);
       const watches = registry.rows.map((row) => {
@@ -1132,6 +1174,20 @@ export async function sweepWatches(
           !record.notification_pending
         ) {
           return record;
+        }
+        if (terminalFailureReason) {
+          exhausted = {
+            notification,
+            attempts: record.notification_attempts ?? 0,
+            reason: terminalFailureReason,
+          };
+          return {
+            ...record,
+            notification_pending: false,
+            notification_next_attempt_at_ms: undefined,
+            notification_exhausted_at_ms: observedAt,
+            notification_exhausted_reason: terminalFailureReason,
+          };
         }
         if (delivered) {
           if (
@@ -1162,6 +1218,21 @@ export async function sweepWatches(
           };
         }
         const attempts = (record.notification_attempts ?? 0) + 1;
+        if (attempts >= NOTIFY_RETRY_LIMIT) {
+          exhausted = {
+            notification,
+            attempts,
+            reason: "retry_limit_exhausted",
+          };
+          return {
+            ...record,
+            notification_pending: false,
+            notification_attempts: attempts,
+            notification_next_attempt_at_ms: undefined,
+            notification_exhausted_at_ms: observedAt,
+            notification_exhausted_reason: "retry_limit_exhausted",
+          };
+        }
         const retryDelay = Math.min(
           NOTIFY_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 16),
           NOTIFY_RETRY_MAX_MS,
@@ -1174,6 +1245,13 @@ export async function sweepWatches(
       });
       writeRegistry(path, registry.version, watches);
     });
+    if (exhausted) {
+      try {
+        await opts.onNotificationExhausted?.(exhausted);
+      } catch {
+        // Exhaustion is already durable. Escalation/logging cannot reopen it.
+      }
+    }
   }
   return result;
 }

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1166,6 +1166,26 @@ export async function sweepWatches(
             attempts: record.notification_attempts ?? 0,
             reason: terminalFailureReason,
           };
+          if (
+            record.change === "content" &&
+            typeof notification.observed_value === "string"
+          ) {
+            const {
+              terminal_reason: _terminalReason,
+              terminal_at_ms: _terminalAt,
+              notification_next_attempt_at_ms: _nextAttempt,
+              ...persistent
+            } = record;
+            return {
+              ...persistent,
+              state: "armed" as const,
+              fingerprint: notification.observed_value,
+              observed_value: notification.observed_value,
+              notification_pending: false,
+              notification_exhausted_at_ms: observedAt,
+              notification_exhausted_reason: terminalFailureReason,
+            };
+          }
           return {
             ...record,
             notification_pending: false,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1224,6 +1224,27 @@ export async function sweepWatches(
             attempts,
             reason: "retry_limit_exhausted",
           };
+          if (
+            record.change === "content" &&
+            typeof notification.observed_value === "string"
+          ) {
+            const {
+              terminal_reason: _terminalReason,
+              terminal_at_ms: _terminalAt,
+              notification_next_attempt_at_ms: _nextAttempt,
+              ...persistent
+            } = record;
+            return {
+              ...persistent,
+              state: "armed" as const,
+              fingerprint: notification.observed_value,
+              observed_value: notification.observed_value,
+              notification_pending: false,
+              notification_attempts: attempts,
+              notification_exhausted_at_ms: observedAt,
+              notification_exhausted_reason: "retry_limit_exhausted",
+            };
+          }
           return {
             ...record,
             notification_pending: false,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -256,6 +256,26 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function hasValidNotificationMetadata(
+  value: Record<string, unknown>,
+): boolean {
+  return (
+    (value.notification_pending === undefined ||
+      typeof value.notification_pending === "boolean") &&
+    (value.notification_attempts === undefined ||
+      (Number.isInteger(value.notification_attempts) &&
+        (value.notification_attempts as number) >= 0)) &&
+    (value.notification_next_attempt_at_ms === undefined ||
+      isFiniteNumber(value.notification_next_attempt_at_ms)) &&
+    (value.notification_delivered_at_ms === undefined ||
+      isFiniteNumber(value.notification_delivered_at_ms)) &&
+    (value.notification_exhausted_at_ms === undefined ||
+      isFiniteNumber(value.notification_exhausted_at_ms)) &&
+    (value.notification_exhausted_reason === undefined ||
+      Boolean(cleanString(value.notification_exhausted_reason)))
+  );
+}
+
 function isWatchRecord(value: unknown): value is WatchRecord {
   if (!isRecord(value) || !isRecord(value.liveness)) return false;
   if (
@@ -311,43 +331,7 @@ function isWatchRecord(value: unknown): value is WatchRecord {
   ) {
     return false;
   }
-  if (
-    value.notification_pending !== undefined &&
-    typeof value.notification_pending !== "boolean"
-  ) {
-    return false;
-  }
-  if (
-    value.notification_attempts !== undefined &&
-    (!Number.isInteger(value.notification_attempts) ||
-      (value.notification_attempts as number) < 0)
-  ) {
-    return false;
-  }
-  if (
-    value.notification_next_attempt_at_ms !== undefined &&
-    !isFiniteNumber(value.notification_next_attempt_at_ms)
-  ) {
-    return false;
-  }
-  if (
-    value.notification_delivered_at_ms !== undefined &&
-    !isFiniteNumber(value.notification_delivered_at_ms)
-  ) {
-    return false;
-  }
-  if (
-    value.notification_exhausted_at_ms !== undefined &&
-    !isFiniteNumber(value.notification_exhausted_at_ms)
-  ) {
-    return false;
-  }
-  if (
-    value.notification_exhausted_reason !== undefined &&
-    !cleanString(value.notification_exhausted_reason)
-  ) {
-    return false;
-  }
+  if (!hasValidNotificationMetadata(value)) return false;
   if (
     value.terminal_reason !== undefined &&
     !isWatchNotificationReason(value.terminal_reason)

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -370,6 +370,8 @@ describe("agent lifecycle health", () => {
 
     expect(health.reconciled_state).toBe("ready");
     expect(health.issue_codes).toContain("registry_screen_disagreement");
+    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
+    expect(health.status).toBe("healthy");
   });
 
   it("marks stale dispatches on a live monitor as wedged, not dead", () => {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -25,6 +25,10 @@ import { CmuxSocketClient } from "../src/cmux-socket-client.js";
 import { CmuxClient, type ExecFn } from "../src/cmux-client.js";
 import { createCmuxClient } from "../src/cmux-client-factory.js";
 import { getTransportHealth } from "../src/cmux-transport-self-heal.js";
+import {
+  currentCliFallbackSources,
+  withTransportRetryTracking,
+} from "../src/transport-retry-context.js";
 
 // ── Mock V2 Socket Server ──────────────────────────────────────────────
 
@@ -36,6 +40,15 @@ const INTERLEAVED_STATUS_FRAME = readFileSync(
 ).trim();
 const MOCK_WORKSPACE_ID = "8481D6A0-CE17-4B7C-8695-7A722D30FEE2";
 const MOCK_SECOND_WORKSPACE_ID = "7335E54B-6E88-4B19-BE8C-71C39F4E9D10";
+
+it("names every CLI fallback call site instead of emitting unspecified provenance", () => {
+  const source = readFileSync(
+    new URL("../src/cmux-socket-client.ts", import.meta.url),
+    "utf8",
+  );
+
+  expect(source).not.toMatch(/cliFallbackPinned\(\)/);
+});
 
 interface MockV2Request {
   id: string;
@@ -1316,9 +1329,14 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
         cliFallback: createMockCli(),
       });
 
-      await expect(client.listWindows()).resolves.toEqual({
+      const result = await withTransportRetryTracking(async () => {
+        const windows = await client.listWindows();
+        return { windows, sources: currentCliFallbackSources() };
+      });
+      expect(result.windows).toEqual({
         windows: [{ id: "cli-window", workspace_count: 1 }],
       });
+      expect(result.sources).toEqual(["list_windows"]);
       expect(cliCalls).toEqual([{ method: "listWindows", args: [] }]);
     } finally {
       MOCK_RESPONSES["window.list"] = saved;
@@ -1345,6 +1363,23 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient V2→CLI fallback", () 
         ],
       },
     ]);
+  });
+
+  it("labels the socket-missing new-surface path in transport provenance", async () => {
+    const client = new CmuxSocketClient({
+      socketPath: MOCK_SOCKET_PATH,
+      cliFallback: createMockCli(),
+    });
+
+    const sources = await withTransportRetryTracking(async () => {
+      await client.newSurface({
+        pane: "pane:1",
+        workspace: "workspace:1",
+      });
+      return currentCliFallbackSources();
+    });
+
+    expect(sources).toEqual(["new_surface"]);
   });
 
   it("newSplit falls back to CLI when surface.split returns method_not_found", async () => {

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -185,13 +185,15 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     );
 
     const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
     expect(parsed).toMatchObject({
       delivered: false,
-      terminal: false,
-      delivery_state: "queued",
+      terminal: true,
+      delivery_state: "failed",
+      error_code: "blocked_by_foreign_draft",
     });
-    expect(parsed.WARNING).toMatch(/not delivered yet/i);
-    expect(parsed.WARNING).toMatch(/composer already holds text/i);
+    expect(parsed.WARNING).toMatch(/terminal failure/i);
+    expect(parsed.error).toMatch(/composer already holds text/i);
     expect(mutatedPane(mockExec)).toBe(false);
     context.dispose();
   }, 20_000);
@@ -281,10 +283,12 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
       {} as any,
     );
 
+    expect(result.isError).toBe(true);
     expect(parseToolResult(result)).toMatchObject({
       delivered: false,
-      terminal: false,
-      delivery_state: "queued",
+      terminal: true,
+      delivery_state: "failed",
+      error_code: "blocked_by_foreign_draft",
     });
     expect(mutatedPane(mockExec)).toBe(false);
     context.dispose();
@@ -379,7 +383,7 @@ describe("T2 delivery truth — draft guard must not fire on chrome (B1)", () =>
   }, 20_000);
 });
 
-describe("T2 delivery truth — a blocked composer is not a terminal verdict (B1a)", () => {
+describe("T2 delivery truth — a blocked composer is a terminal refusal (B1a)", () => {
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), "cmuxlayer-t2-delivery-truth-"));
   });
@@ -389,7 +393,7 @@ describe("T2 delivery truth — a blocked composer is not a terminal verdict (B1
     vi.resetModules();
   });
 
-  it("queues instead of terminally failing when the composer holds unflushed text", async () => {
+  it("refuses instead of accepting a send when the composer holds unflushed text", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n\u276f ";
     const mockExec = makeLifecycleExec(() => screenText);
@@ -402,10 +406,8 @@ describe("T2 delivery truth — a blocked composer is not a terminal verdict (B1
     const server = createServer({ context });
     const agentId = await spawnReadyAgent(server);
 
-    // This delivery's OWN prior message, still sitting unflushed in the
-    // composer (the queued_followup shape). The guard cannot tell it from a
-    // human draft -- and must not, because the right answer for both is
-    // "wait for the composer to flush", never a terminal failure.
+    // The guard cannot prove who owns this existing draft. It can prove that
+    // appending and pressing Return is unsafe, so this invocation must refuse.
     screenText = "Claude Code\n> an earlier message that has not flushed yet\n";
     mockExec.mockClear();
 
@@ -415,14 +417,14 @@ describe("T2 delivery truth — a blocked composer is not a terminal verdict (B1
     );
 
     const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
     expect(parsed).toMatchObject({
-      ok: true,
+      ok: false,
       delivered: false,
-      delivery_state: "queued",
-      terminal: false,
+      delivery_state: "failed",
+      terminal: true,
+      error_code: "blocked_by_foreign_draft",
     });
-    expect(parsed.WARNING).toMatch(/not delivered yet/i);
-    expect(parsed.WARNING).toMatch(/composer already holds text/i);
     // Still the property #442 exists for: nothing was typed.
     expect(mutatedPane(mockExec)).toBe(false);
     context.dispose();

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -892,6 +892,29 @@ describe("enter reliability", () => {
     });
   });
 
+  it("returns surface-mode send_to as the same JSON receipt shape as agent mode", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client);
+    registerAgent(server);
+
+    const result = await callTool(server, "send_to", {
+      mode: "surface",
+      surface: client.surface,
+      text: "surface receipt parity",
+      press_enter: false,
+    });
+    const contentReceipt = JSON.parse(result.content[0].text);
+
+    expect(result.isError).not.toBe(true);
+    expect(contentReceipt).toMatchObject({
+      ok: true,
+      delivery_id: expect.any(String),
+      delivery_state: "typed",
+      timings_ms: expect.any(Object),
+    });
+    expect(contentReceipt).toEqual(result.structuredContent);
+  });
+
   it("resolves agent-mode composer-only delivery as terminal typed on the same ID", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.stableSurfaceIdentity = "11111111-1111-4111-8111-111111111111";

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -1311,8 +1311,9 @@ describe("report_to_parent hierarchy-bound escalation", () => {
     expect(parsed).toMatchObject({
       ok: true,
       route: "direct",
-      delivery: "queued",
+      delivery: "refused",
       durable: true,
+      wake_error_code: "blocked_by_foreign_draft",
     });
     expect(sendCalls(exec)).toHaveLength(before);
     expect(readInbox(parent.agent_id, { baseDir: inboxDir })[0]?.task).toBe(

--- a/tests/inbox-nudge.test.ts
+++ b/tests/inbox-nudge.test.ts
@@ -1267,8 +1267,9 @@ describe("report_to_parent hierarchy-bound escalation", () => {
     expect(sendCalls(exec).at(-1)?.join(" ")).toContain("surface:new");
   });
 
-  it("keeps a parent blocker durable without typing into a foreign draft", async () => {
+  it("keeps a parent blocker durable and escalates past a foreign draft", async () => {
     await server.close();
+    const grandparentUuid = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
     exec = makeExec(
       "Claude Code\n❯ do not submit this existing draft",
       "parent-pane",
@@ -1280,15 +1281,27 @@ describe("report_to_parent hierarchy-bound escalation", () => {
           title: "child-pane",
           text: "Claude Code\nWhat can I help you with?\n❯ ",
         },
+        {
+          id: grandparentUuid,
+          ref: "surface:grandparent",
+          title: "grandparent-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
       ],
       parentUuid,
     );
     server = createInboxServer(exec, inboxDir);
+    const grandparent = hierarchyRecord({
+      agentId: "orc-grandparent",
+      surfaceId: "surface:grandparent",
+      surfaceUuid: grandparentUuid,
+      parentAgentId: null,
+    });
     const parent = hierarchyRecord({
       agentId: "lead-parent",
       surfaceId: "surface:new",
       surfaceUuid: parentUuid,
-      parentAgentId: null,
+      parentAgentId: grandparent.agent_id,
     });
     const child = hierarchyRecord({
       agentId: "worker-child",
@@ -1296,7 +1309,7 @@ describe("report_to_parent hierarchy-bound escalation", () => {
       surfaceUuid: childUuid,
       parentAgentId: parent.agent_id,
     });
-    register(parent, child);
+    register(grandparent, parent, child);
     const before = sendCalls(exec).length;
 
     const result = await runWithCallerContext({ surfaceId: childUuid }, () =>
@@ -1310,15 +1323,21 @@ describe("report_to_parent hierarchy-bound escalation", () => {
 
     expect(parsed).toMatchObject({
       ok: true,
-      route: "direct",
-      delivery: "refused",
+      route: "fallback",
+      notified_agent_id: grandparent.agent_id,
+      delivery: "submitted",
       durable: true,
-      wake_error_code: "blocked_by_foreign_draft",
     });
-    expect(sendCalls(exec)).toHaveLength(before);
+    expect(sendCalls(exec)).toHaveLength(before + 1);
     expect(readInbox(parent.agent_id, { baseDir: inboxDir })[0]?.task).toBe(
       "Blocked while parent is composing",
     );
+    expect(
+      readInbox(grandparent.agent_id, { baseDir: inboxDir })[0],
+    ).toMatchObject({
+      tag: "parent_delivery_failed",
+      task: expect.stringContaining("Blocked while parent is composing"),
+    });
   });
 
   it("refuses a root caller with no registry parent", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -977,6 +977,218 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     });
   });
 
+  it("delivers to a live owner whose persisted state is terminal", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = { ...parentRecord(parentUuid), state: "done" as const };
+    const reportPath = join(inboxDir, "terminal-owner-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "terminal-owner-child",
+      surface_id: "surface:child",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [parent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    writeFileSync(reportPath, "after\n", "utf8");
+
+    await engine.sweepWatchesBestEffort();
+
+    const wakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      before,
+    );
+    expect(
+      wakeCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(reportPath),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+    ).toMatchObject({
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 0,
+    });
+  });
+
+  it("keeps a first-delivery watch while its terminal child pane is live", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord(parentUuid);
+    const reportPath = join(inboxDir, "live-first-delivery", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(childUuid),
+      agent_id: "live-first-delivery",
+      surface_id: "surface:child",
+      surface_uuid: childUuid,
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [parent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        subject_agent_id: child.agent_id,
+        state: "armed",
+      }),
+    ]);
+  });
+
+  it("keeps a subjectless legacy watch while its terminal child pane is live", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord(parentUuid);
+    const reportPath = join(inboxDir, "legacy-live-terminal", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(childUuid),
+      agent_id: "legacy-live-terminal",
+      surface_id: "surface:child",
+      surface_uuid: childUuid,
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [parent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: parent.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        target: reportPath,
+        state: "armed",
+      }),
+    ]);
+  });
+
   it("keeps a delivered content watch armed while a terminal record still has a live pane", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -1061,6 +1273,89 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       notification_pending: false,
       notification_delivered_at_ms: expect.any(Number),
     });
+  });
+
+  it("does not prune a watch revision that re-arms during liveness probing", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const reportPath = join(inboxDir, "concurrent-rearm", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "concurrent-rearm",
+      surface_id: "surface:closed-child",
+      state: "done",
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    const watch = await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const initialRegistry = JSON.parse(readFileSync(watchRegistryPath, "utf8"));
+    initialRegistry.watches[0] = {
+      ...initialRegistry.watches[0],
+      notification_delivered_at_ms: 2_000,
+    };
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify(initialRegistry, null, 2)}\n`,
+      "utf8",
+    );
+    let releaseLivenessProbe: (() => void) | undefined;
+    let markProbeStarted: (() => void) | undefined;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    const livenessGate = new Promise<void>((resolve) => {
+      releaseLivenessProbe = resolve;
+    });
+    vi.spyOn(engine.getRegistry(), "isSurfaceAlive").mockImplementation(
+      async () => {
+        markProbeStarted?.();
+        await livenessGate;
+        return false;
+      },
+    );
+
+    const pruning = (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+    await probeStarted;
+    const rearmedRegistry = JSON.parse(readFileSync(watchRegistryPath, "utf8"));
+    rearmedRegistry.watches[0] = {
+      ...rearmedRegistry.watches[0],
+      fingerprint: "concurrent-revision",
+      observed_value: "concurrent-revision",
+      notification_delivered_at_ms: 3_000,
+    };
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify(rearmedRegistry, null, 2)}\n`,
+      "utf8",
+    );
+    releaseLivenessProbe?.();
+    await pruning;
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        watch_id: watch.watch_id,
+        fingerprint: "concurrent-revision",
+        notification_delivered_at_ms: 3_000,
+      }),
+    ]);
   });
 
   it("keeps lifecycle initialization live and retries startup pruning after lock contention", async () => {
@@ -1185,8 +1480,9 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       "report.md",
     );
     const child: AgentRecord = {
-      ...parentRecord(),
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
       agent_id: "terminal-child-without-stop-flag",
+      surface_id: "surface:closed-child",
       state: "done",
       user_killed: false,
       parent_agent_id: "lead-parent",

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -18,7 +18,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer, createServerContext } from "../src/server.js";
 import type { ExecFn } from "../src/cmux-client.js";
@@ -975,6 +975,75 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       notification_attempts: 0,
       notification_exhausted_reason: "owner_not_live",
     });
+  });
+
+  it("accepts a successful external watch notification when the owner seat is absent", async () => {
+    await server.close();
+    const externalNotify = vi.fn().mockResolvedValue(true);
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchNotify: externalNotify,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "externally-notified-child",
+      surface_id: "surface:child",
+      parent_agent_id: "missing-owner-seat",
+      spawn_depth: 1,
+      role: "worker",
+    };
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    const contentPath = join(inboxDir, child.agent_id, "content-report.md");
+    const markerPath = join(inboxDir, child.agent_id, "marker-report.md");
+    mkdirSync(dirname(contentPath), { recursive: true });
+    writeFileSync(contentPath, "before\n", "utf8");
+    writeFileSync(markerPath, "before\n", "utf8");
+    await engine.armWatch({
+      owner: child.parent_agent_id as string,
+      subject_agent_id: child.agent_id,
+      target: contentPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    await engine.armWatch({
+      owner: child.parent_agent_id as string,
+      subject_agent_id: child.agent_id,
+      target: markerPath,
+      marker: "DONE_EXTERNAL",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    writeFileSync(contentPath, "after\n", "utf8");
+    appendFileSync(markerPath, "DONE_EXTERNAL\n", "utf8");
+
+    await engine.sweepWatchesBestEffort();
+
+    expect(externalNotify).toHaveBeenCalledTimes(2);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: contentPath,
+          state: "armed",
+          notification_pending: false,
+          notification_attempts: 0,
+        }),
+        expect.objectContaining({
+          target: markerPath,
+          state: "fired",
+          notification_pending: false,
+          notification_attempts: 0,
+        }),
+      ]),
+    );
   });
 
   it("delivers to a live owner whose persisted state is terminal", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -769,6 +769,300 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ).toEqual([]);
   });
 
+  it("prunes at least 100 legacy rows whose agent channel directories are absent", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const watches = Array.from({ length: 120 }, (_, index) => ({
+      watch_id: `legacy-dead-${index}`,
+      owner: "lead-parent",
+      target: join(inboxDir, `legacy-dead-${index}`, "report.md"),
+      change: "content" as const,
+      deadline: Number.MAX_SAFE_INTEGER,
+      target_kind: "file" as const,
+      armed_at_ms: 1_000,
+      last_heartbeat_at_ms: 1_000,
+      liveness_source: "process",
+      liveness: {
+        value: true,
+        source: "process" as const,
+        observed_at_ms: 1_000,
+      },
+      state: "armed" as const,
+    }));
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify({ version: 1, watches }, null, 2)}\n`,
+      "utf8",
+    );
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toHaveLength(120);
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toHaveLength(0);
+  });
+
+  it("never lets terminal-child pruning remove an undelivered notification", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const reportPath = join(inboxDir, "pending-notification", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "pending-notification",
+      state: "done",
+      parent_agent_id: "lead-parent",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "done\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    const watch = await engine.armWatch({
+      owner: "lead-parent",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const registryFile = JSON.parse(readFileSync(watchRegistryPath, "utf8"));
+    registryFile.watches[0] = {
+      ...registryFile.watches[0],
+      state: "fired",
+      terminal_reason: "target_changed",
+      terminal_at_ms: 2_000,
+      observed_value: "sha256:changed",
+      notification_pending: true,
+      notification_attempts: 8,
+      notification_next_attempt_at_ms: 2_000,
+    };
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify(registryFile, null, 2)}\n`,
+      "utf8",
+    );
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        watch_id: watch.watch_id,
+        notification_pending: true,
+        notification_attempts: 8,
+      }),
+    ]);
+  });
+
+  it("resolves a legacy bare owner seat to the live suffixed lead before delivery", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = {
+      ...parentRecord(),
+      agent_id: "cmuxlayerClaude-live-seat",
+      seat_id: "cmuxlayerClaude",
+    };
+    const reportPath = join(inboxDir, "bare-owner-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "bare-owner-child",
+      surface_id: "surface:child",
+      parent_agent_id: "cmuxlayerClaude",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [parent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: "cmuxlayerClaude",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    writeFileSync(reportPath, "after\n", "utf8");
+
+    await engine.sweepWatchesBestEffort();
+
+    const wakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
+    expect(
+      wakeCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(reportPath),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+    ).toMatchObject({
+      owner: "cmuxlayerClaude",
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 0,
+    });
+  });
+
+  it("fails a missing owner seat fast without incrementing delivery attempts", async () => {
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const reportPath = join(inboxDir, "missing-owner-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "missing-owner-child",
+      surface_id: "surface:child",
+      parent_agent_id: "retired-lead-seat",
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: "retired-lead-seat",
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    writeFileSync(reportPath, "after\n", "utf8");
+
+    await engine.sweepWatchesBestEffort();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+    ).toMatchObject({
+      state: "fired",
+      notification_pending: false,
+      notification_attempts: 0,
+      notification_exhausted_reason: "owner_not_live",
+    });
+  });
+
+  it("keeps a delivered content watch armed while a terminal record still has a live pane", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+      }),
+    );
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord();
+    const reportPath = join(inboxDir, "live-terminal-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord(),
+      agent_id: "live-terminal-child",
+      surface_id: "surface:child",
+      surface_uuid: childUuid,
+      state: "done",
+      parent_agent_id: parent.agent_id,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    for (const record of [parent, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: parent.agent_id,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    writeFileSync(reportPath, "first distinct change\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+    const afterFirstWake = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+    writeFileSync(reportPath, "second distinct change\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+
+    const secondWakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      afterFirstWake,
+    );
+    expect(
+      secondWakeCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(reportPath),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+    ).toMatchObject({
+      state: "armed",
+      notification_pending: false,
+      notification_delivered_at_ms: expect.any(Number),
+    });
+  });
+
   it("keeps lifecycle initialization live and retries startup pruning after lock contention", async () => {
     await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -939,7 +939,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     });
   });
 
-  it("fails a missing owner seat fast without incrementing delivery attempts", async () => {
+  it("fails a missing owner seat fast and re-arms the persistent content watch", async () => {
     await server._registeredTools.list_agents.handler({}, {} as never);
     const engine = server._registeredTools.interact._engine;
     const reportPath = join(inboxDir, "missing-owner-child", "report.md");
@@ -967,14 +967,114 @@ describe("P11 spawn_agent issues the coordination contract", () => {
 
     await engine.sweepWatchesBestEffort();
 
-    expect(
-      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
-    ).toMatchObject({
-      state: "fired",
+    const watch = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0];
+    expect(watch).toMatchObject({
+      state: "armed",
       notification_pending: false,
       notification_attempts: 0,
       notification_exhausted_reason: "owner_not_live",
     });
+    expect(watch?.fingerprint).toBe(watch?.observed_value);
+  });
+
+  it("re-arms after owner_not_live and wakes the resumed owner for the next revision", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    exec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "resumed-parent-pane",
+      undefined,
+      [],
+      parentUuid,
+    );
+    let watchNow = 1_000;
+    const unavailableExternalNotify = vi.fn().mockResolvedValue(false);
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchRegistryNow: () => watchNow,
+        watchNotify: unavailableExternalNotify,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    const ownerId = "resumed-lead-seat";
+    const reportPath = join(inboxDir, "resumed-owner-child", "report.md");
+    const child: AgentRecord = {
+      ...parentRecord("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      agent_id: "resumed-owner-child",
+      surface_id: "surface:child",
+      parent_agent_id: ownerId,
+      spawn_depth: 1,
+      role: "worker",
+      report_path: reportPath,
+    };
+    mkdirSync(join(inboxDir, child.agent_id), { recursive: true });
+    writeFileSync(reportPath, "before\n", "utf8");
+    engine.stateMgr.writeState(child);
+    engine.getRegistry().set(child.agent_id, child);
+    await engine.armWatch({
+      owner: ownerId,
+      subject_agent_id: child.agent_id,
+      target: reportPath,
+      change: "content",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const initialFingerprint = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0]?.fingerprint;
+
+    writeFileSync(reportPath, "first revision while owner is away\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+
+    const afterOwnerLoss = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0];
+    expect(unavailableExternalNotify).toHaveBeenCalledOnce();
+    expect(afterOwnerLoss).toMatchObject({
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 0,
+      notification_exhausted_reason: "owner_not_live",
+    });
+    expect(afterOwnerLoss?.fingerprint).toBe(afterOwnerLoss?.observed_value);
+    expect(afterOwnerLoss?.fingerprint).not.toBe(initialFingerprint);
+
+    const resumedOwner = { ...parentRecord(parentUuid), agent_id: ownerId };
+    engine.stateMgr.writeState(resumedOwner);
+    engine.getRegistry().set(resumedOwner.agent_id, resumedOwner);
+    const beforeResumeWake = (exec as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    watchNow = 2_000;
+    writeFileSync(reportPath, "second revision after owner resumed\n", "utf8");
+    await engine.sweepWatchesBestEffort();
+
+    const resumedWakeCalls = (
+      exec as ReturnType<typeof vi.fn>
+    ).mock.calls.slice(beforeResumeWake);
+    expect(
+      resumedWakeCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[report]") && arg.includes(reportPath),
+        ),
+      ),
+    ).toBe(true);
+    expect(unavailableExternalNotify).toHaveBeenCalledTimes(2);
+    const afterResume = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0];
+    expect(afterResume).toMatchObject({
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 0,
+    });
+    expect(afterResume?.fingerprint).toBe(afterResume?.observed_value);
+    expect(afterResume?.fingerprint).not.toBe(afterOwnerLoss?.fingerprint);
   });
 
   it("accepts a successful external watch notification when the owner seat is absent", async () => {
@@ -1044,6 +1144,93 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         }),
       ]),
     );
+  });
+
+  it("falls back externally after an aliased owner's local wake is refused", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    exec = makeExec(
+      "Claude Code\n❯ preserve this human draft",
+      "aliased-parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "external-fallback-child",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    const externalNotify = vi.fn().mockResolvedValue(true);
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchNotify: externalNotify,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    const owner = {
+      ...parentRecord(parentUuid),
+      agent_id: "cmuxlayerClaude-live-seat",
+      seat_id: "cmuxlayerClaude",
+    };
+    const child: AgentRecord = {
+      ...parentRecord(childUuid),
+      agent_id: "external-fallback-child",
+      surface_id: "surface:child",
+      parent_agent_id: "cmuxlayerClaude",
+      spawn_depth: 1,
+      role: "worker",
+    };
+    for (const record of [owner, child]) {
+      engine.stateMgr.writeState(record);
+      engine.getRegistry().set(record.agent_id, record);
+    }
+    await engine.armWatch({
+      owner: "cmuxlayerClaude",
+      subject_agent_id: child.agent_id,
+      target: child.agent_id,
+      predicate: "idle",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await engine.sweepWatchesBestEffort();
+
+    expect(externalNotify).toHaveBeenCalledOnce();
+    expect(externalNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "cmuxlayerClaude",
+        subject_agent_id: child.agent_id,
+        target: child.agent_id,
+        reason: "predicate_matched",
+      }),
+    );
+    const localMutationCalls = (
+      exec as ReturnType<typeof vi.fn>
+    ).mock.calls.slice(before);
+    expect(
+      localMutationCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) => arg.includes("[watch]") && arg.includes(child.agent_id),
+        ),
+      ),
+    ).toBe(false);
+    const afterFallback = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0];
+    expect(afterFallback).toMatchObject({
+      state: "fired",
+      notification_pending: false,
+      notification_attempts: 0,
+    });
   });
 
   it("delivers to a live owner whose persisted state is terminal", async () => {

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -262,8 +262,9 @@ describe("send_to consolidated modes", () => {
     expect(parsed.terminal).toBe(true);
     expect(parsed.delivered).toBe(false);
     expect(parsed.typed).toBe(true);
-    expect(result.content[0].text).toContain("typed into");
-    expect(result.content[0].text).toContain("not submitted");
+    expect(JSON.parse(result.content[0].text)).toEqual(
+      result.structuredContent,
+    );
   });
 
   it("returns terminal typed truth when raw surface Return was unverified", async () => {
@@ -295,8 +296,10 @@ describe("send_to consolidated modes", () => {
     expect(parsed.terminal).toBe(true);
     expect(parsed.delivered).toBe(false);
     expect(parsed.typed).toBe(true);
-    expect(result.content[0].text).toContain("submission attempted");
-    expect(result.content[0].text).toContain("not verified");
+    expect(JSON.parse(result.content[0].text)).toEqual(
+      result.structuredContent,
+    );
+    expect(parsed.WARNING).toMatch(/not verified/i);
   });
 
   it("routes command mode through atomic raw-surface command delivery", async () => {

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -164,7 +164,7 @@ describe("WatchSpec MCP contract", () => {
     });
   });
 
-  it("returns a matched terminal verdict when the notification owner is not live", async () => {
+  it("tries external notification before returning owner-not-live exhaustion", async () => {
     const notify = vi.fn().mockResolvedValue(false);
     const server = createWatchServer(notify);
     const target = join(TEST_DIR, "delivery-down.md");
@@ -193,7 +193,7 @@ describe("WatchSpec MCP contract", () => {
         notification_exhausted_reason: "owner_not_live",
       },
     });
-    expect(notify).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledOnce();
   });
 
   it("D14 emits MCP progress before a long wait hits the harness silence cutoff", async () => {

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -164,7 +164,7 @@ describe("WatchSpec MCP contract", () => {
     });
   });
 
-  it("returns a matched terminal verdict when notification delivery is down", async () => {
+  it("returns a matched terminal verdict when the notification owner is not live", async () => {
     const notify = vi.fn().mockResolvedValue(false);
     const server = createWatchServer(notify);
     const target = join(TEST_DIR, "delivery-down.md");
@@ -188,11 +188,12 @@ describe("WatchSpec MCP contract", () => {
       watch: {
         state: "fired",
         terminal_reason: "predicate_matched",
-        notification_pending: true,
-        notification_attempts: 1,
+        notification_pending: false,
+        notification_attempts: 0,
+        notification_exhausted_reason: "owner_not_live",
       },
     });
-    expect(notify).toHaveBeenCalledOnce();
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it("D14 emits MCP progress before a long wait hits the harness silence cutoff", async () => {

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -867,6 +867,65 @@ describe("WatchSpec arm contract", () => {
     });
   });
 
+  it("re-arms a persistent content watch after retry exhaustion", async () => {
+    const target = join(TEST_DIR, "persistent-retry-exhaustion.md");
+    writeFileSync(target, "before\n", "utf8");
+    const notify = vi.fn(async () => notify.mock.calls.length > 8);
+    const onNotificationExhausted = vi.fn();
+    let now = 1_000;
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        change: "content",
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: registryPath(), now: () => now },
+    );
+    writeFileSync(target, "first revision\n", "utf8");
+
+    for (let attempt = 1; attempt <= 8; attempt += 1) {
+      now += 60_000;
+      await sweepWatches({
+        registryPath: registryPath(),
+        now: () => now,
+        notify,
+        onNotificationExhausted,
+      });
+    }
+
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      watch_id: armed.watch_id,
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 8,
+      notification_exhausted_reason: "retry_limit_exhausted",
+    });
+
+    writeFileSync(target, "second revision\n", "utf8");
+    now += 60_000;
+    const secondRevision = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => now,
+      notify,
+      onNotificationExhausted,
+    });
+
+    expect(secondRevision.fired).toEqual([armed.watch_id]);
+    expect(notify).toHaveBeenCalledTimes(9);
+    expect(onNotificationExhausted).toHaveBeenCalledOnce();
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      state: "armed",
+      notification_pending: false,
+      notification_attempts: 0,
+      notification_delivered_at_ms: now,
+    });
+  });
+
   it("persists and delivers deadline_elapsed through the retryable transition", async () => {
     const target = join(TEST_DIR, "deadline.md");
     writeFileSync(target, "", "utf8");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -820,6 +820,53 @@ describe("WatchSpec arm contract", () => {
     ).toMatchObject({ state: "fired", notification_pending: false });
   });
 
+  it("bounds notification retries and records one exhausted escalation", async () => {
+    const target = join(TEST_DIR, "retry-exhaustion.md");
+    writeFileSync(target, "", "utf8");
+    const notify = vi.fn().mockResolvedValue(false);
+    const onNotificationExhausted = vi.fn();
+    let now = 1_000;
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        marker: "DONE",
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: registryPath(), now: () => now },
+    );
+    appendFileSync(target, "DONE\n", "utf8");
+
+    for (let attempt = 1; attempt <= 12; attempt += 1) {
+      now += 60_000;
+      await sweepWatches({
+        registryPath: registryPath(),
+        now: () => now,
+        notify,
+        onNotificationExhausted,
+      });
+    }
+
+    expect(notify).toHaveBeenCalledTimes(8);
+    expect(onNotificationExhausted).toHaveBeenCalledOnce();
+    expect(onNotificationExhausted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notification: expect.objectContaining({ watch_id: armed.watch_id }),
+        attempts: 8,
+        reason: "retry_limit_exhausted",
+      }),
+    );
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      watch_id: armed.watch_id,
+      state: "fired",
+      notification_pending: false,
+      notification_attempts: 8,
+      notification_exhausted_reason: "retry_limit_exhausted",
+    });
+  });
+
   it("persists and delivers deadline_elapsed through the retryable transition", async () => {
     const target = join(TEST_DIR, "deadline.md");
     writeFileSync(target, "", "utf8");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -870,7 +870,7 @@ describe("WatchSpec arm contract", () => {
   it("re-arms a persistent content watch after retry exhaustion", async () => {
     const target = join(TEST_DIR, "persistent-retry-exhaustion.md");
     writeFileSync(target, "before\n", "utf8");
-    const notify = vi.fn(async () => notify.mock.calls.length > 8);
+    const notify = vi.fn(() => notify.mock.calls.length > 8);
     const onNotificationExhausted = vi.fn();
     let now = 1_000;
     const armed = await armWatch(


### PR DESCRIPTION
## Summary

- prune legacy subjectless report watches by their engine-issued channel path while retaining ambiguous rows
- preserve pending wake notifications, cap retry delivery at eight attempts, fail missing owners immediately, and re-arm content watches while their panes remain live
- make surface `send_to` receipts waitable JSON, terminally refuse foreign drafts, reconcile screen-confirmed-ready health, and name every socket-to-CLI fallback source

## P2-4 diagnosis

`spawn_agent` legitimately reaches the CLI for `new_surface`, because the cmux socket protocol does not expose that RPC. An unscoped `read_screen` can reach `list_windows` for workspace discovery when the daemon lacks `window.list`. The receipts remain honest CLI-fallback receipts; they now report `transport_fallbacks:["new_surface"]` or `["list_windows"]` instead of `"unspecified"`.

## Verification

- focused RED: 12 failures / 234 passes before implementation
- focused GREEN: 246/246 tests
- full suite: 153 files, 3,528 tests passed, 1 intentional skip
- root typecheck: GREEN
- site typecheck: GREEN
- canonical 8x12 daemon benchmark: GREEN, socket transport for all operations
- forced CLI fallback benchmark: RED as required (`socket_transport_only:false`, exit 1)
- live real-cmux contract: system ping, dist daemon list/read, doctor, and graceful retire/autostart all PASS
- realistic legacy fixture: 120 rows before prune, 0 after

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a03fb5","ts":"2026-08-26T20:50:19Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes terminal delivery semantics for foreign-draft composers and watch notification retry/owner resolution, which can alter parent wake behavior and what callers consider success vs failure.
> 
> **Overview**
> **Hardens child report watch lifecycle and parent wake delivery** so legacy engine-issued `report.md` watches can be pruned safely, pending notifications are never dropped, and owners are resolved even when persisted seats are bare or terminal but the pane is still live.
> 
> `pruneClosedChildReportWatches` now snapshots the registry before pruning, skips rows with `notification_pending` or revisions changed under the write lock, infers subjects from channel paths, and uses surface liveness so a terminal child with a live pane keeps its watch. Watch sweeps cap notification retries at **8**, record `notification_exhausted_*`, re-arm **content** watches after exhaustion or `owner_not_live`, and accept terminal `{ delivered: false, retryable: false, reason }` from the notify path (with optional `onNotificationExhausted` logging in the engine).
> 
> **Delivery safety and receipts:** typing into a composer that already holds foreign draft text is a **terminal** `blocked_by_foreign_draft` refusal (`DeliverySafetyGateError`), not a queued retry. `report_to_parent` may report `delivery: "refused"`. When local wake to the parent fails (e.g. foreign draft), watch delivery can fall back to external notify; missing owners fail fast with `owner_not_live`. Surface-mode `send_to` wraps results with consistent JSON/`timings_ms` via `withSurfaceDeliveryTimings`.
> 
> **Smaller fixes:** agent health treats screen-confirmed `ready` as active evidence for severity; socket client routes all CLI fallbacks through `requiredCliFallback("<source>")` instead of unnamed `cliFallbackPinned()!` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfca5ab44334acacfad87490d6406aefdd9bea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden wake delivery and receipts with terminal refusals and bounded watch retries
> - Surface deliveries now terminally refuse with `blocked_by_foreign_draft` when a foreign draft is detected before typing, instead of remaining queued.
> - Watch notifications are bounded to 8 retries (`NOTIFY_RETRY_LIMIT` in `watch-spec.ts`); terminal failures or retry exhaustion mark the watch as exhausted and re-arm content-change watches.
> - Watch delivery terminates with `owner_not_live` when no live owner is found, and opportunistically falls back to external notify when local delivery fails.
> - `agent-engine.ts` makes `pruneClosedChildReportWatches` more conservative: it preserves pending notifications, recently mutated rows, and live terminal subjects, while removing stale legacy channel directories.
> - `cmux-socket-client.ts` adds `requiredCliFallback` to label all CLI fallback call sites with a source string instead of bare `cliFallbackPinned()` assertions.
> - Risk: `send_to` deliveries with a foreign draft now return `delivery_state: 'failed'` with `error_code: 'blocked_by_foreign_draft'` instead of queuing. The `report_to_parent` schema now includes `delivery='refused'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdfca5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch reliability by preserving active terminal-agent watches and pending notifications.
  * Added retry limits and exhaustion tracking for undelivered notifications.
  * Foreign-draft delivery conflicts now fail immediately with clear refusal details.
  * Improved owner resolution and handling of inactive notification recipients.
  * Health checks now recognize screen-confirmed “ready” agents as active.
  * Surface delivery responses now consistently include structured results and timing details.
* **Reliability**
  * Added clearer diagnostics when notification retries are exhausted.
  * Improved fallback operation tracking across window, workspace, surface, and paste actions.
  * Improved blocker escalation when a parent is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->