### PR TITLE
fix: make composer and monitor receipts screen-truthful

### DIFF
--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -28,21 +28,21 @@
       "list_surfaces": 142,
       "read_screen": 161,
       "send_to_surface_warm": 214,
-      "send_to_agent_warm": 217,
+      "send_to_agent_warm": 232,
       "list_agents": 112,
       "control_health": 97,
       "spawn_close_during_sweep": 161,
-      "first_send_after_spawn": 216
+      "first_send_after_spawn": 231
     },
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
       "read_screen": "0f6c57ad85b668c2ae73f651d9d44c41525b8f2fba3d2f7783e6acb592dc2137",
       "send_to_surface_warm": "d2b6d478fff8c5cf8568d2c2caaa48cbe98314a700477cccbc20657a0ba3058e",
-      "send_to_agent_warm": "2d59a5a9a94bfa7b2fa6a23a16e91eab26dee814b37a6b4285f382303907593c",
+      "send_to_agent_warm": "ec21fdf5817b3568ba66b0f44b2b5982319c2778cd60a7de637c1231428ee6e1",
       "list_agents": "4f4fb87e95a8f7cded25a4fd1bb35d11492182997e1f7d14c856683f53cc0416",
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
-      "first_send_after_spawn": "84b72f5cc76154d091394b15154b3dcc6aefd7e80d6027a2666c71c83a6194a6"
+      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75"
     },
     "transport": {
       "list_surfaces": "socket",
@@ -100,6 +100,6 @@
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "60864aaa599333a1ebcced00058d7c67f25ef412c36a09499aacf7f06c54362c"
+    "content_sha256": "5e082ba864d9aa64876bd2f8901ad301adab6286da3d18623c9ae4cc8682e601"
   }
 }

--- a/docs/plans/2026-08-27-run9-reviewer-round2.md
+++ b/docs/plans/2026-08-27-run9-reviewer-round2.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Harness API error truth
 
 **Files:** `src/screen-parser.ts`, `src/agent-engine.ts`, `tests/screen-parser.test.ts`, `tests/agent-engine.test.ts`

--- a/docs/plans/2026-08-27-run9-reviewer-round2.md
+++ b/docs/plans/2026-08-27-run9-reviewer-round2.md
@@ -1,0 +1,55 @@
+# Run 9 Reviewer Round 2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close reviewer round 1 by fixing all six P1s and both P2s without weakening the D136 or D145 contracts.
+
+**Architecture:** Preserve the existing parser, lifecycle, health, transport, and delivery boundaries. Add biting regressions first, then make the smallest correction at each source boundary and migrate every repository caller of changed public contracts.
+
+**Tech Stack:** TypeScript, JavaScript, Bun, Vitest, MCP stdio/socket clients, cmux live daemon.
+
+---
+
+### Task 1: Harness API error truth
+
+**Files:** `src/screen-parser.ts`, `src/agent-engine.ts`, `tests/screen-parser.test.ts`, `tests/agent-engine.test.ts`
+
+1. Add separate failing tests proving typed composer text cannot clear an API error and a halt-type transition still wakes the parent immediately.
+2. Run the focused tests and record the expected failures.
+3. Require attributable submitted/output evidence for parser recovery and let harness-error transitions fall through to dispatch.
+4. Re-run the focused tests green.
+
+### Task 2: Public contract caller migration
+
+**Files:** `src/doctor.ts`, `scripts/run-real-cmux-contract.ts`, `scripts/acceptance-registry-liveness.mjs`, `scripts/run-live-id-churn-probe.ts`, relevant tests
+
+1. Add failing assertions for the unchanged caller payloads.
+2. Inventory every repository `control_health` and `send_to` caller.
+3. Migrate diagnostic callers to `detail:"full"`, agent sends to explicit `mode:"agent"`, and key sends to canonical `text`.
+4. Run caller-focused tests green without restoring aliases or optional mode.
+
+### Task 3: Server health error propagation
+
+**Files:** `src/server.ts`, health/server tests
+
+1. Add failing server-path tests for request-ID-bearing `harness_api_error` across general health overrides.
+2. Carry `screen_errors` through the read predicate, safe overrides, and fallback reader dependency.
+3. Run server health and lifecycle tests green.
+
+### Task 4: Surface identity and skill observation safety
+
+**Files:** `src/cmux-socket-client.ts`, `src/server.ts`, socket and skill-delivery tests
+
+1. Add failing tests for `notify({surface:"45"})`, stable UUID/workspace post-skill reads, and post-read failure after successful mutation.
+2. Validate V1 notify surface arguments at serialization, use stable route identity for observation, and make observation best-effort.
+3. Run focused tests green and prove no duplicate mutation is encouraged.
+
+### Task 5: Evidence and review closure
+
+**Files:** agent report and GitHub review threads
+
+1. Measure terse and full byte sizes from a real live daemon response.
+2. Run both full-suite environments, root/site typechecks, D138, perf ratchet, diff check, and archive exact-head verification.
+3. Push one reviewed round-2 commit.
+4. Reply to and resolve all 37 threads, crediting substantive finders and declining DeepSource-only lint churn.
+5. Update the agent report to `REVIEW_NEEDED` with exact head, caller inventory, evidence, absent bot coverage, and the final improvement gate.

