### PR TITLE
fix(watches): gate external notifications behind explicit opt-in

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12398,6 +12398,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           watchRegistryPath,
           watchRegistryNow: opts?.watchRegistryNow,
           watchNotify: async (event) => {
+            const externalNotify =
+              event.notify === true ? opts?.watchNotify : undefined;
             const subjectStillBelongsToOwner = (): boolean => {
               if (!event.subject_agent_id) return true;
               const subject =
@@ -12440,9 +12442,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   : undefined;
               })();
             let externalDelivered = true;
-            if (event.reason !== "predicate_matched" && opts?.watchNotify) {
+            if (event.reason !== "predicate_matched" && externalNotify) {
               try {
-                externalDelivered = (await opts.watchNotify(event)) !== false;
+                externalDelivered = (await externalNotify(event)) !== false;
               } catch {
                 externalDelivered = false;
               }
@@ -12451,15 +12453,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               return true;
             }
             if (!owner) {
-              if (event.reason === "predicate_matched" && opts?.watchNotify) {
+              if (event.reason === "predicate_matched" && externalNotify) {
                 try {
                   externalDelivered =
-                    (await opts.watchNotify(event)) !== false;
+                    (await externalNotify(event)) !== false;
                 } catch {
                   externalDelivered = false;
                 }
               }
-              if (opts?.watchNotify && externalDelivered) {
+              if (externalNotify && externalDelivered) {
                 return true;
               }
               return {
@@ -12472,13 +12474,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               const externalFallbackAfterLocalFailure = async () => {
                 if (
                   event.reason !== "predicate_matched" ||
-                  !opts?.watchNotify
+                  !externalNotify
                 ) {
                   return false;
                 }
                 if (!subjectStillBelongsToOwner()) return true;
                 try {
-                  return (await opts.watchNotify(event)) !== false;
+                  return (await externalNotify(event)) !== false;
                 } catch {
                   return false;
                 }
@@ -12522,10 +12524,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               }
             }
             if (event.reason !== "predicate_matched") {
-              return opts?.watchNotify ? externalDelivered : false;
+              return externalNotify ? externalDelivered : false;
             }
-            return opts?.watchNotify
-              ? (await opts.watchNotify(event)) !== false
+            return externalNotify
+              ? (await externalNotify(event)) !== false
               : false;
           },
           closeForensicsRunner: opts?.enableCloseForensics

--- a/src/server.ts
+++ b/src/server.ts
@@ -429,6 +429,10 @@ const WatchSpecArgsSchema = {
     .nonnegative()
     .optional()
     .describe("Prior marker count; defaults to count observed at arm time"),
+  notify: z
+    .boolean()
+    .optional()
+    .describe("Opt in to the configured external notification transport"),
   deadline: z
     .number()
     .int()

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -35,6 +35,8 @@ export interface WatchSpec {
   owner: string;
   /** Managed child whose lifecycle owns this watch. */
   subject_agent_id?: string;
+  /** Opt in to the configured external notification transport. */
+  notify?: boolean;
   target: string;
   predicate?: WatchAgentPredicate;
   marker?: string;
@@ -101,6 +103,7 @@ export interface WatchNotification {
   watch_id: string;
   owner: string;
   subject_agent_id?: string;
+  notify?: boolean;
   target: string;
   target_kind: "file" | "agent";
   reason: WatchNotificationReason;
@@ -322,6 +325,9 @@ function isWatchRecord(value: unknown): value is WatchRecord {
     value.subject_agent_id !== undefined &&
     typeof value.subject_agent_id !== "string"
   ) {
+    return false;
+  }
+  if (value.notify !== undefined && typeof value.notify !== "boolean") {
     return false;
   }
   if (
@@ -829,6 +835,7 @@ export async function armWatch(
     watch_id: randomUUID(),
     owner: checked.owner,
     ...(subjectAgentId ? { subject_agent_id: subjectAgentId } : {}),
+    ...(spec.notify === true ? { notify: true } : {}),
     target,
     ...(checked.predicate ? { predicate: checked.predicate } : {}),
     ...(checked.marker ? { marker: checked.marker } : {}),
@@ -903,6 +910,7 @@ function notificationFor(
     ...(record.subject_agent_id
       ? { subject_agent_id: record.subject_agent_id }
       : {}),
+    ...(record.notify === true ? { notify: true } : {}),
     target: record.target,
     target_kind: record.target_kind,
     reason,
@@ -1285,8 +1293,10 @@ export async function sweepWatches(
 export async function httpNotifyWatch(
   event: WatchNotification,
   notifyUrl = DEFAULT_NOTIFY_URL,
+  deliver: typeof httpDeliver = httpDeliver,
 ): Promise<boolean> {
-  return httpDeliver(
+  if (event.notify !== true) return true;
+  return deliver(
     {
       title: "Declared watch changed",
       body: `Watch ${event.watch_id} for ${event.owner}: ${event.reason}; target=${event.target}`,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -1023,6 +1023,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       subject_agent_id: child.agent_id,
       target: reportPath,
       change: "content",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
     const initialFingerprint = readWatchRegistry({
@@ -1111,6 +1112,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       subject_agent_id: child.agent_id,
       target: contentPath,
       change: "content",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
     await engine.armWatch({
@@ -1118,6 +1120,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       subject_agent_id: child.agent_id,
       target: markerPath,
       marker: "DONE_EXTERNAL",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
     writeFileSync(contentPath, "after\n", "utf8");
@@ -1198,6 +1201,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       subject_agent_id: child.agent_id,
       target: child.agent_id,
       predicate: "idle",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
     const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
@@ -1999,6 +2003,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       subject_agent_id: child.agent_id,
       target: reportPath,
       change: "content",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
     const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
@@ -2051,6 +2056,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       owner: parent.agent_id,
       target: reportPath,
       marker: "DONE_REAPED_CHILD",
+      notify: true,
       deadline: Number.MAX_SAFE_INTEGER,
     });
 

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -197,6 +197,36 @@ describe("WatchSpec MCP contract", () => {
     expect(notify).toHaveBeenCalledOnce();
   });
 
+  it("does not invoke an injected external notifier without explicit opt-in", async () => {
+    const notify = vi.fn().mockResolvedValue(true);
+    const server = createWatchServer(notify);
+    const target = join(TEST_DIR, "local-only.md");
+    writeFileSync(target, "", "utf8");
+    setTimeout(() => appendFileSync(target, "DONE\n", "utf8"), 30);
+
+    const { raw, parsed } = await callTool(server, "wait_for", {
+      watch: {
+        owner: "lead-a",
+        target,
+        marker: "DONE",
+        deadline: Date.now() + 1_000,
+      },
+      timeout_ms: 500,
+    });
+
+    expect(raw.isError).not.toBe(true);
+    expect(parsed).toMatchObject({
+      ok: true,
+      matched: true,
+      watch: {
+        state: "fired",
+        terminal_reason: "predicate_matched",
+        notification_pending: false,
+      },
+    });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   it("D14 emits MCP progress before a long wait hits the harness silence cutoff", async () => {
     vi.useFakeTimers();
     try {

--- a/tests/watch-spec-mcp.test.ts
+++ b/tests/watch-spec-mcp.test.ts
@@ -176,6 +176,7 @@ describe("WatchSpec MCP contract", () => {
         owner: "lead-a",
         target,
         marker: "DONE",
+        notify: true,
         deadline: Date.now() + 1_000,
       },
       timeout_ms: 500,

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import {
   WatchArmError,
   armWatch,
+  httpNotifyWatch,
   readWatchRegistry,
   reserveWatchReportPath,
   releaseWatchReportPathReservation,
@@ -33,6 +34,50 @@ describe("WatchSpec arm contract", () => {
 
   afterEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("notifies the transport only when the declared watch opts in", async () => {
+    const silentTarget = join(TEST_DIR, "silent.md");
+    const notifyingTarget = join(TEST_DIR, "notifying.md");
+    writeFileSync(silentTarget, "", "utf8");
+    writeFileSync(notifyingTarget, "", "utf8");
+    const transport = vi.fn().mockResolvedValue(true);
+
+    await armWatch(
+      {
+        owner: "lead-a",
+        target: silentTarget,
+        marker: "DONE",
+        deadline: 60_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    await armWatch(
+      {
+        owner: "lead-a",
+        target: notifyingTarget,
+        marker: "DONE",
+        deadline: 60_000,
+        notify: true,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    appendFileSync(silentTarget, "DONE\n", "utf8");
+    appendFileSync(notifyingTarget, "DONE\n", "utf8");
+
+    await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify: (event) =>
+        httpNotifyWatch(event, "http://notify.invalid", transport),
+    });
+
+    expect(transport).toHaveBeenCalledOnce();
+    expect(transport.mock.calls[0]?.[0]).toMatchObject({
+      title: "Declared watch changed",
+      body: expect.stringContaining(`target=${notifyingTarget}`),
+    });
+    expect(transport.mock.calls[0]?.[1]).toBe("http://notify.invalid");
   });
 
   it("rejects a nonexistent file target immediately with a structured arm error", async () => {
@@ -80,6 +125,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         change: "content",
+        notify: true,
         deadline: 60_000,
       },
       {
@@ -298,6 +344,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target: "worker-a",
         predicate: "done",
+        notify: true,
         deadline: 60_000,
       },
       {
@@ -349,6 +396,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target: "worker-a",
         predicate: "done",
+        notify: true,
         deadline: 60_000,
       },
       {
@@ -777,6 +825,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         marker: "DONE",
+        notify: true,
         deadline: 60_000,
       },
       { registryPath: registryPath(), now: () => now },
@@ -831,6 +880,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         marker: "DONE",
+        notify: true,
         deadline: Number.MAX_SAFE_INTEGER,
       },
       { registryPath: registryPath(), now: () => now },
@@ -878,6 +928,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         change: "content",
+        notify: true,
         deadline: Number.MAX_SAFE_INTEGER,
       },
       { registryPath: registryPath(), now: () => now },
@@ -935,6 +986,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         marker: "DONE",
+        notify: true,
         deadline: 2_000,
       },
       { registryPath: registryPath(), now: () => 1_000 },
@@ -964,6 +1016,7 @@ describe("WatchSpec arm contract", () => {
         owner: "lead-a",
         target,
         marker: "DONE_P1",
+        notify: true,
         deadline: 60_000,
       },
       { registryPath: registryPath(), now: () => 1_000 },


### PR DESCRIPTION
## Summary

- Require explicit `notify: true` before a watch can emit an external notification, stopping the Telegram spam class by default.
- This D168-only change was split from #569 under Ruling 12.
- #569 remains open and unmerged pending a design pass for epoch/generation CAS prune liveness.
- The incident addressed here reached the user on 2026-08-27.
- This PR is the clean cherry-pick of `fe433d1` only: 4 files, +69/-1.
- D155 prune-truth is intentionally excluded and does not ship in 0.4.68.

## Verification

- `bun run typecheck`
- `bunx vitest run tests/watch-spec.test.ts tests/watch-spec-mcp.test.ts` — 31/31
- `bun run test` — 3579 passed, 1 skipped
- `env -u CMUX_SOCKET_PATH -u CMUXLAYER_DAEMON_SOCKET bun run test` — 3579 passed, 1 skipped
- `bun run pre-pr` — pass; P11 66/66; fast benchmark nonce `103f7d34-48c6-46a1-8f1e-8ec54fc85e0a`
- canonical socket benchmark — GREEN, nonce `0458b75c-99e2-4b4b-9002-e770d0aed24f`
- forced CLI fallback benchmark — expected RED, nonce `c139dffa-669b-4bc4-806e-3ce141d9b7c9`
- pre-push full suite — 3579 passed, 1 skipped
- bounded CodeRabbit CLI review — zero findings

— cmuxlayerCodex-a3e9331e (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-a3e9331e","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0421a","ts":"2026-08-30T09:42:41Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default notification behavior for all watches and may stop external alerts until callers opt in; local owner delivery paths are unchanged.
> 
> **Overview**
> **External watch notifications (HTTP/Telegram, etc.) now require `notify: true` on the watch spec.** Watches still fire and can wake the owner locally; only the configured external transport is skipped unless the watch opts in.
> 
> The optional `notify` flag is added to the MCP/schema `WatchSpec`, persisted on `WatchRecord`, and copied onto `WatchNotification` events. Server delivery logic uses `event.notify === true` before calling `opts.watchNotify`, and `httpNotifyWatch` returns success without HTTP when the flag is absent.
> 
> **Breaking behavior:** callers that relied on automatic external delivery must set `notify: true` when arming or waiting; otherwise injected notifiers stay silent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06690f9186017fbd8d29144c675e302457775eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate external watch notifications behind explicit `notify` opt-in
> - Adds an optional boolean `notify` field to `WatchSpec`, `WatchNotification`, `WatchSpecArgsSchema`, and the persisted `WatchRecord` so callers must explicitly opt in to external notification delivery.
> - In `createServer`'s `watchNotify` handler, external notifier invocations now use a local `externalNotify` that is only set when `event.notify === true`; local owner delivery remains unchanged.
> - `httpNotifyWatch` short-circuits and returns `true` without contacting the transport unless `event.notify === true`.
> - `armWatch` persists `notify: true` on the `WatchRecord` when the spec opts in, and `notificationFor` propagates it to emitted notifications.
> - Behavioral Change: watches armed before this change will no longer trigger external notifications unless re-armed with `notify: true`; the `isWatchRecord` type guard now accepts an optional boolean `notify` field and rejects non-boolean values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06690f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `notify` setting for watches.
  - External notifications are sent only when a watch explicitly enables notifications.
  - Notification preferences persist throughout the watch lifecycle.

- **Bug Fixes**
  - Prevented unintended external notification delivery for watches without explicit opt-in.

- **Tests**
  - Added coverage for enabled and disabled external notification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->