--- a/scripts/acceptance-registry-liveness.mjs
+++ b/scripts/acceptance-registry-liveness.mjs
@@ -688,7 +688,16 @@ async function main() {
     let sendOk = 0;
     for (const a of spawned) {
       try {
-        const sr = await mcp.call("send_to", { agent_id: a.agent_id, text: "§7 addressability ping", press_enter: false }, 60_000);
+        const sr = await mcp.call(
+          "send_to",
+          {
+            mode: "agent",
+            agent_id: a.agent_id,
+            text: "§7 addressability ping",
+            press_enter: false,
+          },
+          60_000,
+        );
         if (sr.delivered !== false && sr.ok !== false) sendOk += 1;
       } catch (e) {
         process.stdout.write(`  send_to ${a.agent_id} threw: ${e.message}\n`);

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -820,6 +820,7 @@ async function measureFirstSendAfterSpawn(
   await waitForSweepHoldState(sweepHoldState, holdToken, "held");
   const first = await measureSend(
     {
+      mode: "agent",
       agent_id: spawnResult.agent_id,
       text: "Read and follow docs.local/scratch/run5r3/bench-first-send.md",
       press_enter: true,
@@ -833,6 +834,7 @@ async function measureFirstSendAfterSpawn(
   await waitForSweepHoldState(sweepHoldState, holdToken, "complete");
   const second = await measureSend(
     {
+      mode: "agent",
       agent_id: spawnResult.agent_id,
       text: "Read and follow docs.local/scratch/run5r3/bench-second-send.md",
       press_enter: true,

--- a/scripts/run-live-id-churn-probe.ts
+++ b/scripts/run-live-id-churn-probe.ts
@@ -310,13 +310,13 @@ async function main(): Promise<void> {
       mode: "key",
       surface: child.surface_id,
       workspace: child.workspace_id,
-      key: "down",
+      text: "down",
     });
     await call(client, "send_to", {
       mode: "key",
       surface: child.surface_id,
       workspace: child.workspace_id,
-      key: "return",
+      text: "return",
     });
     const afterOverlaySend = await rawCall(client, "send_to", {
       mode: "agent",

--- a/scripts/run-real-cmux-contract.ts
+++ b/scripts/run-real-cmux-contract.ts
@@ -1006,7 +1006,11 @@ async function runContractSteps(
     peer.sendNotification("notifications/initialized");
 
     setActiveStep("control_health baseline");
-    const healthResponse = await peer.callTool("control_health", {}, 15_000);
+    const healthResponse = await peer.callTool(
+      "control_health",
+      { detail: "full" },
+      15_000,
+    );
     const health = extractStructuredContent(healthResponse);
     assertLiveHealth(health, cmuxSocket);
     const initialDaemonPid = daemonPidFromHealth(health);
@@ -1047,7 +1051,11 @@ async function runContractSteps(
     assertOwnedDaemonSocket(root, daemonSocket);
     await terminateRecordedPid(initialDaemonPid, recordedPids);
 
-    const recoveredResponse = await peer.callTool("control_health", {}, 20_000);
+    const recoveredResponse = await peer.callTool(
+      "control_health",
+      { detail: "full" },
+      20_000,
+    );
     const recoveredHealth = extractStructuredContent(recoveredResponse);
     assertLiveHealth(recoveredHealth, cmuxSocket);
     const replacementDaemonPid = daemonPidFromHealth(recoveredHealth);

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -29,6 +29,7 @@ export interface DiscoveredAgent {
   token_count: number | null;
   context_pct: number | null;
   actions?: string[];
+  errors?: string[];
   has_agent: boolean;
   read_error: boolean;
 }
@@ -200,6 +201,7 @@ export class AgentDiscovery {
         token_count: parsed.token_count,
         context_pct: parsed.context_pct,
         actions: parsed.actions ?? [],
+        errors: parsed.errors,
         has_agent: cli !== "unknown",
         read_error: false,
       };
@@ -228,6 +230,7 @@ export class AgentDiscovery {
         model: null,
         token_count: null,
         context_pct: null,
+        errors: [],
         has_agent: false,
         read_error: true,
       };

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4742,6 +4742,14 @@ export class AgentEngine {
         halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);
+    } else if (
+      haltType === "harness_api_error" &&
+      agent.halt_last_observable_action !== haltObservableAction
+    ) {
+      episode = this.stateMgr.updateRecord(agent.agent_id, {
+        halt_last_observable_action: haltObservableAction,
+      });
+      this.registry.set(agent.agent_id, episode);
     }
     if (episode.halt_notification_sent_at) return episode;
 

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8139,6 +8139,7 @@ export class AgentEngine {
         status: parsed.status,
         agent_type: parsed.agent_type,
         control_state: parsed.control_state,
+        errors: parsed.errors,
       });
       // Mid-boot or an unparseable frame: the screen has no authority over the
       // status here, and reading its default as an idle prompt would fire an

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4626,7 +4626,11 @@ export class AgentEngine {
     );
     agent = this.persistPausedState(agent, parsed.paused === true, nowIso);
     if (agent.halt_escalation === false) return agent;
+    const hasHarnessApiError = parsed.errors.some((error) =>
+      error.startsWith("harness_api_error:"),
+    );
     if (
+      !hasHarnessApiError &&
       parsed.paused !== true &&
       (parsed.control_state === "shell" ||
         parsed.control_state === "dead" ||
@@ -4661,7 +4665,7 @@ export class AgentEngine {
       this.blockingBackgroundWaitElapsedMs(screenText);
     let haltType: AgentHaltType | null = null;
     let episodeStartedAtMs = nowMs;
-    if (parsed.errors.some((error) => error.startsWith("harness_api_error:"))) {
+    if (hasHarnessApiError) {
       haltType = "harness_api_error";
     } else if (
       parsed.control_state === "permission_prompt" ||

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4705,6 +4705,8 @@ export class AgentEngine {
       haltType === "harness_api_error"
         ? (harnessApiError ?? parsed.current_action ?? haltType)
         : (parsed.current_action ?? harnessApiError ?? haltType);
+    const harnessRequestId = (value: string | null | undefined): string | null =>
+      value?.match(/\brequest_id=(req_[A-Za-z0-9]+)/i)?.[1] ?? null;
 
     let episode = agent;
     if (!agent.halt_episode_type) {
@@ -4750,15 +4752,24 @@ export class AgentEngine {
       haltType === "harness_api_error" &&
       agent.halt_last_observable_action !== haltObservableAction
     ) {
-      episode = this.stateMgr.updateRecord(agent.agent_id, {
-        halt_episode_started_at: nowIso,
-        halt_episode_observations: 1,
-        halt_notification_sent_at: null,
-        halt_notified_ancestor_id: null,
-        halt_fallback_sink_id: null,
-        halt_last_delivery_error: null,
-        halt_last_observable_action: haltObservableAction,
-      });
+      const sameRequestId =
+        harnessRequestId(agent.halt_last_observable_action) !== null &&
+        harnessRequestId(agent.halt_last_observable_action) ===
+          harnessRequestId(haltObservableAction);
+      episode = this.stateMgr.updateRecord(
+        agent.agent_id,
+        sameRequestId
+          ? { halt_last_observable_action: haltObservableAction }
+          : {
+              halt_episode_started_at: nowIso,
+              halt_episode_observations: 1,
+              halt_notification_sent_at: null,
+              halt_notified_ancestor_id: null,
+              halt_fallback_sink_id: null,
+              halt_last_delivery_error: null,
+              halt_last_observable_action: haltObservableAction,
+            },
+      );
       this.registry.set(agent.agent_id, episode);
     }
     if (episode.halt_notification_sent_at) return episode;

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -3583,7 +3583,7 @@ export class AgentEngine {
     return updated;
   }
 
-  private async readAgentScreen(
+  async readAgentScreen(
     agent: Pick<AgentRecord, "agent_id">,
     opts: { lines?: number; scrollback?: boolean } = {},
   ): Promise<CmuxReadScreenResult> {
@@ -4730,7 +4730,8 @@ export class AgentEngine {
         halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);
-      return episode;
+      if (haltType !== "harness_api_error") return episode;
+      agent = episode;
     }
     if (haltType === "wedged") {
       episode = this.stateMgr.updateRecord(agent.agent_id, {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4694,10 +4694,13 @@ export class AgentEngine {
       haltType = "idle_without_done";
     }
     if (!haltType) return this.clearHaltEpisode(agent);
+    const harnessApiError = parsed.errors.find((error) =>
+      error.startsWith("harness_api_error:"),
+    );
     const haltObservableAction =
-      parsed.current_action ??
-      parsed.errors.find((error) => error.startsWith("harness_api_error:")) ??
-      haltType;
+      haltType === "harness_api_error"
+        ? (harnessApiError ?? parsed.current_action ?? haltType)
+        : (parsed.current_action ?? harnessApiError ?? haltType);
 
     let episode = agent;
     if (!agent.halt_episode_type) {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4747,6 +4747,12 @@ export class AgentEngine {
       agent.halt_last_observable_action !== haltObservableAction
     ) {
       episode = this.stateMgr.updateRecord(agent.agent_id, {
+        halt_episode_started_at: nowIso,
+        halt_episode_observations: 1,
+        halt_notification_sent_at: null,
+        halt_notified_ancestor_id: null,
+        halt_fallback_sink_id: null,
+        halt_last_delivery_error: null,
         halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -4110,6 +4110,8 @@ export class AgentEngine {
         return this.haltIdleWithoutDoneDwellMs;
       case "wedged":
         return this.haltWedgedDwellMs;
+      case "harness_api_error":
+        return 0;
     }
   }
 
@@ -4130,6 +4132,8 @@ export class AgentEngine {
           `the child is paused and cannot act — unpause the pane before send_to, ` +
           `or send_key(surface: "${agent.surface_id}", key: "return") if the screen says to resume`
         );
+      case "harness_api_error":
+        return `inspect the harness API error and request ID on surface ${agent.surface_id}, then retry or resume the harness turn`;
     }
   }
 
@@ -4657,7 +4661,9 @@ export class AgentEngine {
       this.blockingBackgroundWaitElapsedMs(screenText);
     let haltType: AgentHaltType | null = null;
     let episodeStartedAtMs = nowMs;
-    if (
+    if (parsed.errors.some((error) => error.startsWith("harness_api_error:"))) {
+      haltType = "harness_api_error";
+    } else if (
       parsed.control_state === "permission_prompt" ||
       parsed.control_state === "interactive_overlay"
     ) {
@@ -4688,6 +4694,10 @@ export class AgentEngine {
       haltType = "idle_without_done";
     }
     if (!haltType) return this.clearHaltEpisode(agent);
+    const haltObservableAction =
+      parsed.current_action ??
+      parsed.errors.find((error) => error.startsWith("harness_api_error:")) ??
+      haltType;
 
     let episode = agent;
     if (!agent.halt_episode_type) {
@@ -4702,10 +4712,11 @@ export class AgentEngine {
         halt_notified_ancestor_id: null,
         halt_fallback_sink_id: null,
         halt_last_delivery_error: null,
-        halt_last_observable_action: parsed.current_action ?? haltType,
+        halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);
-      return episode;
+      if (haltType !== "harness_api_error") return episode;
+      agent = episode;
     }
     if (agent.halt_episode_type !== haltType) {
       episode = this.stateMgr.updateRecord(agent.agent_id, {
@@ -4716,7 +4727,7 @@ export class AgentEngine {
         halt_notified_ancestor_id: null,
         halt_fallback_sink_id: null,
         halt_last_delivery_error: null,
-        halt_last_observable_action: parsed.current_action ?? haltType,
+        halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);
       return episode;
@@ -4724,7 +4735,7 @@ export class AgentEngine {
     if (haltType === "wedged") {
       episode = this.stateMgr.updateRecord(agent.agent_id, {
         halt_episode_observations: (agent.halt_episode_observations ?? 0) + 1,
-        halt_last_observable_action: parsed.current_action ?? haltType,
+        halt_last_observable_action: haltObservableAction,
       });
       this.registry.set(agent.agent_id, episode);
     }
@@ -5709,6 +5720,7 @@ export class AgentEngine {
               return {
                 status: parsed.status,
                 actions: parsed.actions,
+                errors: parsed.errors,
               };
             } catch {
               return null;

--- a/src/agent-health-input.ts
+++ b/src/agent-health-input.ts
@@ -26,6 +26,7 @@ export interface ParsedSurfaceHealthInput {
   agent_type?: ParsedScreenAgentType | null;
   control_state?: ParsedControlPlaneState | null;
   actions?: string[] | null;
+  errors?: string[] | null;
 }
 
 export interface AgentHealthInputOverrides {
@@ -37,6 +38,7 @@ export interface AgentHealthInputOverrides {
   screen_agent_type?: ParsedScreenAgentType | null;
   screen_control_state?: ParsedControlPlaneState | null;
   screen_actions?: string[] | null;
+  screen_errors?: string[] | null;
   surface_workspace_id?: string | null;
   surface_title?: string | null;
   topology?: AgentTopologyHealthInput | null;
@@ -115,8 +117,9 @@ export async function buildAgentHealthInput(
     overrides.screen_agent_type === undefined ||
     overrides.screen_control_state === undefined ||
     overrides.screen_actions === undefined;
+  const needsScreenErrors = overrides.screen_errors === undefined;
   let parsedScreen: ParsedSurfaceHealthInput | null | undefined = null;
-  if (needsScreen) {
+  if (needsScreen || needsScreenErrors) {
     try {
       parsedScreen = await deps.readParsedSurface?.(agent);
     } catch {
@@ -131,6 +134,10 @@ export async function buildAgentHealthInput(
     overrides.screen_actions !== undefined
       ? overrides.screen_actions
       : parsedScreen?.actions;
+  const screenErrors =
+    overrides.screen_errors !== undefined
+      ? overrides.screen_errors
+      : parsedScreen?.errors;
   const screenAgentType =
     overrides.screen_agent_type !== undefined
       ? overrides.screen_agent_type
@@ -165,6 +172,7 @@ export async function buildAgentHealthInput(
     screen_agent_type: screenAgentType,
     screen_control_state: screenControlState,
     screen_actions: screenActions,
+    screen_errors: screenErrors,
     surface_workspace_id: surfaceWorkspaceId,
     surface_title: overrides.surface_title,
     topology,

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -28,6 +28,7 @@ export type AgentHealthIssueCode =
   | "agent_wedged"
   | "agent_shell_fallback"
   | "pane_pty_dead"
+  | "harness_api_error"
   | "registry_screen_disagreement"
   | "registry_surface_workspace_mismatch"
   | "closure_without_artifact"
@@ -53,6 +54,7 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   agent_wedged: "blocking",
   agent_shell_fallback: "blocking",
   pane_pty_dead: "blocking",
+  harness_api_error: "blocking",
   closure_without_artifact: "blocking",
   pr_loop_incomplete: "blocking",
   kept_open_contract_incomplete: "blocking",
@@ -97,6 +99,7 @@ export interface AgentHealthInput {
   closure_artifact_verified?: boolean | null;
   harvestability?: WorkerHarvestability | null;
   screen_actions?: string[] | null;
+  screen_errors?: string[] | null;
   topology?: AgentTopologyHealthInput | null;
   surface_write_liveness?: SurfaceWriteLivenessObservation | null;
   collapsed_monitors?: CollapsedMonitorHealthInput[];
@@ -452,6 +455,17 @@ export function evaluateAgentHealth(
 
   const screenActive =
     input.screen_status === "working" || input.screen_status === "thinking";
+  const harnessApiErrors = (input.screen_errors ?? []).filter((error) =>
+    error.startsWith("harness_api_error:"),
+  );
+  if (harnessApiErrors.length > 0) {
+    addIssue(
+      issueCodes,
+      issues,
+      "harness_api_error",
+      harnessApiErrors.join("; "),
+    );
+  }
   const panePtyDead =
     screenActive && input.surface_write_liveness?.pty_dead === true;
   if (panePtyDead) {

--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -485,6 +485,7 @@ export function evaluateAgentHealth(
       status: input.screen_status,
       agent_type: input.screen_agent_type,
       control_state: input.screen_control_state,
+      errors: input.screen_errors,
     }) ?? undefined;
   const screenIsShell =
     input.screen_control_state === "shell" &&

--- a/src/agent-types.ts
+++ b/src/agent-types.ts
@@ -25,7 +25,11 @@ export type SeatIdentityStatus = "ok" | "mismatch" | "unknown";
 // behind `resumable`, #482), as opposed to a remembered registry field.
 export type ObservationSource = "screen" | "registry" | "process" | "disk";
 export type AgentHaltType =
-  "awaiting_input" | "idle_without_done" | "wedged" | "paused";
+  | "awaiting_input"
+  | "idle_without_done"
+  | "wedged"
+  | "paused"
+  | "harness_api_error";
 
 export interface Observed<T> {
   value: T;

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -124,7 +124,11 @@ export class CmuxClient {
 
   private async run(args: string[]): Promise<string> {
     for (let index = 0; index < args.length - 1; index += 1) {
-      if (args[index] === "--surface") {
+      if (
+        args[index] === "--surface" ||
+        args[index] === "--before" ||
+        args[index] === "--after"
+      ) {
         assertCanonicalSurfaceRef(args[index + 1]);
       }
     }

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -27,6 +27,7 @@ import { normalizeKeyName } from "./key-names.js";
 import { CmuxSocketError } from "./cmux-socket-error.js";
 import { parseCmuxStatusFrame } from "./cmux-status-frame.js";
 import { isCmuxAccessControlDenied } from "./cmux-access-control.js";
+import { assertCanonicalSurfaceRef } from "./surface-ref.js";
 
 const execFileAsync = promisify(execFile);
 /**
@@ -122,6 +123,21 @@ export class CmuxClient {
   }
 
   private async run(args: string[]): Promise<string> {
+    for (let index = 0; index < args.length - 1; index += 1) {
+      if (args[index] === "--surface") {
+        assertCanonicalSurfaceRef(args[index + 1]);
+      }
+    }
+    if (args[0] === "rpc" && args[2]) {
+      try {
+        const params = JSON.parse(args[2]) as { surface_id?: unknown };
+        if (typeof params.surface_id === "string") {
+          assertCanonicalSurfaceRef(params.surface_id);
+        }
+      } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+      }
+    }
     try {
       // Pin every CLI-fallback exec to the instance env (CMUX_SOCKET_PATH) so
       // the `cmux` subprocess cannot inherit an ambient socket path pointing at

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -31,6 +31,7 @@ import { DEFAULT_SOCKET_PATH } from "./cmux-socket-path.js";
 import { parseCmuxStatusFrame } from "./cmux-status-frame.js";
 import { recordCliFallback } from "./transport-retry-context.js";
 import { listAllWindowWorkspaces } from "./surface-topology.js";
+import { assertCanonicalSurfaceRef } from "./surface-ref.js";
 export { CmuxSocketError } from "./cmux-socket-error.js";
 
 // ── Configuration ──────────────────────────────────────────────────────
@@ -146,6 +147,9 @@ export class CmuxSocketClient {
     method: string,
     params: Record<string, unknown> = {},
   ): Promise<T> {
+    if (typeof params.surface_id === "string") {
+      assertCanonicalSurfaceRef(params.surface_id);
+    }
     return this.withConnectionRetry(
       async () => {
         await this.ensureAuthenticated();

--- a/src/cmux-socket-client.ts
+++ b/src/cmux-socket-client.ts
@@ -673,6 +673,7 @@ export class CmuxSocketClient {
     workspace?: string;
     surface?: string;
   }): Promise<void> {
+    if (opts?.surface) assertCanonicalSurfaceRef(opts.surface);
     const args: V1Arg[] = [];
     if (opts?.title) {
       args.push(this.rawV1Arg("--title"), opts.title);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -573,7 +573,10 @@ function probeDaemonMcp(
               jsonrpc: "2.0",
               id: 2,
               method: "tools/call",
-              params: { name: "control_health", arguments: {} },
+              params: {
+                name: "control_health",
+                arguments: { detail: "full" },
+              },
             });
           } else if (message.id === 2) {
             const result = isRecord(message.result) ? message.result : null;

--- a/src/live-agent-state.ts
+++ b/src/live-agent-state.ts
@@ -63,6 +63,7 @@ export function screenConfirmedAgentState(
   // A tracked agent surface that has fallen back to a bare shell has no agent
   // process left; that is an error regardless of how idle the prompt looks.
   if (controlState === "shell" && agentType === "unknown") return "error";
+  if (status === "frozen") return "error";
   if (status === "working" || status === "thinking") return "working";
   if (
     controlState === "ready" &&

--- a/src/live-agent-state.ts
+++ b/src/live-agent-state.ts
@@ -33,6 +33,7 @@ export type ScreenStateObservation = {
   status?: ParsedScreenStatus | string | null;
   agent_type?: string | null;
   control_state?: ParsedControlPlaneState | string | null;
+  errors?: string[] | null;
 };
 
 export type LiveAgentState = {
@@ -60,10 +61,16 @@ export function screenConfirmedAgentState(
   const status = screen.status ?? null;
   const agentType = screen.agent_type ?? null;
   const controlState = screen.control_state ?? null;
+  const hasHarnessApiError = (screen.errors ?? []).some((error) =>
+    error.startsWith("harness_api_error:"),
+  );
   // A tracked agent surface that has fallen back to a bare shell has no agent
   // process left; that is an error regardless of how idle the prompt looks.
   if (controlState === "shell" && agentType === "unknown") return "error";
-  if (status === "frozen") return "error";
+  // `frozen` is shared by recoverable permission prompts, interactive pickers,
+  // and transient SQLITE_BUSY contention. Only the terminal harness API error
+  // marker is strong enough to force agent state to `error`.
+  if (hasHarnessApiError) return "error";
   if (status === "working" || status === "thinking") return "working";
   if (
     controlState === "ready" &&

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1217,7 +1217,7 @@ function parseErrors(text: string): string[] {
   const harnessErrorLine = lines[harnessErrorIndex];
   const recoveredAfterHarnessError = lines
     .slice(harnessErrorIndex + 1)
-    .some((line) => /^(?:❯|>)\s+\S/.test(line));
+    .some((line) => ACTION_BLOCK_LINE_RE.test(line));
   if (harnessErrorLine && !recoveredAfterHarnessError) {
     const errorTail = lines.slice(harnessErrorIndex).join("\n");
     const requestId =

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1206,12 +1206,25 @@ function parseErrors(text: string): string[] {
 
   const lines = text.split("\n").map((line) => line.trim());
   let harnessErrorIndex = -1;
+  let harnessErrorRequestId: string | null = null;
   for (let index = 0; index < lines.length; index += 1) {
     if (
       /^API Error:/i.test(lines[index]) ||
       /^Claude Code can't respond\b.*$/i.test(lines[index])
     ) {
+      const composerIndex = lines.findIndex(
+        (line, candidateIndex) =>
+          candidateIndex > index && /^❯(?:\s|$)/.test(line),
+      );
+      if (composerIndex < 0) continue;
+      const errorBlock = lines.slice(index, composerIndex).join("\n");
+      const requestId =
+        errorBlock.match(
+          /(?:"request_id"\s*:\s*"|request[ _]id\s*:\s*)(req_[A-Za-z0-9]+)/i,
+        )?.[1] ?? null;
+      if (!requestId) continue;
       harnessErrorIndex = index;
+      harnessErrorRequestId = requestId;
     }
   }
   const harnessErrorLine = lines[harnessErrorIndex];
@@ -1219,15 +1232,13 @@ function parseErrors(text: string): string[] {
     .slice(harnessErrorIndex + 1)
     .some((line) => ACTION_BLOCK_LINE_RE.test(line));
   if (harnessErrorLine && !recoveredAfterHarnessError) {
-    const errorTail = lines.slice(harnessErrorIndex).join("\n");
-    const requestId =
-      errorTail.match(/(?:"request_id"\s*:\s*"|request[ _]id\s*:\s*)(req_[A-Za-z0-9]+)/i)?.[1] ??
-      "unknown";
     const summary = harnessErrorLine
       .replace(/^API Error:\s*/i, "")
       .replace(/\s+/g, " ")
       .trim();
-    errors.push(`harness_api_error: ${summary} request_id=${requestId}`);
+    errors.push(
+      `harness_api_error: ${summary} request_id=${harnessErrorRequestId}`,
+    );
   }
 
   if (hasApprovalPromptBlock(text)) {

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1213,6 +1213,14 @@ function parseErrors(text: string): string[] {
       /^API Error:/i.test(rawLines[index] ?? "") ||
       /^Claude Code can't respond\b.*$/i.test(rawLines[index] ?? "")
     ) {
+      const precedingLine = [...lines.slice(0, index)]
+        .reverse()
+        .find((line) => line.length > 0);
+      const beginsHarnessOwnedBlock =
+        precedingLine === undefined ||
+        /^Claude Code(?:\s+v?\d.*)?$/i.test(precedingLine) ||
+        /^❯(?:\s|$)/.test(precedingLine);
+      if (!beginsHarnessOwnedBlock) continue;
       const composerIndex = lines.findIndex(
         (line, candidateIndex) =>
           candidateIndex > index && /^❯(?:\s|$)/.test(line),

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1231,7 +1231,10 @@ function parseErrors(text: string): string[] {
   const harnessErrorLine = lines[harnessErrorIndex];
   const recoveredAfterHarnessError = lines
     .slice(harnessErrorIndex + 1)
-    .some((line) => ACTION_BLOCK_LINE_RE.test(line));
+    .some(
+      (line) =>
+        ACTION_BLOCK_LINE_RE.test(line) || CLAUDE_WORKING_LINE_RE.test(line),
+    );
   if (harnessErrorLine && !recoveredAfterHarnessError) {
     const summary = harnessErrorLine
       .replace(/^API Error:\s*/i, "")

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1204,6 +1204,32 @@ export function isPickerOrMenuScreen(text: string, cli?: CliType): boolean {
 function parseErrors(text: string): string[] {
   const errors: string[] = [];
 
+  const lines = text.split("\n").map((line) => line.trim());
+  let harnessErrorIndex = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (
+      /^API Error:/i.test(lines[index]) ||
+      /^Claude Code can't respond\b.*$/i.test(lines[index])
+    ) {
+      harnessErrorIndex = index;
+    }
+  }
+  const harnessErrorLine = lines[harnessErrorIndex];
+  const recoveredAfterHarnessError = lines
+    .slice(harnessErrorIndex + 1)
+    .some((line) => /^(?:❯|>)\s+\S/.test(line));
+  if (harnessErrorLine && !recoveredAfterHarnessError) {
+    const errorTail = lines.slice(harnessErrorIndex).join("\n");
+    const requestId =
+      errorTail.match(/(?:"request_id"\s*:\s*"|request[ _]id\s*:\s*)(req_[A-Za-z0-9]+)/i)?.[1] ??
+      "unknown";
+    const summary = harnessErrorLine
+      .replace(/^API Error:\s*/i, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    errors.push(`harness_api_error: ${summary} request_id=${requestId}`);
+  }
+
   if (hasApprovalPromptBlock(text)) {
     errors.push("permission_prompt");
   }

--- a/src/screen-parser.ts
+++ b/src/screen-parser.ts
@@ -1204,13 +1204,14 @@ export function isPickerOrMenuScreen(text: string, cli?: CliType): boolean {
 function parseErrors(text: string): string[] {
   const errors: string[] = [];
 
-  const lines = text.split("\n").map((line) => line.trim());
+  const rawLines = text.split("\n");
+  const lines = rawLines.map((line) => line.trim());
   let harnessErrorIndex = -1;
   let harnessErrorRequestId: string | null = null;
   for (let index = 0; index < lines.length; index += 1) {
     if (
-      /^API Error:/i.test(lines[index]) ||
-      /^Claude Code can't respond\b.*$/i.test(lines[index])
+      /^API Error:/i.test(rawLines[index] ?? "") ||
+      /^Claude Code can't respond\b.*$/i.test(rawLines[index] ?? "")
     ) {
       const composerIndex = lines.findIndex(
         (line, candidateIndex) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -18066,17 +18066,29 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   { lines: 20 },
                 );
                 const submittedCommand = args.command!.trim();
+                const screenLines = screen.text
+                  .split("\n")
+                  .map((line) => line.trim());
+                let commandLineIndex = -1;
+                for (let index = screenLines.length - 1; index >= 0; index -= 1) {
+                  if (
+                    screenLines[index]?.replace(/^[>❯›]\s*/, "") ===
+                    submittedCommand
+                  ) {
+                    commandLineIndex = index;
+                    break;
+                  }
+                }
                 screenResultLine =
-                  screen.text
-                    .split("\n")
-                    .map((line) => line.trim())
+                  screenLines
+                    .slice(commandLineIndex + 1)
                     .filter(
                       (line) =>
+                        commandLineIndex >= 0 &&
                         (!isComposerFooterOrChromeLine(line) ||
                           /^CLAUDE_COUNTER:/i.test(line)) &&
                         !/^Claude Code(?:\s+v?\d|$)/i.test(line) &&
-                        !/^[>❯›]\s*$/.test(line) &&
-                        line.replace(/^[>❯›]\s*/, "") !== submittedCommand,
+                        !/^[>❯›]\s*$/.test(line),
                     )
                     .at(-1) ?? null;
                 screenResultAvailable = screenResultLine !== null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -220,7 +220,12 @@ import type {
   ParsedScreenResult,
 } from "./types.js";
 import { isSubmitKey, normalizeKeyName } from "./key-names.js";
-import { currentCallerContext, type CallerContext } from "./caller-context.js";
+import { assertCanonicalSurfaceRef } from "./surface-ref.js";
+import {
+  callerContextFromEnv,
+  currentCallerContext,
+  type CallerContext,
+} from "./caller-context.js";
 import {
   CLI_INPUT_PROMPT_PREFIXES,
   CURSOR_FOLLOWUP_ENTER_SEND_NOW_RE,
@@ -561,18 +566,19 @@ const SendToArgsSchema = z.object({
           SEND_TO_WORKING_EXAMPLE,
       }),
     })
-    .optional()
-    .default("agent"),
-  target: z.string().optional(),
+    .optional(),
+  target: z
+    .union([z.string(), z.number().transform((value) => String(value))])
+    .optional(),
   agent_id: z.string().optional(),
-  surface: z.string().optional(),
-  text: z.string().optional(),
-  command: z.string().optional(),
-  key: z
+  surface: z
+    .union([z.string(), z.number().transform((value) => String(value))])
+    .optional(),
+  text: z
     .string()
     .optional()
     .describe(
-      'Key name for mode="key". Submit aliases (return, enter, KPEnter, ctrl-m, a raw CR) are normalized to "return" and verified from observed prompt/composer transitions; unchanged composer contents alone are not treated as failure.',
+      'Text for every mode. In mode="key", this is the key name; submit aliases are normalized to "return".',
     ),
   workspace: z.string().optional(),
   chunk_size: z.number().int().min(1).optional().default(200),
@@ -996,6 +1002,7 @@ export interface PublicDeliveryReceipt {
   typed: boolean;
   submit_attempted: boolean;
   submit_verified: boolean | null;
+  submitted: boolean;
   submit_evidence?: SubmitEvidence | null;
   retry_count: number;
   delivery?: PublicDeliveryState;
@@ -1107,6 +1114,7 @@ export function buildPublicDeliveryReceipt(input: {
     typed: input.typed,
     submit_attempted: input.submit_attempted,
     submit_verified: input.submit_verified,
+    submitted: input.submit_verified === true,
     ...(input.submit_verified !== null
       ? { submit_evidence: input.submit_evidence ?? null }
       : {}),
@@ -1300,12 +1308,13 @@ class DeliverySafetyGateError extends Error {
       | "blocked_by_permission_prompt"
       | "blocked_by_foreign_draft",
     readonly screen: ParsedScreenResult,
+    readonly draftText?: string,
   ) {
     super(
       error_code === "blocked_by_permission_prompt"
         ? "delivery blocked by active permission prompt"
         : error_code === "blocked_by_foreign_draft"
-          ? "target composer already holds text this delivery did not write; refused before typing"
+          ? `target composer already holds text this delivery did not write: ${JSON.stringify(draftText ?? "unknown")}; refused before typing`
         : "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
     );
     this.name = "DeliverySafetyGateError";
@@ -5468,6 +5477,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       throw new DeliverySafetyGateError(
         "blocked_by_foreign_draft",
         snapshot.parsed,
+        extractComposerInputRegion(snapshot.text)?.trim() || undefined,
       );
     }
 
@@ -6147,7 +6157,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       opts.source_event === "send_to_agent" ||
       opts.source_event === "send_input" ||
       opts.source_event === "dispatch_nudge" ||
-      opts.source_event === "report_to_parent";
+      opts.source_event === "report_to_parent" ||
+      opts.source_event === "interact";
     const draftGuardText = opts.chunks.join("");
     const deliverySafetySnapshot = await assertDeliveryTargetIsSafe({
       surface: opts.surface,
@@ -6427,8 +6438,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     let updateElapsedMs = 0;
     let updateWasSeen = false;
     let updateShellRelaunches = 0;
-    let codexUpdateMenuAccepted = false;
-    let codexUpdateMenuAcceptedAt: number | null = null;
     type QueuedBootObservation = {
       metrics: RawSubmitEvidenceMetrics;
       route: { surface: string; workspace?: string };
@@ -6469,56 +6478,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
 
         if (shouldHandleCodexUpdateMenu(opts.cli, screen.text)) {
-          if (codexUpdateMenuAccepted) {
-            const elapsedSinceAcceptMs =
-              codexUpdateMenuAcceptedAt === null
-                ? BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS
-                : now - codexUpdateMenuAcceptedAt;
-            if (
-              elapsedSinceAcceptMs < BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS
-            ) {
-              consecutiveMatches.clear();
-              await delay(BOOT_PROMPT_READY_POLL_MS);
-              continue;
-            }
-            throw new BootPromptUpdateMenuBlockedError(
-              `Boot prompt delivery blocked by Codex update menu on ${target.surface}`,
-              tailLines(lastText, 10),
-            );
-          }
-          updateWasSeen = true;
-          consecutiveMatches.clear();
-          await sendKeyWithRetry(
-            target.surface,
-            "return",
-            target.workspace,
-            opts.resolveRoute
-              ? async () => {
-                  const current = await opts.resolveRoute!();
-                  if (
-                    current.surface !== target.surface ||
-                    (current.workspace ?? null) !== (target.workspace ?? null)
-                  ) {
-                    throw new Error(
-                      `Boot prompt route changed before update-menu Return; ` +
-                        `refusing terminal mutation.`,
-                    );
-                  }
-                }
-              : undefined,
+          throw new BootPromptUpdateMenuBlockedError(
+            `Boot prompt delivery blocked by Codex update menu on ${target.surface}; cmuxlayer will not press Return before the prompt is typed`,
+            tailLines(lastText, 10),
           );
-          codexUpdateMenuAccepted = true;
-          const acceptedAt = Date.now();
-          codexUpdateMenuAcceptedAt = acceptedAt;
-          deadline = Math.max(
-            deadline,
-            acceptedAt + postUpdateReadyBudgetMs(),
-            acceptedAt +
-              BOOT_PROMPT_UPDATE_MENU_DISMISS_GRACE_MS +
-              BOOT_PROMPT_READY_POLL_MS,
-          );
-          await delay(BOOT_PROMPT_READY_POLL_MS);
-          continue;
         }
 
         if (updateState === "updating") {
@@ -6699,18 +6662,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         // A NULL count stays inconclusive on purpose: several CLIs never
         // report one, and reading unknown as zero would break every boot.
         const consumptionRefuted = metrics.tokenCount === 0;
+        const composerInput = extractComposerInputRegion(snapshot.text);
+        const hasPendingInput = screenShowsPendingInput(
+          snapshot.text,
+          opts.text,
+        );
         if (
+          !hasPendingInput &&
           !consumptionRefuted &&
           isSubmitVerifiedStatus(snapshot.parsed.status)
         ) {
           return "status_only";
         }
 
-        const composerInput = extractComposerInputRegion(snapshot.text);
-        const hasPendingInput = screenShowsPendingInput(
-          snapshot.text,
-          opts.text,
-        );
         if (
           composerInput !== null &&
           !hasPendingInput &&
@@ -8993,19 +8957,76 @@ export function createServer(opts?: CreateServerOptions): McpServer {
 
   server.tool(
     "control_health",
-    "Report cmuxlayer control-path health: selected transport, prod/nightly socket markers, cmux binary resolution, process env, and job-control diagnostics.",
-    {},
+    "Report terse control-path health by default; pass detail=full for diagnostics.",
+    {
+      detail: z.enum(["terse", "full"]).optional().default("terse"),
+    },
     ANNOTATIONS.readOnly,
-    async () => {
+    async (args) => {
       try {
         const health = await appendControlHealthSnapshot();
         const staleWarning = staleBuildWarning();
         const healthWithStale = staleWarning
           ? { ...health, warnings: [...health.warnings, staleWarning] }
           : health;
-        return okFormatted(formatControlHealth(healthWithStale), {
-          health: healthWithStale,
-        });
+        if (args.detail === "full") {
+          return okFormatted(formatControlHealth(healthWithStale), {
+            health: healthWithStale,
+          });
+        }
+        const callerSurface =
+          currentCallerContext()?.surfaceId?.trim() ??
+          callerContextFromEnv()?.surfaceId?.trim();
+        const caller =
+          resolveCurrentCallerAgent() ??
+          (callerSurface
+            ? stateMgr
+                .listStates()
+                .find(
+                  (agent) =>
+                    agent.surface_id === callerSurface ||
+                    agent.surface_uuid?.toLowerCase() ===
+                      callerSurface.toLowerCase(),
+                ) ?? null
+            : null);
+        const callerOwners = new Set(
+          [caller?.agent_id, caller?.seat_id].filter(
+            (value): value is string => Boolean(value),
+          ),
+        );
+        const watches = caller
+          ? readWatchRegistry({
+              registryPath:
+                opts?.watchRegistryPath ??
+                join(context.stateDir, "watch-specs.json"),
+            }).watches
+              .filter(
+                (watch) =>
+                  callerOwners.has(watch.owner) &&
+                  (watch.state === "armed" || watch.state === "firing"),
+              )
+              .map(({ watch_id, target, state }) => ({
+                watch_id,
+                target,
+                state,
+              }))
+          : [];
+        const terse = {
+          transport: healthWithStale.selected_transport,
+          warnings: healthWithStale.warnings,
+          daemon_lifecycle: healthWithStale.daemon_lifecycle,
+          self_heal: {
+            pane_pty_dead:
+              healthWithStale.self_heal.pane_pty_dead.count,
+            collapsed_monitors:
+              healthWithStale.self_heal.monitor_registry.collapsed,
+          },
+          caller_live_watches: {
+            count: watches.length,
+            watches,
+          },
+        };
+        return okFormatted(JSON.stringify(terse), { health: terse });
       } catch (e) {
         return err(e);
       }
@@ -16790,6 +16811,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (rawArgs) => {
         let failedReceiptPayload: Record<string, unknown> = {};
         try {
+          if (rawArgs.mode === undefined) {
+            throw new Error("mode required (agent|surface|command|key)");
+          }
+          if ("message" in rawArgs || "command" in rawArgs || "key" in rawArgs) {
+            throw new Error("send_to accepts one payload parameter: text");
+          }
+          for (const field of ["surface", "target"] as const) {
+            if (typeof rawArgs[field] === "number") {
+              throw new Error(
+                `bare surface index ${JSON.stringify(rawArgs[field])} is not allowed; use surface:<index> ref or a surface UUID`,
+              );
+            }
+          }
           const parsedArgs = SendToArgsSchema.safeParse(rawArgs);
           if (!parsedArgs.success) {
             return err(
@@ -16798,7 +16832,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
 
           const args = parsedArgs.data;
-          const mode = args.mode ?? "agent";
+          const mode = args.mode;
+          if (!mode) {
+            throw new Error("mode required (agent|surface|command|key)");
+          }
           if (args.targeting && mode !== "agent") {
             throw new Error(
               "send_to.targeting is supported only in mode=agent",
@@ -16811,6 +16848,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 `send_to mode=${mode} requires target or surface`,
               );
             }
+            assertCanonicalSurfaceRef(surface);
             const legacyHandler = (name: string) => {
               const handler = toolHandlersByName.get(name);
               if (!handler) {
@@ -16845,11 +16883,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               );
             }
             if (mode === "command") {
-              const command = args.command ?? args.text;
+              const command = args.text;
               if (command === undefined) {
-                throw new Error(
-                  "send_to mode=command requires command or text",
-                );
+                throw new Error("send_to mode=command requires text");
               }
               return legacyHandler("send_command")(
                 {
@@ -16863,11 +16899,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 {},
               );
             }
-            if (!args.key) {
-              throw new Error("send_to mode=key requires key");
+            if (!args.text) {
+              throw new Error("send_to mode=key requires text");
             }
             return legacyHandler("send_key")(
-              { surface, workspace: args.workspace, key: args.key },
+              { surface, workspace: args.workspace, key: args.text },
               {},
             );
           }
@@ -17575,7 +17611,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ANNOTATIONS.mutating,
       async (rawArgs) => {
         try {
-          const parsedArgs = SendToArgsSchema.safeParse(rawArgs);
+          const parsedArgs = SendToArgsSchema.safeParse({
+            ...rawArgs,
+            mode: "agent",
+          });
           if (!parsedArgs.success) {
             return err(
               new Error(
@@ -17997,12 +18036,23 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 press_enter: true,
                 source_event: "interact",
               });
+              const route = await engine.resolveAgentIoRoute(args.agent);
+              const screen = await client.readScreen(route.surface_id, {
+                workspace: route.workspace_id ?? undefined,
+                lines: 20,
+              });
+              const screenResultLine = screen.text
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .at(-1) ?? null;
               const d = {
                 agent_id: args.agent,
                 action: "skill",
                 command: args.command,
                 retry_count: delivery.retry_count,
                 submit_verified: delivery.submit_verified,
+                screen_result_line: screenResultLine,
               };
               return okFormatted(formatOk("interact:skill", d), d);
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -17594,6 +17594,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         } catch (e) {
           if (e instanceof DeliverySafetyGateError) {
             return err(e, {
+              ...e.receipt,
               ...failedReceiptPayload,
               error_code: e.error_code,
               submit_verified: e.submit_verified,
@@ -18055,6 +18056,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               const submittedCommand = args.command!.trim();
               const isSubmittedCommandEcho = (line: string): boolean =>
                 line.trim().replace(/^[>❯›]\s*/, "") === submittedCommand;
+              const isActiveSkillProgressLine = (line: string): boolean =>
+                /^(?:[•✻✢✳✶✦]\s*(?:Thinking|Working)|[⏺⬡]\s*Running)(?:\b|…)/iu.test(
+                  line,
+                );
               let commandEchoCountBefore: number | null = null;
               try {
                 const beforeScreen = await engine.readAgentScreen(
@@ -18105,6 +18110,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         commandEchoCountBefore !== null &&
                         commandEchoCountAfter > commandEchoCountBefore &&
                         commandLineIndex >= 0 &&
+                        !isActiveSkillProgressLine(line) &&
                         (!isComposerFooterOrChromeLine(line) ||
                           /^CLAUDE_COUNTER:/i.test(line)) &&
                         !/^Claude Code(?:\s+v?\d|$)/i.test(line) &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -18052,6 +18052,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return okFormatted(formatOk("interact:resume", d), d);
             }
             case "skill": {
+              const submittedCommand = args.command!.trim();
+              const isSubmittedCommandEcho = (line: string): boolean =>
+                line.trim().replace(/^[>❯›]\s*/, "") === submittedCommand;
+              let commandEchoCountBefore: number | null = null;
+              try {
+                const beforeScreen = await engine.readAgentScreen(
+                  { agent_id: args.agent },
+                  { lines: 20 },
+                );
+                commandEchoCountBefore = beforeScreen.text
+                  .split("\n")
+                  .filter(isSubmittedCommandEcho).length;
+              } catch {
+                // Without a baseline, later output cannot be attributed to
+                // this invocation rather than an identical historical echo.
+              }
               const delivery = await deliverAgentInput({
                 agent_id: args.agent,
                 text: args.command!,
@@ -18065,10 +18081,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   { agent_id: args.agent },
                   { lines: 20 },
                 );
-                const submittedCommand = args.command!.trim();
                 const screenLines = screen.text
                   .split("\n")
                   .map((line) => line.trim());
+                const commandEchoCountAfter = screenLines.filter(
+                  isSubmittedCommandEcho,
+                ).length;
                 let commandLineIndex = -1;
                 for (let index = screenLines.length - 1; index >= 0; index -= 1) {
                   if (
@@ -18084,6 +18102,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     .slice(commandLineIndex + 1)
                     .filter(
                       (line) =>
+                        commandEchoCountBefore !== null &&
+                        commandEchoCountAfter > commandEchoCountBefore &&
                         commandLineIndex >= 0 &&
                         (!isComposerFooterOrChromeLine(line) ||
                           /^CLAUDE_COUNTER:/i.test(line)) &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -1375,15 +1375,18 @@ class BootPromptDeliveryError extends Error {
 
 class BootPromptUpdateMenuBlockedError extends Error {
   readonly error_code = "blocked_by_update_menu";
-  readonly recovery =
-    "Codex kept showing the interactive update menu after cmuxlayer accepted the default 'Update now' option. Rerun the spawn; the bounded updater guard prevents an infinite loop.";
+  readonly recovery: string;
 
   constructor(
     message: string,
     readonly last_10_lines: string[],
+    surface: string,
   ) {
     super(message);
     this.name = "BootPromptUpdateMenuBlockedError";
+    this.recovery =
+      `First resolve the update menu on ${surface}; cmuxlayer deliberately did not press Return. ` +
+      "Then deliver or resume the boot prompt on that same surface instead of rerunning the spawn.";
   }
 }
 
@@ -6480,6 +6483,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           throw new BootPromptUpdateMenuBlockedError(
             `Boot prompt delivery blocked by Codex update menu on ${target.surface}; cmuxlayer will not press Return before the prompt is typed`,
             tailLines(lastText, 10),
+            target.surface,
           );
         }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8552,6 +8552,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         screen_agent_type: parsed?.parsed.agent_type ?? null,
         screen_control_state: parsed?.parsed.control_state ?? null,
         screen_actions: parsed?.parsed.actions ?? null,
+        screen_errors: parsed?.parsed.errors ?? null,
       },
       live: resolveLiveAgentState(
         agent,
@@ -8560,6 +8561,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               status: parsed.parsed.status,
               agent_type: parsed.parsed.agent_type,
               control_state: parsed.parsed.control_state,
+              errors: parsed.parsed.errors,
             }
           : null,
       ),
@@ -12035,6 +12037,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       parsed_status?: string | null;
       control_state?: string | null;
       cli?: string | null;
+      errors?: string[] | null;
       read_error?: unknown;
     };
     // Same binding rule list_agents uses: a UUID pair, or a surface_id match
@@ -12065,12 +12068,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       status: string | null;
       agent_type: string | null;
       control_state: string | null;
+      errors: string[] | null;
     } | null => {
       if (!row || row.read_error) return null;
       return {
         status: row.parsed_status ?? null,
         agent_type: row.cli === "kiro" ? "unknown" : (row.cli ?? null),
         control_state: row.control_state ?? null,
+        errors: row.errors ?? null,
       };
     };
     const screenObservationForRecord = (
@@ -12079,6 +12084,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       status: string | null;
       agent_type: string | null;
       control_state: string | null;
+      errors: string[] | null;
     } | null => {
       const cached = discovery.cachedScan();
       if (!cached) return null;
@@ -12961,6 +12967,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               agent_type:
                 freshOccupant.cli === "kiro" ? "unknown" : freshOccupant.cli,
               control_state: freshOccupant.control_state,
+              errors: freshOccupant.errors ?? null,
             }
           : null,
       );
@@ -16219,6 +16226,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                             ? "unknown"
                             : trustedScreenObservation.cli,
                         control_state: trustedScreenObservation.control_state,
+                        errors: trustedScreenObservation.errors ?? null,
                       }
                     : null,
                 );
@@ -16240,6 +16248,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                             trustedScreenObservation.control_state,
                           screen_actions:
                             trustedScreenObservation.actions ?? [],
+                          screen_errors:
+                            trustedScreenObservation.errors ?? [],
                         }
                       : {}),
                     // Without this the health block re-derived harvestability

--- a/src/server.ts
+++ b/src/server.ts
@@ -222,7 +222,6 @@ import type {
 import { isSubmitKey, normalizeKeyName } from "./key-names.js";
 import { assertCanonicalSurfaceRef } from "./surface-ref.js";
 import {
-  callerContextFromEnv,
   currentCallerContext,
   type CallerContext,
 } from "./caller-context.js";
@@ -8999,9 +8998,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             health: healthWithStale,
           });
         }
-        const callerSurface =
-          currentCallerContext()?.surfaceId?.trim() ??
-          callerContextFromEnv()?.surfaceId?.trim();
+        const callerSurface = currentCallerContext()?.surfaceId?.trim();
         const caller =
           resolveCurrentCallerAgent() ??
           (callerSurface

--- a/src/server.ts
+++ b/src/server.ts
@@ -9002,19 +9002,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             health: healthWithStale,
           });
         }
-        const callerSurface = currentCallerContext()?.surfaceId?.trim();
-        const caller =
-          resolveCurrentCallerAgent() ??
-          (callerSurface
-            ? stateMgr
-                .listStates()
-                .find(
-                  (agent) =>
-                    agent.surface_id === callerSurface ||
-                    agent.surface_uuid?.toLowerCase() ===
-                      callerSurface.toLowerCase(),
-                ) ?? null
-            : null);
+        const caller = resolveCurrentCallerAgent();
         const callerOwners = new Set(
           [caller?.agent_id, caller?.seat_id].filter(
             (value): value is string => Boolean(value),

--- a/src/server.ts
+++ b/src/server.ts
@@ -8589,7 +8589,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       (overrides?.screen_status === undefined ||
         overrides?.screen_agent_type === undefined ||
         overrides?.screen_control_state === undefined ||
-        overrides?.screen_actions === undefined)
+        overrides?.screen_actions === undefined ||
+        overrides?.screen_errors === undefined)
     ) {
       parsedSurface = await readParsedSurface(
         binding.surfaceRef,
@@ -8627,6 +8628,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : binding
             ? (parsedSurface?.parsed.actions ?? null)
             : null,
+      screen_errors:
+        overrides?.screen_errors !== undefined
+          ? overrides.screen_errors
+          : binding
+            ? (parsedSurface?.parsed.errors ?? null)
+            : null,
       surface_write_liveness: binding
         ? surfaceWriteLiveness.observe(
             binding.surfaceRef,
@@ -8643,6 +8650,22 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         dispatchAckTimeoutMs: AGENT_HEALTH_DISPATCH_ACK_TIMEOUT_MS,
         assessHarvestability: (target) =>
           lifecycleHealthEngine?.assessHarvestability(target),
+        readParsedSurface: async (target) => {
+          const targetBinding = resolveAuthorizedAgentSurfaceBinding(
+            target,
+            topology,
+          );
+          if (!targetBinding) return null;
+          const observation =
+            target.agent_id === agent.agent_id && parsedSurface
+              ? parsedSurface
+              : await readParsedSurface(
+                  targetBinding.surfaceRef,
+                  targetBinding.workspaceId ?? undefined,
+                  { agent: target },
+                );
+          return observation?.parsed ?? null;
+        },
         resolveCollapsedMonitors: (ownerSeats) => {
           if (!opts?.monitorRegistryPath) return [];
           const owners = new Set(ownerSeats);
@@ -18046,22 +18069,31 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 press_enter: true,
                 source_event: "interact",
               });
-              const route = await engine.resolveAgentIoRoute(args.agent);
-              const screen = await client.readScreen(route.surface_id, {
-                workspace: route.workspace_id ?? undefined,
-                lines: 20,
-              });
-              const screenResultLine = screen.text
-                .split("\n")
-                .map((line) => line.trim())
-                .filter(Boolean)
-                .at(-1) ?? null;
+              let screenResultLine: string | null = null;
+              let screenResultAvailable = false;
+              try {
+                const screen = await engine.readAgentScreen(
+                  { agent_id: args.agent },
+                  { lines: 20 },
+                );
+                screenResultLine =
+                  screen.text
+                    .split("\n")
+                    .map((line) => line.trim())
+                    .filter(Boolean)
+                    .at(-1) ?? null;
+                screenResultAvailable = true;
+              } catch {
+                // Submission already succeeded. Observation loss must not invite
+                // a retry that could execute the skill twice.
+              }
               const d = {
                 agent_id: args.agent,
                 action: "skill",
                 command: args.command,
                 retry_count: delivery.retry_count,
                 submit_verified: delivery.submit_verified,
+                screen_result_available: screenResultAvailable,
                 screen_result_line: screenResultLine,
               };
               return okFormatted(formatOk("interact:skill", d), d);

--- a/src/server.ts
+++ b/src/server.ts
@@ -18073,13 +18073,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   { agent_id: args.agent },
                   { lines: 20 },
                 );
+                const submittedCommand = args.command!.trim();
                 screenResultLine =
                   screen.text
                     .split("\n")
                     .map((line) => line.trim())
-                    .filter(Boolean)
+                    .filter(
+                      (line) =>
+                        (!isComposerFooterOrChromeLine(line) ||
+                          /^CLAUDE_COUNTER:/i.test(line)) &&
+                        !/^Claude Code(?:\s+v?\d|$)/i.test(line) &&
+                        !/^[>❯›]\s*$/.test(line) &&
+                        line.replace(/^[>❯›]\s*/, "") !== submittedCommand,
+                    )
                     .at(-1) ?? null;
-                screenResultAvailable = true;
+                screenResultAvailable = screenResultLine !== null;
               } catch {
                 // Submission already succeeded. Observation loss must not invite
                 // a retry that could execute the skill twice.

--- a/src/server.ts
+++ b/src/server.ts
@@ -18060,6 +18060,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                 /^(?:[•✻✢✳✶✦]\s*(?:Thinking|Working)|[⏺⬡]\s*Running)(?:\b|…)/iu.test(
                   line,
                 );
+              const isComposerInputLine = (line: string): boolean =>
+                /^[>❯›]\s*\S/u.test(line);
               let commandEchoCountBefore: number | null = null;
               try {
                 const beforeScreen = await engine.readAgentScreen(
@@ -18111,6 +18113,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                         commandEchoCountAfter > commandEchoCountBefore &&
                         commandLineIndex >= 0 &&
                         !isActiveSkillProgressLine(line) &&
+                        !isComposerInputLine(line) &&
                         (!isComposerFooterOrChromeLine(line) ||
                           /^CLAUDE_COUNTER:/i.test(line)) &&
                         !/^Claude Code(?:\s+v?\d|$)/i.test(line) &&

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,6 +109,7 @@ import {
   isLiveDeliverable,
   isLiveTerminal,
   resolveLiveAgentState,
+  screenConfirmedAgentState,
   TERMINAL_AGENT_STATES,
   type LiveAgentState,
 } from "./live-agent-state.js";
@@ -3394,6 +3395,7 @@ export function reconcileAgentLiveState(
   registryState: AgentState,
   screen: ParsedScreenResult | null,
 ): AgentState {
+  if (screenConfirmedAgentState(screen) === "error") return "error";
   // Only a REAL agent screen can clear an error. parseScreen reports status:"idle" for a
   // plain shell prompt (agent_type:"unknown"), so a crashed agent fallen back to a shell must
   // keep its registry error instead of being masked as healthy idle.

--- a/src/surface-ref.ts
+++ b/src/surface-ref.ts
@@ -1,0 +1,9 @@
+const BARE_SURFACE_INDEX_RE = /^\d+$/;
+
+export function assertCanonicalSurfaceRef(value: string): void {
+  if (BARE_SURFACE_INDEX_RE.test(value.trim())) {
+    throw new Error(
+      `bare surface index ${JSON.stringify(value)} is not allowed; use surface:<index> ref or a surface UUID`,
+    );
+  }
+}

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9806,6 +9806,44 @@ Session ID: ${sessionId}`,
       expect(updated.halt_notification_sent_at).toEqual(expect.any(String));
     });
 
+    it("lets a live harness API error outrank recorded done evidence", async () => {
+      const parent = makeRecord({
+        agent_id: "api-stale-done-parent",
+        surface_id: "surface:api-stale-done-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const child = makeRecord({
+        agent_id: "api-stale-done-child",
+        surface_id: "surface:api-stale-done-child",
+        state: "working",
+        role: "worker",
+        cli: "claude",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+        task_done_detected_at: new Date().toISOString(),
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      await (engine as any).maybeEscalateLiveHalt(
+        child,
+        'Claude Code\nAPI Error: 500 {"request_id":"req_after_done"}\n❯',
+      );
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).toContain(
+        "req_after_done",
+      );
+    });
+
     it("persists prompt blockage even when escalation is opted out and clears it from healthy screen truth", async () => {
       const nowMs = Date.parse("2026-08-14T13:00:00.000Z");
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9621,6 +9621,64 @@ Session ID: ${sessionId}`,
       );
     });
 
+    it("wakes the parent immediately when a child transitions into a harness API error", async () => {
+      const nowMs = Date.parse("2026-08-27T07:05:00.000Z");
+      engine.dispose();
+      engine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          inboxOpts: { baseDir: TEST_DIR },
+          haltNow: () => nowMs,
+        },
+      );
+      const parent = makeRecord({
+        agent_id: "api-transition-parent",
+        surface_id: "surface:api-transition-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const child = makeRecord({
+        agent_id: "api-transition-child",
+        surface_id: "surface:api-transition-child",
+        state: "working",
+        role: "worker",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+        halt_episode_type: "permission_prompt",
+        halt_episode_started_at: new Date(nowMs - 1_000).toISOString(),
+        halt_episode_observations: 1,
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      liveSurfaces = [parent, child].map((record) =>
+        makeSurface(record.surface_id),
+      );
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      await (engine as any).maybeEscalateLiveHalt(
+        child,
+        'Claude Code\nAPI Error: 500 {"request_id":"req_run9_transition"}\n❯',
+      );
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })).toEqual([
+        expect.objectContaining({
+          tag: "agent_halt_harness_api_error",
+          task: expect.stringContaining("req_run9_transition"),
+        }),
+      ]);
+    });
+
     it("persists prompt blockage even when escalation is opted out and clears it from healthy screen truth", async () => {
       const nowMs = Date.parse("2026-08-14T13:00:00.000Z");
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9742,6 +9742,70 @@ Session ID: ${sessionId}`,
       );
     });
 
+    it("starts a new halt episode when the harness request id changes", async () => {
+      const nowMs = Date.parse("2026-08-27T07:07:00.000Z");
+      engine.dispose();
+      engine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          inboxOpts: { baseDir: TEST_DIR },
+          haltNow: () => nowMs,
+        },
+      );
+      const parent = makeRecord({
+        agent_id: "api-new-request-parent",
+        surface_id: "surface:api-new-request-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const oldStartedAt = new Date(nowMs - 1_000).toISOString();
+      const child = makeRecord({
+        agent_id: "api-new-request-child",
+        surface_id: "surface:api-new-request-child",
+        state: "working",
+        role: "worker",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+        halt_episode_type: "harness_api_error",
+        halt_episode_started_at: oldStartedAt,
+        halt_episode_observations: 1,
+        halt_notification_sent_at: new Date(nowMs - 500).toISOString(),
+        halt_notified_ancestor_id: parent.agent_id,
+        halt_last_observable_action:
+          "harness_api_error: first request_id=req_first",
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      liveSurfaces = [parent, child].map((record) =>
+        makeSurface(record.surface_id),
+      );
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      const updated = await (engine as any).maybeEscalateLiveHalt(
+        child,
+        'Claude Code\nAPI Error: 500 {"request_id":"req_second"}\n❯',
+      );
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).toContain(
+        "req_second",
+      );
+      expect(updated.halt_episode_started_at).toBe(
+        new Date(nowMs).toISOString(),
+      );
+      expect(updated.halt_notification_sent_at).toEqual(expect.any(String));
+    });
+
     it("persists prompt blockage even when escalation is opted out and clears it from healthy screen truth", async () => {
       const nowMs = Date.parse("2026-08-14T13:00:00.000Z");
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9564,6 +9564,63 @@ Session ID: ${sessionId}`,
   });
 
   describe("halt escalation", () => {
+    it("wakes the parent immediately when a harness API error freezes a child", async () => {
+      const nowMs = Date.parse("2026-08-27T07:00:00.000Z");
+      engine.dispose();
+      engine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          inboxOpts: { baseDir: TEST_DIR },
+          haltNow: () => nowMs,
+        },
+      );
+      const parent = makeRecord({
+        agent_id: "api-error-parent",
+        surface_id: "surface:api-error-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const child = makeRecord({
+        agent_id: "api-error-child",
+        surface_id: "surface:api-error-child",
+        state: "working",
+        role: "worker",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      liveSurfaces = [parent, child].map((record) =>
+        makeSurface(record.surface_id),
+      );
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      const apiError =
+        'Claude Code\nAPI Error: 500 {"request_id":"req_run9_api_error"}\n❯';
+      await (engine as any).maybeEscalateLiveHalt(child, apiError);
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })).toEqual([
+        expect.objectContaining({
+          tag: "agent_halt_harness_api_error",
+          task: expect.stringContaining("harness_api_error"),
+        }),
+      ]);
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).toContain(
+        "req_run9_api_error",
+      );
+    });
+
     it("persists prompt blockage even when escalation is opted out and clears it from healthy screen truth", async () => {
       const nowMs = Date.parse("2026-08-14T13:00:00.000Z");
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9806,6 +9806,66 @@ Session ID: ${sessionId}`,
       expect(updated.halt_notification_sent_at).toEqual(expect.any(String));
     });
 
+    it("does not restart a notified halt episode when the same request reflows", async () => {
+      const nowMs = Date.parse("2026-08-27T07:08:00.000Z");
+      engine.dispose();
+      engine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          inboxOpts: { baseDir: TEST_DIR },
+          haltNow: () => nowMs,
+        },
+      );
+      const parent = makeRecord({
+        agent_id: "api-reflow-parent",
+        surface_id: "surface:api-reflow-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const oldStartedAt = new Date(nowMs - 1_000).toISOString();
+      const child = makeRecord({
+        agent_id: "api-reflow-child",
+        surface_id: "surface:api-reflow-child",
+        state: "working",
+        role: "worker",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+        halt_episode_type: "harness_api_error",
+        halt_episode_started_at: oldStartedAt,
+        halt_episode_observations: 1,
+        halt_notification_sent_at: new Date(nowMs - 500).toISOString(),
+        halt_notified_ancestor_id: parent.agent_id,
+        halt_last_observable_action:
+          "harness_api_error: narrow summary request_id=req_same",
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      liveSurfaces = [parent, child].map((record) =>
+        makeSurface(record.surface_id),
+      );
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      const updated = await (engine as any).maybeEscalateLiveHalt(
+        child,
+        'Claude Code\nAPI Error: wider reflowed summary {"request_id":"req_same"}\n❯',
+      );
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })).toEqual([]);
+      expect(updated.halt_episode_started_at).toBe(oldStartedAt);
+      expect(updated.halt_last_observable_action).toContain("wider reflowed");
+    });
+
     it("lets a live harness API error outrank recorded done evidence", async () => {
       const parent = makeRecord({
         agent_id: "api-stale-done-parent",

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9682,6 +9682,66 @@ Session ID: ${sessionId}`,
       ]);
     });
 
+    it("refreshes the request id before retrying a harness API error notification", async () => {
+      const nowMs = Date.parse("2026-08-27T07:06:00.000Z");
+      engine.dispose();
+      engine = new AgentEngine(
+        stateMgr,
+        new AgentRegistry(stateMgr, async () => liveSurfaces),
+        mockClient,
+        {
+          spawnPreflight: async () => {},
+          sessionIdentityResolver: () => null,
+          inboxOpts: { baseDir: TEST_DIR },
+          haltNow: () => nowMs,
+        },
+      );
+      const parent = makeRecord({
+        agent_id: "api-refresh-parent",
+        surface_id: "surface:api-refresh-parent",
+        state: "working",
+        role: "orchestrator",
+      });
+      const child = makeRecord({
+        agent_id: "api-refresh-child",
+        surface_id: "surface:api-refresh-child",
+        state: "working",
+        role: "worker",
+        parent_agent_id: parent.agent_id,
+        spawn_depth: 1,
+        halt_escalation: true,
+        halt_episode_type: "harness_api_error",
+        halt_episode_started_at: new Date(nowMs - 1_000).toISOString(),
+        halt_episode_observations: 1,
+        halt_last_observable_action:
+          "harness_api_error: stale request_id=req_stale",
+      });
+      stateMgr.writeState(parent);
+      stateMgr.writeState(child);
+      liveSurfaces = [parent, child].map((record) =>
+        makeSurface(record.surface_id),
+      );
+      await engine.getRegistry().reconstitute();
+      (mockClient.readScreen as ReturnType<typeof vi.fn>).mockResolvedValue({
+        surface: parent.surface_id,
+        text: "Claude Code\nWorking (2s • esc to interrupt)",
+        lines: 80,
+        scrollback_used: false,
+      });
+
+      await (engine as any).maybeEscalateLiveHalt(
+        child,
+        'Claude Code\nAPI Error: 500 {"request_id":"req_current"}\n❯',
+      );
+
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).toContain(
+        "req_current",
+      );
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).not.toContain(
+        "req_stale",
+      );
+    });
+
     it("persists prompt blockage even when escalation is opted out and clears it from healthy screen truth", async () => {
       const nowMs = Date.parse("2026-08-14T13:00:00.000Z");
       engine.dispose();

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -9607,7 +9607,7 @@ Session ID: ${sessionId}`,
       });
 
       const apiError =
-        'Claude Code\nAPI Error: 500 {"request_id":"req_run9_api_error"}\n❯';
+        '⏺ Reading stale-work.ts\nClaude Code\nAPI Error: 500 {"request_id":"req_run9_api_error"}\n❯';
       await (engine as any).maybeEscalateLiveHalt(child, apiError);
 
       expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })).toEqual([
@@ -9618,6 +9618,9 @@ Session ID: ${sessionId}`,
       ]);
       expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).toContain(
         "req_run9_api_error",
+      );
+      expect(readInbox(parent.agent_id, { baseDir: TEST_DIR })[0]?.task).not.toContain(
+        "Reading stale-work.ts",
       );
     });
 

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -43,6 +43,23 @@ function makeRecord(overrides?: Partial<AgentRecord>): AgentRecord {
 }
 
 describe("agent lifecycle health", () => {
+  it("degrades a pane whose latest turn ended on a harness API error", () => {
+    const health = evaluateAgentHealth(makeRecord(), {
+      screen_status: "frozen",
+      screen_agent_type: "claude",
+      screen_control_state: "unknown",
+      screen_errors: [
+        "harness_api_error: Fable 5 safeguards flagged this message request_id=req_011CeRnwgFeHAsTb3hU4n9jt",
+      ],
+    });
+
+    expect(health.status).not.toBe("healthy");
+    expect(health.issue_codes).toContain("harness_api_error");
+    expect(health.issues.join(" ")).toContain(
+      "req_011CeRnwgFeHAsTb3hU4n9jt",
+    );
+  });
+
   it("marks an owner unhealthy when its registered monitor collapsed", () => {
     const health = evaluateAgentHealth(makeRecord(), {
       monitor_alive: true,

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -38,6 +38,21 @@ describe("surface reference validation", () => {
     );
     expect(exec).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["before", () => ({ before: "45" })],
+    ["after", () => ({ after: "45" })],
+  ])("rejects a bare %s surface index before invoking the CLI", async (_name, placement) => {
+    const { client, exec } = mockClient({});
+    await expect(
+      client.moveSurface({
+        surface: "surface:9",
+        workspace: "workspace:2",
+        ...placement(),
+      }),
+    ).rejects.toThrow(/use surface:<index> ref or a surface UUID/);
+    expect(exec).not.toHaveBeenCalled();
+  });
 });
 
 describe("CmuxClient.listWorkspaces", () => {

--- a/tests/cmux-client.test.ts
+++ b/tests/cmux-client.test.ts
@@ -30,6 +30,16 @@ function mockClient(response: object | string) {
   return { client, exec };
 }
 
+describe("surface reference validation", () => {
+  it("rejects a bare surface index before invoking the CLI", async () => {
+    const { client, exec } = mockClient({});
+    await expect(client.send("45", "hello")).rejects.toThrow(
+      /use surface:<index> ref or a surface UUID/,
+    );
+    expect(exec).not.toHaveBeenCalled();
+  });
+});
+
 describe("CmuxClient.listWorkspaces", () => {
   it("calls cmux --json list-workspaces", async () => {
     const data = {

--- a/tests/cmux-socket-client.test.ts
+++ b/tests/cmux-socket-client.test.ts
@@ -1231,6 +1231,15 @@ describe.skipIf(!CAN_BIND_MOCK_SOCKET)("CmuxSocketClient", () => {
     }
   });
 
+  it("rejects a bare numeric notify surface before V1 serialization", async () => {
+    const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
+
+    await expect(
+      client.notify({ title: "Wrong target", surface: "45" }),
+    ).rejects.toThrow(/bare surface index/);
+    expect(lastV1Command).toBe("");
+  });
+
   it("renameTab sends V2 tab.action with rename params", async () => {
     const client = new CmuxSocketClient({ socketPath: MOCK_SOCKET_PATH });
 

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -776,6 +776,18 @@ describe("control health", () => {
       model: "codex",
       cli: "codex",
     } as any);
+    stateMgr.writeState({
+      agent_id: "stale-recycled-agent",
+      seat_id: "stale-recycled-seat",
+      surface_id: "surface:recycled",
+      surface_uuid: null,
+      surface_observer_id: null,
+      workspace_id: "workspace:1",
+      state: "done",
+      repo: "cmuxlayer",
+      model: "codex",
+      cli: "codex",
+    } as any);
     const watch = (watch_id: string, owner: string, state: string) => ({
       watch_id,
       owner,
@@ -797,6 +809,7 @@ describe("control health", () => {
           watch("mine-live", "caller-agent", "armed"),
           watch("mine-dropped", "caller-seat", "fired"),
           watch("foreign-live", "another-agent", "armed"),
+          watch("stale-live", "stale-recycled-agent", "armed"),
         ],
       }),
     );
@@ -820,6 +833,10 @@ describe("control health", () => {
       () => tool.handler({}, {} as any),
     );
     const unscopedTerse = await tool.handler({}, {} as any);
+    const recycledRefTerse = await runWithCallerContext(
+      { surfaceId: "surface:recycled" },
+      () => tool.handler({}, {} as any),
+    );
     const full = await tool.handler({ detail: "full" }, {} as any);
     if (previousCallerSurface === undefined) delete process.env.CMUX_SURFACE_ID;
     else process.env.CMUX_SURFACE_ID = previousCallerSurface;
@@ -834,6 +851,9 @@ describe("control health", () => {
       count: 0,
       watches: [],
     });
+    expect(
+      recycledRefTerse.structuredContent.health.caller_live_watches,
+    ).toEqual({ count: 0, watches: [] });
     expect(terse.content[0].text.length).toBeLessThan(full.content[0].text.length);
     await server.close();
   });

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -819,6 +819,7 @@ describe("control health", () => {
       { surfaceId: "11111111-2222-4333-8444-555555555555" },
       () => tool.handler({}, {} as any),
     );
+    const unscopedTerse = await tool.handler({}, {} as any);
     const full = await tool.handler({ detail: "full" }, {} as any);
     if (previousCallerSurface === undefined) delete process.env.CMUX_SURFACE_ID;
     else process.env.CMUX_SURFACE_ID = previousCallerSurface;
@@ -828,6 +829,10 @@ describe("control health", () => {
       watches: [
         { watch_id: "mine-live", target: "/reports/mine-live.md", state: "armed" },
       ],
+    });
+    expect(unscopedTerse.structuredContent.health.caller_live_watches).toEqual({
+      count: 0,
+      watches: [],
     });
     expect(terse.content[0].text.length).toBeLessThan(full.content[0].text.length);
     await server.close();

--- a/tests/control-health.test.ts
+++ b/tests/control-health.test.ts
@@ -19,6 +19,7 @@ import { AgentEngine } from "../src/agent-engine.js";
 import { AgentRegistry } from "../src/agent-registry.js";
 import { StateManager } from "../src/state-manager.js";
 import { SurfaceWriteLivenessTracker } from "../src/surface-write-liveness.js";
+import { runWithCallerContext } from "../src/caller-context.js";
 
 const TEST_ROOT = join(tmpdir(), "cmuxlayer-control-health-test");
 const ACCESS_CONTROL_DENIED_TEXT =
@@ -605,13 +606,13 @@ describe("control health", () => {
         { surface: "surface:untracked", key: "return" },
         {} as any,
       );
-      const first = await controlHealth.handler({}, {} as any);
+      const first = await controlHealth.handler({ detail: "full" }, {} as any);
       nowMs += 1_000;
       await sendKey.handler(
         { surface: "surface:untracked", key: "return" },
         {} as any,
       );
-      const second = await controlHealth.handler({}, {} as any);
+      const second = await controlHealth.handler({ detail: "full" }, {} as any);
       const firstHealth =
         first.structuredContent.health.self_heal.pane_pty_dead;
       const secondHealth =
@@ -635,7 +636,10 @@ describe("control health", () => {
         { surface: "surface:untracked", key: "return" },
         {} as any,
       );
-      const afterNonPtyFailure = await controlHealth.handler({}, {} as any);
+      const afterNonPtyFailure = await controlHealth.handler(
+        { detail: "full" },
+        {} as any,
+      );
       expect(
         afterNonPtyFailure.structuredContent.health.self_heal.pane_pty_dead,
       ).toMatchObject({
@@ -658,7 +662,10 @@ describe("control health", () => {
         { surface: "surface:untracked", key: "return" },
         {} as any,
       );
-      const nextEpisode = await controlHealth.handler({}, {} as any);
+      const nextEpisode = await controlHealth.handler(
+        { detail: "full" },
+        {} as any,
+      );
       expect(
         nextEpisode.structuredContent.health.self_heal.pane_pty_dead.surfaces[0]
           .since_at,
@@ -719,7 +726,7 @@ describe("control health", () => {
     });
     const tool = (server as any)._registeredTools["control_health"];
 
-    const result = await tool.handler({}, {} as any);
+    const result = await tool.handler({ detail: "full" }, {} as any);
 
     const parsed =
       result.structuredContent ?? JSON.parse(result.content[0].text);
@@ -745,6 +752,85 @@ describe("control health", () => {
     expect(lines[0].snapshot.cmux_instances.nightly.socket_path).toBe(
       nightlySocket,
     );
+  });
+
+  it("defaults to terse health and lists only the caller's live watches", async () => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(TEST_ROOT, { recursive: true });
+    const watchRegistryPath = join(TEST_ROOT, "watch-specs.json");
+    const rawHealth = await collectControlHealth({
+      homeDir: join(TEST_ROOT, "home-terse"),
+      tmpDir: join(TEST_ROOT, "tmp-terse"),
+      env: { PATH: "" },
+      execFile: async () => ({ stdout: "" }),
+    });
+    const stateMgr = new StateManager(TEST_ROOT);
+    stateMgr.writeState({
+      agent_id: "caller-agent",
+      seat_id: "caller-seat",
+      surface_id: "surface:caller",
+      surface_uuid: "11111111-2222-4333-8444-555555555555",
+      workspace_id: "workspace:1",
+      state: "working",
+      repo: "cmuxlayer",
+      model: "codex",
+      cli: "codex",
+    } as any);
+    const watch = (watch_id: string, owner: string, state: string) => ({
+      watch_id,
+      owner,
+      target: `/reports/${watch_id}.md`,
+      target_kind: "file",
+      marker: "TASK_DONE",
+      deadline: Date.now() + 60_000,
+      armed_at_ms: Date.now(),
+      last_heartbeat_at_ms: Date.now(),
+      liveness_source: "test",
+      liveness: { value: true, source: "process", observed_at_ms: Date.now() },
+      state,
+    });
+    writeFileSync(
+      watchRegistryPath,
+      JSON.stringify({
+        version: 1,
+        watches: [
+          watch("mine-live", "caller-agent", "armed"),
+          watch("mine-dropped", "caller-seat", "fired"),
+          watch("foreign-live", "another-agent", "armed"),
+        ],
+      }),
+    );
+    const context = createServerContext({ stateDir: TEST_ROOT });
+    const server = createServer({
+      context,
+      watchRegistryPath,
+      skipAgentLifecycle: true,
+      controlHealthCollector: async () => rawHealth,
+    });
+    const tool = (server as any)._registeredTools.control_health;
+    expect(new StateManager(context.stateDir).listStates()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ agent_id: "caller-agent" }),
+      ]),
+    );
+    const previousCallerSurface = process.env.CMUX_SURFACE_ID;
+    process.env.CMUX_SURFACE_ID = "11111111-2222-4333-8444-555555555555";
+    const terse = await runWithCallerContext(
+      { surfaceId: "11111111-2222-4333-8444-555555555555" },
+      () => tool.handler({}, {} as any),
+    );
+    const full = await tool.handler({ detail: "full" }, {} as any);
+    if (previousCallerSurface === undefined) delete process.env.CMUX_SURFACE_ID;
+    else process.env.CMUX_SURFACE_ID = previousCallerSurface;
+
+    expect(terse.structuredContent.health.caller_live_watches).toEqual({
+      count: 1,
+      watches: [
+        { watch_id: "mine-live", target: "/reports/mine-live.md", state: "armed" },
+      ],
+    });
+    expect(terse.content[0].text.length).toBeLessThan(full.content[0].text.length);
+    await server.close();
   });
 
   it("control_health surfaces daemon fallback warnings", async () => {

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -277,6 +277,51 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     context.dispose();
   });
 
+  it("interact skill keeps the successful receipt when only its final observation fails", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n❯ ";
+    let failFinalObservation = false;
+    const baseExec = makeLifecycleExec(() => screenText);
+    const mockExec: ExecFn = vi.fn().mockImplementation(
+      async (command: string, args: string[]) => {
+        if (
+          failFinalObservation &&
+          args.includes("read-screen") &&
+          args.includes("--lines") &&
+          args.includes("20")
+        ) {
+          throw new Error("surface disappeared after submitted skill");
+        }
+        return baseExec(command, args);
+      },
+    );
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    screenText = "Claude Code\n> \nCLAUDE_COUNTER:1\n";
+    failFinalObservation = true;
+
+    const result = await (server as any)._registeredTools.interact.handler(
+      { agent: agentId, action: "skill", command: "/review" },
+      {} as any,
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(parseToolResult(result)).toMatchObject({
+      ok: true,
+      submit_verified: true,
+      screen_result_available: false,
+      screen_result_line: null,
+    });
+    expect(mutatedPane(mockExec)).toBe(true);
+    context.dispose();
+  });
+
   it("send_to delivers through a rotating Codex placeholder", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText =

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -277,6 +277,54 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     context.dispose();
   });
 
+  it("interact skill does not report terminal chrome as a screen result", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n❯ ";
+    const baseExec = makeLifecycleExec(() => screenText);
+    const mockExec: ExecFn = vi.fn().mockImplementation(
+      async (command: string, args: string[]) => {
+        if (
+          args.includes("read-screen") &&
+          args.includes("--lines") &&
+          args.includes("20")
+        ) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "Claude Code\n❯ /review\n⏵⏵ bypass permissions on · 2 monitors\n",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(command, args);
+      },
+    );
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    screenText = "Claude Code\n❯ \nCLAUDE_COUNTER:1\n";
+
+    const result = await (server as any)._registeredTools.interact.handler(
+      { agent: agentId, action: "skill", command: "/review" },
+      {} as any,
+    );
+
+    expect(parseToolResult(result)).toMatchObject({
+      ok: true,
+      submit_verified: true,
+      screen_result_available: false,
+      screen_result_line: null,
+    });
+    context.dispose();
+  });
+
   it("interact skill keeps the successful receipt when only its final observation fails", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n❯ ";

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -180,7 +180,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
       {} as any,
     );
 
@@ -215,11 +215,64 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
       {} as any,
     );
 
     expect(parseToolResult(result).ok).toBe(true);
+    expect(mutatedPane(mockExec)).toBe(true);
+    context.dispose();
+  });
+
+  it("interact skill refuses a non-empty composer and names its contents", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n❯ ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    screenText = "Claude Code\n❯ keep this human draft\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools.interact.handler(
+      { agent: agentId, action: "skill", command: "/review" },
+      {} as any,
+    );
+    expect(result.isError).toBe(true);
+    expect(parseToolResult(result).error).toContain("keep this human draft");
+    expect(mutatedPane(mockExec)).toBe(false);
+    context.dispose();
+  });
+
+  it("interact skill submits from an empty composer and receipts the screen result", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n❯ ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    screenText = "Claude Code\n❯ \nCLAUDE_COUNTER:1\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools.interact.handler(
+      { agent: agentId, action: "skill", command: "/review" },
+      {} as any,
+    );
+    expect(parseToolResult(result)).toMatchObject({
+      ok: true,
+      submit_verified: true,
+      screen_result_line: "CLAUDE_COUNTER:1",
+    });
     expect(mutatedPane(mockExec)).toBe(true);
     context.dispose();
   });
@@ -245,7 +298,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
       {} as any,
     );
 
@@ -279,7 +332,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
       {} as any,
     );
 
@@ -373,7 +426,7 @@ describe("T2 delivery truth — draft guard must not fire on chrome (B1)", () =>
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
       {} as any,
     );
 
@@ -412,7 +465,7 @@ describe("T2 delivery truth — a blocked composer is a terminal refusal (B1a)",
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { agent_id: agentId, text: "second message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "second message", press_enter: true },
       {} as any,
     );
 

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -252,7 +252,27 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
   it("interact skill submits from an empty composer and receipts the screen result", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n❯ ";
-    const mockExec = makeLifecycleExec(() => screenText);
+    const baseExec = makeLifecycleExec(() => screenText);
+    const mockExec: ExecFn = vi.fn().mockImplementation(
+      async (command: string, args: string[]) => {
+        if (
+          args.includes("read-screen") &&
+          args.includes("--lines") &&
+          args.includes("20")
+        ) {
+          return {
+            stdout: JSON.stringify({
+              surface: "surface:new",
+              text: "Claude Code\n❯ /review\nCLAUDE_COUNTER:1\n",
+              lines: 20,
+              scrollback_used: false,
+            }),
+            stderr: "",
+          };
+        }
+        return baseExec(command, args);
+      },
+    );
     const context = createServerContext({
       exec: mockExec,
       stateDir: testDir,
@@ -291,7 +311,8 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
           return {
             stdout: JSON.stringify({
               surface: "surface:new",
-              text: "Claude Code\n❯ /review\n⏵⏵ bypass permissions on · 2 monitors\n",
+              text:
+                "Claude Code\n⏺ Earlier unrelated answer\n❯ /review\n⏵⏵ bypass permissions on · 2 monitors\n",
               lines: 20,
               scrollback_used: false,
             }),

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -359,9 +359,14 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     context.dispose();
   });
 
-  it.each(["✻ Thinking…", "✻ Working…", "⏺ Running…"])(
-    "interact skill does not report active progress %s as a screen result",
-    async (activeProgressLine) => {
+  it.each([
+    "✻ Thinking…",
+    "✻ Working…",
+    "⏺ Running…",
+    "❯ investigate next issue",
+  ])(
+    "interact skill does not report non-result row %s as a screen result",
+    async (nonResultLine) => {
       const { createServer, createServerContext } = await loadServerModule();
       let screenText = "Claude Code\n❯ ";
       let submitted = false;
@@ -380,7 +385,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
             return {
               stdout: JSON.stringify({
                 surface: "surface:new",
-                text: `Claude Code\n❯ /review\n${activeProgressLine}\n`,
+                text: `Claude Code\n❯ /review\n${nonResultLine}\n`,
                 lines: 20,
                 scrollback_used: false,
               }),

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -252,10 +252,15 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
   it("interact skill submits from an empty composer and receipts the screen result", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n❯ ";
+    let submitted = false;
     const baseExec = makeLifecycleExec(() => screenText);
     const mockExec: ExecFn = vi.fn().mockImplementation(
       async (command: string, args: string[]) => {
+        if (args.includes("send-key") && args.includes("return")) {
+          submitted = true;
+        }
         if (
+          submitted &&
           args.includes("read-screen") &&
           args.includes("--lines") &&
           args.includes("20")
@@ -281,6 +286,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     });
     const server = createServer({ context });
     const agentId = await spawnReadyAgent(server);
+    submitted = false;
     screenText = "Claude Code\n❯ \nCLAUDE_COUNTER:1\n";
     mockExec.mockClear();
 
@@ -300,10 +306,15 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
   it("interact skill does not report terminal chrome as a screen result", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n❯ ";
+    let submitted = false;
     const baseExec = makeLifecycleExec(() => screenText);
     const mockExec: ExecFn = vi.fn().mockImplementation(
       async (command: string, args: string[]) => {
+        if (args.includes("send-key") && args.includes("return")) {
+          submitted = true;
+        }
         if (
+          submitted &&
           args.includes("read-screen") &&
           args.includes("--lines") &&
           args.includes("20")
@@ -330,7 +341,48 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     });
     const server = createServer({ context });
     const agentId = await spawnReadyAgent(server);
+    submitted = false;
     screenText = "Claude Code\n❯ \nCLAUDE_COUNTER:1\n";
+
+    const result = await (server as any)._registeredTools.interact.handler(
+      { agent: agentId, action: "skill", command: "/review" },
+      {} as any,
+    );
+
+    expect(parseToolResult(result)).toMatchObject({
+      ok: true,
+      submit_verified: true,
+      screen_result_available: false,
+      screen_result_line: null,
+    });
+    context.dispose();
+  });
+
+  it("interact skill does not reuse a historical identical command echo", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let submitted = false;
+    const beforeScreen =
+      "Claude Code\n❯ /review\n⏺ Historical review result\n❯ \n";
+    const baseExec = makeLifecycleExec(() =>
+      submitted ? `${beforeScreen}CLAUDE_COUNTER:1\n` : beforeScreen,
+    );
+    const mockExec: ExecFn = vi.fn().mockImplementation(
+      async (command: string, args: string[]) => {
+        if (args.includes("send-key") && args.includes("return")) {
+          submitted = true;
+        }
+        return baseExec(command, args);
+      },
+    );
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+    submitted = false;
 
     const result = await (server as any)._registeredTools.interact.handler(
       { agent: agentId, action: "skill", command: "/review" },

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -190,6 +190,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
       delivered: false,
       terminal: true,
       delivery_state: "failed",
+      submitted: false,
       error_code: "blocked_by_foreign_draft",
     });
     expect(parsed.WARNING).toMatch(/terminal failure/i);
@@ -357,6 +358,62 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     });
     context.dispose();
   });
+
+  it.each(["✻ Thinking…", "✻ Working…", "⏺ Running…"])(
+    "interact skill does not report active progress %s as a screen result",
+    async (activeProgressLine) => {
+      const { createServer, createServerContext } = await loadServerModule();
+      let screenText = "Claude Code\n❯ ";
+      let submitted = false;
+      const baseExec = makeLifecycleExec(() => screenText);
+      const mockExec: ExecFn = vi.fn().mockImplementation(
+        async (command: string, args: string[]) => {
+          if (args.includes("send-key") && args.includes("return")) {
+            submitted = true;
+          }
+          if (
+            submitted &&
+            args.includes("read-screen") &&
+            args.includes("--lines") &&
+            args.includes("20")
+          ) {
+            return {
+              stdout: JSON.stringify({
+                surface: "surface:new",
+                text: `Claude Code\n❯ /review\n${activeProgressLine}\n`,
+                lines: 20,
+                scrollback_used: false,
+              }),
+              stderr: "",
+            };
+          }
+          return baseExec(command, args);
+        },
+      );
+      const context = createServerContext({
+        exec: mockExec,
+        stateDir: testDir,
+        disableSpawnPreflight: true,
+        sessionIdentityResolver: () => null,
+      });
+      const server = createServer({ context });
+      const agentId = await spawnReadyAgent(server);
+      submitted = false;
+
+      const result = await (server as any)._registeredTools.interact.handler(
+        { agent: agentId, action: "skill", command: "/review" },
+        {} as any,
+      );
+
+      expect(parseToolResult(result)).toMatchObject({
+        ok: true,
+        submit_verified: true,
+        screen_result_available: false,
+        screen_result_line: null,
+      });
+      context.dispose();
+    },
+  );
 
   it("interact skill does not reuse a historical identical command echo", async () => {
     const { createServer, createServerContext } = await loadServerModule();

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -550,6 +550,10 @@ function createReliabilityServer(client: FakeClaudeSurfaceClient) {
     surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
     surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
   });
+  const sendTo = (server as any)._registeredTools.send_to;
+  const sendToHandler = sendTo.handler.bind(sendTo);
+  sendTo.handler = (args: Record<string, unknown>, context: unknown) =>
+    sendToHandler({ mode: "agent", ...args }, context);
   // These tests exercise registry routing and submit verification, not the
   // periodic reconciliation loop. Stop its wall-clock sweep so it cannot race
   // the five-second submit deadline or add unrelated work under parallel load.

--- a/tests/fixtures/live/claude-api-error.txt
+++ b/tests/fixtures/live/claude-api-error.txt
@@ -1,0 +1,6 @@
+Claude Code
+
+API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"},"request_id":"req_011CeRnwUcf8wusrNawosx6c"}
+
+❯
+⏵⏵ bypass permissions on · 2 monitors

--- a/tests/fixtures/live/claude-cant-respond.txt
+++ b/tests/fixtures/live/claude-cant-respond.txt
@@ -1,0 +1,5 @@
+Claude Code can't respond to this message with Fable 5.
+request_id: req_011CeRpLVMKMCob477i3fnNb
+
+❯
+⏵⏵ bypass permissions on · 2 monitors

--- a/tests/fixtures/live/claude-safeguard-refusal.txt
+++ b/tests/fixtures/live/claude-safeguard-refusal.txt
@@ -1,0 +1,7 @@
+Claude Code
+
+API Error: Fable 5's safeguards flagged this message (https://www.anthropic.com/legal/aup). This sometimes happens with safe, normal conversations. Claude Code can't respond to this message with Fable 5.
+Request ID: req_011CeRnwgFeHAsTb3hU4n9jt
+
+❯
+⏵⏵ bypass permissions on · 2 monitors

--- a/tests/live-agent-state.test.ts
+++ b/tests/live-agent-state.test.ts
@@ -39,14 +39,51 @@ function record(overrides: Partial<AgentRecord> = {}): AgentRecord {
 }
 
 describe("screenConfirmedAgentState — the one screen->state rule", () => {
-  it("treats a frozen harness-error screen as an error rather than idle-ready", () => {
+  it("treats a harness API error marker as error independent of frozen status", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "idle",
+        agent_type: "claude",
+        control_state: "unknown",
+        errors: [
+          "harness_api_error: Fable 5 safeguards flagged this message request_id=req_011CeRnwgFeHAsTb3hU4n9jt",
+        ],
+      }),
+    ).toBe("error");
+  });
+
+  it("does not classify a recoverable permission prompt as error and keeps it deliverable", () => {
+    const resolved = resolveLiveAgentState(record({ state: "ready" }), {
+      status: "frozen",
+      agent_type: "claude",
+      control_state: "permission_prompt",
+      errors: ["permission_prompt"],
+    });
+
+    expect(resolved.state).not.toBe("error");
+    expect(isLiveDeliverable(resolved)).toBe(true);
+  });
+
+  it("does not classify a recoverable interactive picker as error", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "frozen",
+        agent_type: "claude",
+        control_state: "interactive_overlay",
+        errors: ["interactive_prompt"],
+      }),
+    ).not.toBe("error");
+  });
+
+  it("does not classify transient SQLITE_BUSY contention as error", () => {
     expect(
       screenConfirmedAgentState({
         status: "frozen",
         agent_type: "claude",
         control_state: "unknown",
+        errors: ["SQLITE_BUSY"],
       }),
-    ).toBe("error");
+    ).not.toBe("error");
   });
 
   it("reads an active screen as working", () => {

--- a/tests/live-agent-state.test.ts
+++ b/tests/live-agent-state.test.ts
@@ -39,6 +39,16 @@ function record(overrides: Partial<AgentRecord> = {}): AgentRecord {
 }
 
 describe("screenConfirmedAgentState — the one screen->state rule", () => {
+  it("treats a frozen harness-error screen as an error rather than idle-ready", () => {
+    expect(
+      screenConfirmedAgentState({
+        status: "frozen",
+        agent_type: "claude",
+        control_state: "unknown",
+      }),
+    ).toBe("error");
+  });
+
   it("reads an active screen as working", () => {
     expect(
       screenConfirmedAgentState({

--- a/tests/live-topology-restart.test.ts
+++ b/tests/live-topology-restart.test.ts
@@ -364,7 +364,7 @@ describe("live daemon-first restart topology", () => {
         jsonrpc: "2.0",
         id: 2,
         method: "tools/call",
-        params: { name: "control_health", arguments: {} },
+        params: { name: "control_health", arguments: { detail: "full" } },
       });
       const initialHealth = await peer.waitForResponse(2, 10_000);
       const initialDaemonPid = daemonPidFromHealth(initialHealth);
@@ -382,7 +382,7 @@ describe("live daemon-first restart topology", () => {
         jsonrpc: "2.0",
         id: 3,
         method: "tools/call",
-        params: { name: "control_health", arguments: {} },
+        params: { name: "control_health", arguments: { detail: "full" } },
       });
       const recoveredHealth = await peer.waitForResponse(3, 15_000);
       const replacementDaemonPid = daemonPidFromHealth(recoveredHealth, stderr);

--- a/tests/paused-visibility.test.ts
+++ b/tests/paused-visibility.test.ts
@@ -132,13 +132,18 @@ class DualCodexSurfaceClient {
 }
 
 function createPausedServer(client: DualCodexSurfaceClient) {
-  return createServer({
+  const server = createServer({
     client,
     stateDir: TEST_DIR,
     disableSpawnPreflight: true,
     surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
     surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
   });
+  const sendTo = (server as any)._registeredTools.send_to;
+  const sendToHandler = sendTo.handler.bind(sendTo);
+  sendTo.handler = (args: Record<string, unknown>, context: unknown) =>
+    sendToHandler({ mode: "agent", ...args }, context);
+  return server;
 }
 
 function makeAgent(

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -539,6 +539,7 @@ describe("pane input pointer discipline", () => {
       submit_attempted: false,
       error_code: "blocked_by_interactive_prompt",
       submit_verified: false,
+      submitted: false,
       error:
         "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
     });
@@ -612,6 +613,7 @@ describe("pane input pointer discipline", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error_code).toBe("blocked_by_permission_prompt");
     expect(parsed.submit_verified).toBe(false);
+    expect(parsed.submitted).toBe(false);
     expect(parsed.screen).toMatchObject({
       control_state: "permission_prompt",
       errors: expect.arrayContaining(["permission_prompt"]),

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -523,7 +523,7 @@ describe("pane input pointer discipline", () => {
     mockExec.mockClear();
 
     const result = await tool.handler(
-      { agent_id: agentId, text: "new fleet message", press_enter: false },
+      { mode: "agent", agent_id: agentId, text: "new fleet message", press_enter: false },
       {} as any,
     );
 
@@ -603,7 +603,7 @@ describe("pane input pointer discipline", () => {
     mockExec.mockClear();
 
     const result = await tool.handler(
-      { agent_id: agentId, text: "continue", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "continue", press_enter: true },
       {} as any,
     );
 
@@ -1010,6 +1010,7 @@ describe("pane input pointer discipline", () => {
 
     const result = await sendTo.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(601),
         press_enter: true,
@@ -1043,7 +1044,7 @@ describe("pane input pointer discipline", () => {
     mockExec.mockClear();
 
     const result = await sendTo.handler(
-      { agent_id: agentId, text: denseIncidentPayload, press_enter: true },
+      { mode: "agent", agent_id: agentId, text: denseIncidentPayload, press_enter: true },
       {} as any,
     );
 
@@ -1057,7 +1058,7 @@ describe("pane input pointer discipline", () => {
 
   it.each([
     ["surface", { text: denseIncidentPayload }],
-    ["command", { command: denseIncidentPayload }],
+    ["command", { text: denseIncidentPayload }],
   ] as const)(
     "send_to mode=%s refuses the dense incident below the general inline cap",
     async (mode, payload) => {
@@ -1113,6 +1114,7 @@ describe("pane input pointer discipline", () => {
 
     const result = await sendTo.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(2_000),
         press_enter: true,
@@ -1154,6 +1156,7 @@ describe("pane input pointer discipline", () => {
 
     const result = await sendTo.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(600),
         press_enter: true,
@@ -1188,6 +1191,7 @@ describe("pane input pointer discipline", () => {
 
     let result = await sendToAgent.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(601),
         press_enter: true,
@@ -1204,6 +1208,7 @@ describe("pane input pointer discipline", () => {
 
     result = await sendToAgent.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(2_000),
         press_enter: true,
@@ -1245,6 +1250,7 @@ describe("pane input pointer discipline", () => {
 
     const result = await sendTo.handler(
       {
+        mode: "agent",
         agent_id: agentId,
         text: "x".repeat(701),
         press_enter: true,

--- a/tests/public-contract-callers.test.ts
+++ b/tests/public-contract-callers.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = (path: string) => readFileSync(path, "utf8");
+
+describe("in-repo public contract callers", () => {
+  it("requests full control_health detail wherever the response is inspected", () => {
+    const doctor = source("src/doctor.ts");
+    const realContract = source("scripts/run-real-cmux-contract.ts");
+
+    expect(doctor).toMatch(
+      /params:\s*\{\s*name: "control_health",\s*arguments: \{ detail: "full" \}/,
+    );
+    expect(
+      realContract.match(
+        /peer\.callTool\(\s*"control_health",\s*\{ detail: "full" \},/g,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("uses the canonical send_to mode and payload fields in live probes", () => {
+    const liveness = source("scripts/acceptance-registry-liveness.mjs");
+    const churn = source("scripts/run-live-id-churn-probe.ts");
+
+    expect(liveness).toMatch(
+      /mcp\.call\(\s*"send_to",\s*\{\s*mode: "agent",\s*agent_id: a\.agent_id,/,
+    );
+    expect(churn).toContain('mode: "key",\n      surface: child.surface_id');
+    expect(churn).toContain('text: "down"');
+    expect(churn).toContain('text: "return"');
+    expect(churn).not.toMatch(/mode: "key",[\s\S]{0,160}\bkey:/);
+  });
+});

--- a/tests/recycled-surface-identity.test.ts
+++ b/tests/recycled-surface-identity.test.ts
@@ -22,7 +22,10 @@ async function callTool(
   if (!tool) {
     throw new Error(`Tool not found: ${name}`);
   }
-  return tool.handler(args, {} as any);
+  return tool.handler(
+    name === "send_to" ? { mode: "agent", ...args } : args,
+    {} as any,
+  );
 }
 
 /**

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -89,6 +89,24 @@ Request ID: req_stillfailed
     expect(parsed.control_state).not.toBe("ready");
   });
 
+  it("does not treat model-authored API Error text without a request id as a harness failure", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+⏺ Completed the parser explanation
+API Error: is the prefix used by the harness for transport failures.
+❯`);
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.status).not.toBe("frozen");
+  });
+
+  it("does not treat API Error text with a request id but no trailing composer as a harness failure", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+⏺ Explaining a captured failure
+API Error: 500 {"request_id":"req_quoted_example"}`);
+
+    expect(parsed.errors).toEqual([]);
+  });
+
   it("parses Claude-style output with response block and done signal", () => {
     const parsed = parseScreen(`
 \u001b[32m⏺ Completed successfully\u001b[0m

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -107,6 +107,16 @@ API Error: 500 {"request_id":"req_quoted_example"}`);
     expect(parsed.errors).toEqual([]);
   });
 
+  it("does not treat an indented quoted API error as a harness failure", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+⏺ Explaining a captured failure
+  API Error: 500 {"request_id":"req_quoted_with_composer"}
+❯`);
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.status).not.toBe("frozen");
+  });
+
   it("parses Claude-style output with response block and done signal", () => {
     const parsed = parseScreen(`
 \u001b[32m⏺ Completed successfully\u001b[0m

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -128,6 +128,16 @@ API Error: 500 {"request_id":"req_quoted_example"}`);
     expect(parsed.status).not.toBe("frozen");
   });
 
+  it("does not treat a column-zero quoted API error as a harness-owned block", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+⏺ Quoting the captured log below
+API Error: 500 {"request_id":"req_quoted_column_zero"}
+❯`);
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.status).not.toBe("frozen");
+  });
+
   it("parses Claude-style output with response block and done signal", () => {
     const parsed = parseScreen(`
 \u001b[32m⏺ Completed successfully\u001b[0m

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -89,6 +89,17 @@ Request ID: req_stillfailed
     expect(parsed.control_state).not.toBe("ready");
   });
 
+  it("clears a stale harness error when a submitted retry is actively thinking", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+API Error: overloaded
+Request ID: req_retry_active
+❯ retry
+✻ Thinking…`);
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.status).toBe("thinking");
+  });
+
   it("does not treat model-authored API Error text without a request id as a harness failure", () => {
     const parsed = parseScreen(`Claude Code v1.0.0
 ⏺ Completed the parser explanation

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -33,6 +33,49 @@ const deadCodexShellFixture = JSON.parse(
 ) as { lines_12: string; lines_80: string };
 
 describe("parseScreen", () => {
+  it.each([
+    ["claude-api-error.txt", "req_011CeRnwUcf8wusrNawosx6c"],
+    ["claude-safeguard-refusal.txt", "req_011CeRnwgFeHAsTb3hU4n9jt"],
+    ["claude-cant-respond.txt", "req_011CeRpLVMKMCob477i3fnNb"],
+  ])(
+    "lifts harness API failure fixture %s into errors with its request id",
+    (fixture, requestId) => {
+      const parsed = parseScreen(readFixture(`live/${fixture}`));
+
+      expect(parsed.errors).toEqual([
+        expect.stringMatching(
+          new RegExp(`^harness_api_error:.*${requestId}$`, "i"),
+        ),
+      ]);
+      expect(parsed.status).toBe("frozen");
+      expect(parsed.control_state).not.toBe("ready");
+    },
+  );
+
+  it("keeps only the latest consecutive harness error and clears stale recovered errors", () => {
+    const consecutive = parseScreen(`
+API Error: first refusal
+Request ID: req_first
+❯ retry
+API Error: latest refusal
+Request ID: req_latest
+❯
+`);
+    expect(consecutive.errors).toEqual([
+      expect.stringMatching(/latest refusal.*req_latest$/),
+    ]);
+
+    const recovered = parseScreen(`
+API Error: old refusal
+Request ID: req_old
+❯ go
+⏺ Recovery completed successfully
+❯
+`);
+    expect(recovered.errors).toEqual([]);
+    expect(recovered.status).not.toBe("frozen");
+  });
+
   it("parses Claude-style output with response block and done signal", () => {
     const parsed = parseScreen(`
 \u001b[32m⏺ Completed successfully\u001b[0m

--- a/tests/screen-parser.test.ts
+++ b/tests/screen-parser.test.ts
@@ -76,6 +76,19 @@ Request ID: req_old
     expect(recovered.status).not.toBe("frozen");
   });
 
+  it("keeps a harness error frozen when recovery text is only typed in the composer", () => {
+    const parsed = parseScreen(`Claude Code v1.0.0
+API Error: overloaded
+Request ID: req_stillfailed
+❯ retry`);
+
+    expect(parsed.errors).toEqual([
+      expect.stringMatching(/^harness_api_error: overloaded .*req_stillfailed$/),
+    ]);
+    expect(parsed.status).toBe("frozen");
+    expect(parsed.control_state).not.toBe("ready");
+  });
+
   it("parses Claude-style output with response block and done signal", () => {
     const parsed = parseScreen(`
 \u001b[32m⏺ Completed successfully\u001b[0m

--- a/tests/send-to-v2-background-verify.test.ts
+++ b/tests/send-to-v2-background-verify.test.ts
@@ -34,7 +34,10 @@ async function callTool(
   if (!tool) {
     throw new Error(`Tool not found: ${name}`);
   }
-  const resultPromise = tool.handler(args, {} as any);
+  const resultPromise = tool.handler(
+    name === "send_to" ? { mode: "agent", ...args } : args,
+    {} as any,
+  );
   for (let elapsed = 0; elapsed < 10_000; elapsed += 100) {
     await vi.advanceTimersByTimeAsync(100);
   }
@@ -482,6 +485,7 @@ describe("send_to v2 background verify", () => {
     registerAgent(server);
 
     const args = {
+      mode: "agent",
       agent_id: "agent-1",
       text: "race me once",
       press_enter: true,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7815,6 +7815,77 @@ describe("agent lifecycle tool handlers", () => {
     expect(live.health.issue_codes).toContain("registry_screen_disagreement");
   });
 
+  it("inbox_check preserves harness API errors through the general health evaluator", async () => {
+    const stableUuid = "71111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:api-error",
+        id: stableUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    routeClient.setScreenText(
+      'Claude Code\nAPI Error: 500 {"request_id":"req_inboxhealth"}\n❯',
+    );
+    const record = makeServerAgentRecord({
+      agent_id: "api-error-health-agent",
+      surface_id: "surface:api-error",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:1",
+      state: "working",
+      cli: "claude",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+
+    const parsed = parseToolResult(
+      await registeredTestTool(server, "inbox_check").handler(
+        { agent_id: record.agent_id },
+        {},
+      ),
+    );
+
+    expect(parsed.health).toMatchObject({
+      status: expect.not.stringMatching(/^healthy$/),
+      issue_codes: expect.arrayContaining(["harness_api_error"]),
+    });
+    expect(parsed.health.issues.join(" ")).toContain("req_inboxhealth");
+  });
+
+  it("interact skill observes the result through the stable UUID and bound workspace", async () => {
+    const stableUuid = "81111111-2222-4333-8444-555555555555";
+    const routeClient = makeUuidRouteClient([
+      {
+        ref: "surface:skill",
+        id: stableUuid,
+        workspace_ref: "workspace:1",
+      },
+    ]);
+    (routeClient.client as any).supportsStableSurfaceReads = true;
+    routeClient.setScreenText("Claude Code\n❯ ");
+    const record = makeServerAgentRecord({
+      agent_id: "stable-skill-agent",
+      surface_id: "surface:skill",
+      surface_uuid: stableUuid,
+      workspace_id: "workspace:1",
+      state: "ready",
+      cli: "claude",
+    });
+    const server = await createUuidRouteServer(routeClient, record);
+
+    const result = parseToolResult(
+      await registeredTestTool(server, "interact").handler(
+        { agent: record.agent_id, action: "skill", command: "/review" },
+        {},
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(routeClient.client.readScreen).toHaveBeenLastCalledWith(stableUuid, {
+      workspace: "workspace:1",
+      lines: 20,
+    });
+  });
+
   it("list_agents reuses a bounded snapshot until live topology changes", async () => {
     const stableUuid = "11111111-2222-4333-8444-555555555555";
     const routeClient = makeUuidRouteClient([

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -14467,6 +14467,14 @@ codex>
       ).toBe("working");
     });
 
+    it("surfaces a live harness API error over a stale healthy registry state", () => {
+      const harnessError = liveScreen("frozen", 50_000);
+      harnessError.errors = [
+        "harness_api_error: request refused request_id=req_my_agents",
+      ];
+      expect(reconcileAgentLiveState("working", harnessError)).toBe("error");
+    });
+
     it("keeps registry error when there is no live screen to reconcile against", () => {
       expect(reconcileAgentLiveState("error", null)).toBe("error");
     });

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -358,6 +358,12 @@ function createTrackedServer(
   const context = createServerContext(normalizedOpts);
   serverContexts.push(context);
   const server = createServer({ ...normalizedOpts, context });
+  const sendToTool = (server as any)._registeredTools?.send_to;
+  if (sendToTool?.handler) {
+    const sendToHandler = sendToTool.handler.bind(sendToTool);
+    sendToTool.handler = (args: Record<string, unknown>, toolContext: unknown) =>
+      sendToHandler({ mode: "agent", ...args }, toolContext);
+  }
   if (defaultCallerContext) {
     const registeredTools = (server as any)._registeredTools as Record<
       string,
@@ -2051,7 +2057,13 @@ function registeredTestTool(server: unknown, name: string): RegisteredTestTool {
       _registeredTools: Record<string, RegisteredTestTool>;
     }
   )._registeredTools;
-  return registry[name]!;
+  const tool = registry[name]!;
+  if (name !== "send_to") return tool;
+  return {
+    handler(args, context) {
+      return tool.handler({ mode: "agent", ...args }, context);
+    },
+  };
 }
 
 function testLifecycleEngine(server: unknown): TestLifecycleEngine {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -9722,7 +9722,7 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
-  it("spawn_agent returns blocked_by_update_menu when the Codex update menu remains after acceptance", async () => {
+  it("spawn_agent returns truthful recovery when the Codex update menu remains", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-blocked-state");
@@ -9854,7 +9854,9 @@ describe("tool handler integration", () => {
         result.structuredContent ?? JSON.parse(result.content[0].text);
       expect(parsed.ok).toBe(false);
       expect(parsed.error_code).toBe("blocked_by_update_menu");
-      expect(parsed.recovery).toContain("Update now");
+      expect(parsed.recovery).toContain("resolve the update menu");
+      expect(parsed.recovery).toContain("surface:2");
+      expect(parsed.recovery).not.toContain("cmuxlayer accepted");
       expect(sentKeys).not.toContain("down");
       expect(sentKeys.filter((key) => key === "return")).toHaveLength(1);
     } finally {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -514,7 +514,7 @@ describe("createServer", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("includes a working send_to example in SDK-level invalid-mode errors", async () => {
+  it("returns the exact missing-mode error and a working SDK invalid-mode example", async () => {
     const stateDir = processScopedTmpDir("cmuxlayer-send-to-schema-error");
     rmSync(stateDir, { recursive: true, force: true });
     const server = createServer({
@@ -535,6 +535,22 @@ describe("createServer", () => {
       client.connect(clientTransport),
     ]);
     try {
+      const missingMode = await client.callTool({
+        name: "send_to",
+        arguments: {
+          agent_id: "cmuxlayerCodex-1234",
+          text: "hello",
+        },
+      });
+      expect(missingMode.isError).toBe(true);
+      const missingModeText = missingMode.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      expect(JSON.parse(missingModeText).error).toBe(
+        "mode required (agent|surface|command|key)",
+      );
+
       const result = await client.callTool({
         name: "send_to",
         arguments: {
@@ -551,6 +567,19 @@ describe("createServer", () => {
         .replaceAll('\\"', '"');
       expect(validationText).toContain(
         'Example: send_to({ mode: "agent", agent_id: "cmuxlayerCodex-1234", text: "hello" })',
+      );
+
+      const numericSurface = await client.callTool({
+        name: "send_to",
+        arguments: { mode: "surface", surface: 3, text: "hello" },
+      });
+      expect(numericSurface.isError).toBe(true);
+      const numericSurfaceText = numericSurface.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      expect(numericSurfaceText).toContain(
+        "use surface:<index> ref or a surface UUID",
       );
     } finally {
       await client.close();
@@ -3637,7 +3666,7 @@ describe("tool handler integration", () => {
       {
         mode: "command",
         surface: "surface:receipt-parity",
-        command: "echo parity",
+        text: "echo parity",
       },
       {} as any,
     );
@@ -3645,7 +3674,7 @@ describe("tool handler integration", () => {
       {
         mode: "key",
         surface: "surface:receipt-parity",
-        key: "escape",
+        text: "escape",
       },
       {} as any,
     );
@@ -9278,7 +9307,7 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
-  it("spawn_agent accepts the default interactive Codex update and never selects Skip", async () => {
+  it("spawn_agent refuses the Codex update menu without pressing a pre-prompt Return", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-state");
@@ -9486,12 +9515,12 @@ describe("tool handler integration", () => {
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
-      expect(parsed.ok).toBe(true);
-      expect(parsed.boot_prompt_delivered).toBe(true);
-      expect(updateAccepted).toBe(true);
-      expect(updateMenuKeys).toEqual(["return"]);
-      expect(launcherSends).toBe(2);
-      expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(1);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error_code).toBe("blocked_by_update_menu");
+      expect(updateAccepted).toBe(false);
+      expect(updateMenuKeys).toEqual([]);
+      expect(launcherSends).toBe(1);
+      expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(0);
     } finally {
       if (previousAllowModel === undefined) {
         delete process.env.REPOGOLEM_ALLOW_MODEL;
@@ -9503,7 +9532,7 @@ describe("tool handler integration", () => {
     }
   }, 10_000);
 
-  it("spawn_agent keeps polling after the accepted Codex update menu repaints once", async () => {
+  it("spawn_agent does not drive a repainted Codex update menu", async () => {
     const previousAllowModel = process.env.REPOGOLEM_ALLOW_MODEL;
     process.env.REPOGOLEM_ALLOW_MODEL = "1";
     const stateDir = join(CHANNEL_TEST_DIR, "spawn-update-menu-slow-state");
@@ -9676,14 +9705,12 @@ describe("tool handler integration", () => {
       );
       const parsed =
         result.structuredContent ?? JSON.parse(result.content[0].text);
-      expect(parsed.ok).toBe(true);
-      expect(parsed.boot_prompt_delivered).toBe(true);
-      // Poll the repaint, confirm readiness, then perform the shared delivery
-      // preflight and verification for the combined caller + mailbox contract.
-      expect(postDismissMenuReads).toBe(3);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error_code).toBe("blocked_by_update_menu");
+      expect(postDismissMenuReads).toBe(0);
       expect(sentKeys).not.toContain("down");
-      expect(sentKeys).toContain("return");
-      expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(1);
+      expect(sentKeys.filter((key) => key === "return")).toHaveLength(1);
+      expect(sentTexts.filter((text) => text.includes(prompt))).toHaveLength(0);
     } finally {
       if (previousAllowModel === undefined) {
         delete process.env.REPOGOLEM_ALLOW_MODEL;
@@ -9829,7 +9856,7 @@ describe("tool handler integration", () => {
       expect(parsed.error_code).toBe("blocked_by_update_menu");
       expect(parsed.recovery).toContain("Update now");
       expect(sentKeys).not.toContain("down");
-      expect(sentKeys).toContain("return");
+      expect(sentKeys.filter((key) => key === "return")).toHaveLength(1);
     } finally {
       if (previousAllowModel === undefined) {
         delete process.env.REPOGOLEM_ALLOW_MODEL;

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -293,7 +293,7 @@ function makeServer(
 
 async function sendKey(server: unknown, key: string): Promise<ToolCallResult> {
   return (await getTool(server, "send_to").handler(
-    { mode: "key", target: SURFACE, key },
+    { mode: "key", target: SURFACE, text: key },
     {},
   )) as ToolCallResult;
 }

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -310,7 +310,7 @@ describe("send_to consolidated modes", () => {
       {
         mode: "command",
         target: "surface:1",
-        command: "pwd",
+        text: "pwd",
       },
       {},
     );
@@ -327,7 +327,7 @@ describe("send_to consolidated modes", () => {
     const server = createServer({ exec, controlHealthIntervalMs: 0 }) as any;
 
     const result = await server._registeredTools.send_to.handler(
-      { mode: "key", surface: "surface:1", key: "escape" },
+      { mode: "key", surface: "surface:1", text: "escape" },
       {},
     );
 
@@ -335,6 +335,41 @@ describe("send_to consolidated modes", () => {
     expect(exec).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["send-key", "--surface", "surface:1", "escape"]),
+    );
+  });
+
+  it("requires mode and accepts only text as the payload parameter", async () => {
+    const server = createServer({ exec: makeExec(), controlHealthIntervalMs: 0 }) as any;
+    const tool = server._registeredTools.send_to;
+
+    const missing = await tool.handler({ target: "surface:1", text: "pwd" }, {});
+    expect(parseResult(missing).error).toBe(
+      "mode required (agent|surface|command|key)",
+    );
+    for (const alias of ["message", "command", "key"] as const) {
+      const rejected = await tool.handler(
+        { mode: "command", target: "surface:1", [alias]: "pwd" },
+        {},
+      );
+      expect(parseResult(rejected).error).toMatch(/one payload parameter: text/);
+    }
+  });
+
+  it("rejects bare surface indexes at the public tool boundary", async () => {
+    const exec = makeExec();
+    const server = createServer({ exec, controlHealthIntervalMs: 0 }) as any;
+    const result = await server._registeredTools.send_to.handler(
+      { mode: "surface", surface: "3", text: "hello" },
+      {},
+    );
+    expect(parseResult(result).error).toMatch(/use surface:<index> ref or a surface UUID/);
+    expect(exec.mock.calls.some(([, args]) => args.includes("send"))).toBe(false);
+    const numeric = await server._registeredTools.send_to.handler(
+      { mode: "surface", surface: 3, text: "hello" },
+      {},
+    );
+    expect(parseResult(numeric).error).toMatch(
+      /use surface:<index> ref or a surface UUID/,
     );
   });
 });

--- a/tests/verified-relay.test.ts
+++ b/tests/verified-relay.test.ts
@@ -21,7 +21,10 @@ async function callTool(
   if (!tool) {
     throw new Error(`Tool not found: ${name}`);
   }
-  return tool.handler(args, {} as any);
+  return tool.handler(
+    name === "send_to" ? { mode: "agent", ...args } : args,
+    {} as any,
+  );
 }
 
 /**


### PR DESCRIPTION
## Outcome

Makes composer delivery, harness-error monitoring, watch health, and public receipts follow the live screen instead of optimistic registry/status inference.

## Changes

- Removes the pre-prompt Codex update-menu Return at the old `src/server.ts:6491-6509` path; an update menu now returns `blocked_by_update_menu` without mutating the composer.
- Reports `submitted:false` unless submit verification is positively true, and lets pending composer text defeat status-only boot evidence.
- Makes slash-command interaction refuse a non-empty composer with its contents and return the post-command screen result line.
- Rejects bare surface indexes at the tool and CLI/socket boundaries; canonical `surface:<index>` refs and UUIDs remain valid.
- Requires explicit `send_to.mode`, accepts only `text` in all four modes, and returns `mode required (agent|surface|command|key)` when absent.
- Parses recorded Claude API/safeguard/cannot-respond screens into `harness_api_error` with request IDs, freezes live state/health, and wakes the parent with the error. Recovered stale errors no longer poison later turns.
- Makes terse `control_health` the default and exposes caller live watches as `{count,watches:[{watch_id,target,state}]}`; full diagnostics remain behind `detail:"full"`.

## RED -> GREEN evidence

- D137/D121: update-menu tests previously expected an automatic Return; pending-composer receipt regression added. GREEN with no pre-prompt Return and `submitted:false` when text remains.
- D124: dirty-composer refusal and empty-composer result-receipt regressions added; both GREEN.
- D125: CLI plus direct-tool and SDK-boundary numeric-surface regressions added; GREEN.
- D136: explicit-mode/single-text regressions added. The real perf replay caught the remaining implicit agent-mode calls; benchmark workload now sends `mode:"agent"`. GREEN.
- D140: three fixture shapes initially produced `errors:[]`; the real recorded `Claude Code can't respond to this message with Fable 5.` row then produced a second RED against the narrower matcher. All recorded rows now parse `status:"frozen"` with the matching request ID; stale recovery is GREEN.
- Watches/D145: armed N -> dropped 0 and terse/full regressions GREEN.

## Live evidence

- Three fresh Codex 0.150.1 right-column probe surfaces showed `› RUN9_AFTER_PROBE_{1,2,3}` on composer line 1. Leftover-text cases: **0/3**. Surfaces 309, 311, and 313 were closed; topology recheck found none remaining.
- The production Claude JSONL rows for `req_011CeRnwUcf8wusrNawosx6c`, `req_011CeRnwgFeHAsTb3hU4n9jt`, and `req_011CeRpLVMKMCob477i3fnNb` were replayed directly through the built parser. Each returned `status:"frozen"` and `errors:["harness_api_error: ... request_id=<matching id>"]`.

## Gates

- Full serial suite: 153 files; 3,549 passed; 1 intentional skip.
- Root typecheck: GREEN. Site typecheck: GREEN.
- D138 machine-home literal gate: GREEN.
- Daemon performance budget: GREEN (8 clients x 12 rounds, socket-only replay).
- `git diff --check`: GREEN.
- New P0/P1 regressions vs main: none found by tests/live probes.

## Bot-first review handoff

Local CodeRabbit was bounded at three minutes and emitted one **real major** before timeout: `screenConfirmedAgentState` currently maps every `status:"frozen"` to registry `error`, including recoverable permission/interactive overlays. Per the run contract, this is reported rather than silently fixed. Lead ruling is required before merge. Status: **REVIEW_NEEDED**.

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0421a","ts":"2026-08-27T07:23:46Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core MCP delivery contracts, spawn boot behavior, and live agent state/health semantics across the server and agent engine—high blast radius for external callers and orchestration paths.
> 
> **Overview**
> This PR tightens **delivery and health** around what the live screen actually shows, and **narrows public MCP contracts** so callers cannot rely on implicit defaults or ambiguous surface refs.
> 
> **Harness API failures** are parsed from Claude-style screens into `harness_api_error` entries (with `request_id`), propagated through discovery, live state, health (`blocking` issue), halt escalation (immediate parent wake, 0ms dwell), and `my_agents` reconciliation—without treating recoverable permission/picker overlays or stale recovered errors as terminal failures.
> 
> **`send_to`** now requires an explicit `mode`, uses **`text` for all modes** (including key/command), rejects legacy `command`/`key`/`message` fields and bare numeric surface indexes (canonical `surface:<index>` or UUID via `assertCanonicalSurfaceRef` on tool, CLI, and socket paths). Receipts add **`submitted`** (true only when submit verification is positive); foreign-draft and safety-gate errors are more explicit. Boot spawn **no longer auto-presses Return** on Codex update menus—spawn fails with `blocked_by_update_menu` and surface-specific recovery guidance. **`interact` skill** applies draft guards, optionally receipts a post-submit screen line, and keeps success if observation fails after a verified submit.
> 
> **`control_health`** defaults to **terse** JSON (transport, warnings, self-heal counts, caller live watches); full diagnostics need `detail: "full"`. In-repo probes, doctor, and contract scripts were migrated accordingly; daemon benchmark payloads include `mode: "agent"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9afa422d4814fdd5ab81e2c238183b1dbc048da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make composer and monitor receipts screen-truthful by requiring `mode`, unifying payload on `text`, and detecting harness API errors
> - `SendToArgsSchema` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) now requires `mode`, accepts only `text` as the payload (removing `command` and `key`), and rejects bare numeric `surface`/`target` values; receipts include a new `submitted` boolean and optional `screen_result_line` from post-submit screen analysis.
> - Screen parser in [screen-parser.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-10170f5d46ab5ce45acb8040a69928bafe44d7f458eb4af90a211557ae574e50) detects harness-owned `API Error:` and `Claude Code can't respond` blocks, lifting them into `errors` with a `harness_api_error:` prefix and request_id when present.
> - Agent engine in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) treats `harness_api_error` as a first-class halt type with zero dwell, starts new episodes on request_id change, and propagates parsed errors through health and state resolution; [agent-health.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-0dd564610d06e111ffe28c5699d77a1cc6e6b41bdbe8d893f63099d89f87e8f3) reports it as a blocking issue.
> - Boot prompt readiness handler in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) stops pressing Return to dismiss the Codex update menu and throws `BootPromptUpdateMenuBlockedError` immediately.
> - `control_health` tool defaults to a terse JSON summary unless `detail: "full"` is requested; `assertCanonicalSurfaceRef` in [surface-ref.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-f506f7324498a6ff317303ce296bc5141190c08bbe946386572a88f6970cbdc8) rejects bare numeric surface refs, enforced in [cmux-client.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-fa09fce9dc0db1d0fcfd897829a228dc976f365c0f36f4cbadacf6d03bd932d4) and [cmux-socket-client.ts](https://github.com/EtanHey/cmuxlayer/pull/570/files#diff-2faad6787f88b4817f02156fda51da8e33fe78618c26d0eff544905b961a82b2).
> - Risk: `send_to` callers omitting `mode`, using `command`/`key` fields, or passing numeric surface indices will now receive errors; internal compatibility paths still default `mode` to `"agent"` but public boundary validation is strict. `control_health` consumers expecting full structured output now get terse JSON by default and must pass `{ detail: "full" }`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9afa422.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health monitoring now detects and reports unrecovered harness/API errors, including request IDs.
  * Added concise or detailed health views with caller-specific live-watch information.
  * Interaction results indicate whether delivery was submitted and provide safer screen observations.
* **Bug Fixes**
  * Prevented accidental acceptance of interactive update menus.
  * Improved protection against overwriting existing composer drafts.
  * Invalid surface references are rejected with clearer guidance.
  * Updated message delivery to require an explicit mode and use a unified text field.
* **Documentation**
  * Added an implementation plan covering reliability, health reporting, safety, and review follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->