### PR TITLE
fix(watches): fire deadline-elapsed notices once

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6626,6 +6626,13 @@ export class AgentEngine {
     );
     await removeWatches(
       (watch) => {
+        // The predicate runs under the watch-registry write lock. If a sweep
+        // changed this row after our snapshot, retain it for the next prune.
+        if (
+          persistedWatchSnapshots.get(watch.watch_id) !== JSON.stringify(watch)
+        ) {
+          return false;
+        }
         if (watch.state === "failed" && !watch.notification_pending) {
           return true;
         }
@@ -6633,14 +6640,6 @@ export class AgentEngine {
           return false;
         }
         if (watch.notification_pending) return false;
-        // The predicate runs under the watch-registry write lock. If a sweep
-        // re-armed or otherwise changed this row after our liveness snapshot,
-        // retain it and let the next prune evaluate the fresh revision.
-        if (
-          persistedWatchSnapshots.get(watch.watch_id) !== JSON.stringify(watch)
-        ) {
-          return false;
-        }
         const subjects = (subjectIdsByWatch.get(watch.watch_id) ?? [])
           .map(
             (subjectAgentId) =>

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -8210,6 +8210,13 @@ export class AgentEngine {
           );
         },
       });
+      if (
+        readWatchRegistry({ registryPath: this.watchRegistryPath }).watches.some(
+          (watch) => watch.state === "failed" && !watch.notification_pending,
+        )
+      ) {
+        this.scheduleClosedChildReportWatchPrune();
+      }
     } catch {
       // Declared watches are retried on the next lifecycle sweep.
     } finally {
@@ -9366,9 +9373,10 @@ export class AgentEngine {
     });
     const releaseWaiterBestEffort = async (): Promise<void> => {
       try {
-        await releaseWatchWaiter(armed.watch_id, {
+        const released = await releaseWatchWaiter(armed.watch_id, {
           registryPath: this.watchRegistryPath,
         });
+        if (released) this.scheduleClosedChildReportWatchPrune();
       } catch (error) {
         this.sweepDebugLog(
           `[cmuxlayer] watch waiter release deferred: watch=${armed.watch_id} error=${error instanceof Error ? error.message : String(error)}`,

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -121,6 +121,7 @@ import type { CloseForensicsSweepResult } from "./close-forensics.js";
 import {
   armWatch as armDeclaredWatch,
   readWatchRegistry,
+  releaseWatchWaiter,
   removeWatches,
   sweepWatches,
   type WatchAgentObservation,
@@ -6562,6 +6563,7 @@ export class AgentEngine {
   private async pruneClosedChildReportWatches(): Promise<void> {
     if (!this.watchRegistryPath) return;
     const agents = this.registry.list();
+    const pruneObservedAt = Date.now();
     const byReportPath = new Map<string, AgentRecord[]>();
     for (const agent of agents) {
       if (!agent.report_path) continue;
@@ -6634,6 +6636,7 @@ export class AgentEngine {
           return false;
         }
         if (watch.state === "failed" && !watch.notification_pending) {
+          if ((watch.waiter_expires_at_ms ?? 0) > pruneObservedAt) return false;
           return true;
         }
         if (watch.target_kind !== "file" || watch.change !== "content") {
@@ -9356,7 +9359,12 @@ export class AgentEngine {
       throw new Error("WatchSpec registry is not configured");
     }
     const startedAt = Date.now();
-    const armed = await this.armWatch(spec);
+    const armed = await armDeclaredWatch(spec, {
+      registryPath: this.watchRegistryPath,
+      now: this.watchRegistryNow,
+      agentObservation: this.watchAgentObservation,
+      waiterExpiresAtMs: Date.now() + Math.max(0, timeoutMs) + 60_000,
+    });
     while (true) {
       const swept = await sweepWatches({
         registryPath: this.watchRegistryPath,
@@ -9371,21 +9379,27 @@ export class AgentEngine {
       });
       const current = readWatchRegistry({
         registryPath: this.watchRegistryPath,
-      }).watches.find((watch) => watch.watch_id === armed.watch_id) ??
-        swept.newly_failed_records.find(
-          (watch) => watch.watch_id === armed.watch_id,
-        );
+      }).watches.find((watch) => watch.watch_id === armed.watch_id);
       if (!current) {
         throw new Error(`Watch disappeared during wait: ${armed.watch_id}`);
       }
       const elapsed = Date.now() - startedAt;
       if (current.state === "fired" || swept.fired.includes(armed.watch_id)) {
+        await releaseWatchWaiter(armed.watch_id, {
+          registryPath: this.watchRegistryPath,
+        });
         return { matched: true, elapsed, watch: current };
       }
       if (current.state === "failed") {
+        await releaseWatchWaiter(armed.watch_id, {
+          registryPath: this.watchRegistryPath,
+        });
         return { matched: false, elapsed, watch: current };
       }
       if (elapsed >= timeoutMs) {
+        await releaseWatchWaiter(armed.watch_id, {
+          registryPath: this.watchRegistryPath,
+        });
         return { matched: false, elapsed, watch: current };
       }
       await new Promise<void>((resolveSleep) => {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6626,6 +6626,9 @@ export class AgentEngine {
     );
     await removeWatches(
       (watch) => {
+        if (watch.state === "failed" && !watch.notification_pending) {
+          return true;
+        }
         if (watch.target_kind !== "file" || watch.change !== "content") {
           return false;
         }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -9371,7 +9371,10 @@ export class AgentEngine {
       });
       const current = readWatchRegistry({
         registryPath: this.watchRegistryPath,
-      }).watches.find((watch) => watch.watch_id === armed.watch_id);
+      }).watches.find((watch) => watch.watch_id === armed.watch_id) ??
+        swept.newly_failed_records.find(
+          (watch) => watch.watch_id === armed.watch_id,
+        );
       if (!current) {
         throw new Error(`Watch disappeared during wait: ${armed.watch_id}`);
       }

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -6636,8 +6636,7 @@ export class AgentEngine {
           return false;
         }
         if (watch.state === "failed" && !watch.notification_pending) {
-          if ((watch.waiter_expires_at_ms ?? 0) > pruneObservedAt) return false;
-          return true;
+          return (watch.waiter_expires_at_ms ?? 0) <= pruneObservedAt;
         }
         if (watch.target_kind !== "file" || watch.change !== "content") {
           return false;
@@ -9365,6 +9364,17 @@ export class AgentEngine {
       agentObservation: this.watchAgentObservation,
       waiterExpiresAtMs: Date.now() + Math.max(0, timeoutMs) + 60_000,
     });
+    const releaseWaiterBestEffort = async (): Promise<void> => {
+      try {
+        await releaseWatchWaiter(armed.watch_id, {
+          registryPath: this.watchRegistryPath,
+        });
+      } catch (error) {
+        this.sweepDebugLog(
+          `[cmuxlayer] watch waiter release deferred: watch=${armed.watch_id} error=${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    };
     while (true) {
       const swept = await sweepWatches({
         registryPath: this.watchRegistryPath,
@@ -9385,21 +9395,15 @@ export class AgentEngine {
       }
       const elapsed = Date.now() - startedAt;
       if (current.state === "fired" || swept.fired.includes(armed.watch_id)) {
-        await releaseWatchWaiter(armed.watch_id, {
-          registryPath: this.watchRegistryPath,
-        });
+        await releaseWaiterBestEffort();
         return { matched: true, elapsed, watch: current };
       }
       if (current.state === "failed") {
-        await releaseWatchWaiter(armed.watch_id, {
-          registryPath: this.watchRegistryPath,
-        });
+        await releaseWaiterBestEffort();
         return { matched: false, elapsed, watch: current };
       }
       if (elapsed >= timeoutMs) {
-        await releaseWatchWaiter(armed.watch_id, {
-          registryPath: this.watchRegistryPath,
-        });
+        await releaseWaiterBestEffort();
         return { matched: false, elapsed, watch: current };
       }
       await new Promise<void>((resolveSleep) => {

--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -9383,40 +9383,41 @@ export class AgentEngine {
         );
       }
     };
-    while (true) {
-      const swept = await sweepWatches({
-        registryPath: this.watchRegistryPath,
-        now: this.watchRegistryNow,
-        agentObservation: this.watchAgentObservation,
-        notify: this.watchNotify,
-        onNotificationExhausted: ({ notification, attempts, reason }) => {
-          this.sweepDebugLog(
-            `[cmuxlayer] watch notification exhausted: watch=${notification.watch_id} owner=${notification.owner} attempts=${attempts} reason=${reason}`,
-          );
-        },
-      });
-      const current = readWatchRegistry({
-        registryPath: this.watchRegistryPath,
-      }).watches.find((watch) => watch.watch_id === armed.watch_id);
-      if (!current) {
-        throw new Error(`Watch disappeared during wait: ${armed.watch_id}`);
+    try {
+      while (true) {
+        const swept = await sweepWatches({
+          registryPath: this.watchRegistryPath,
+          now: this.watchRegistryNow,
+          agentObservation: this.watchAgentObservation,
+          notify: this.watchNotify,
+          onNotificationExhausted: ({ notification, attempts, reason }) => {
+            this.sweepDebugLog(
+              `[cmuxlayer] watch notification exhausted: watch=${notification.watch_id} owner=${notification.owner} attempts=${attempts} reason=${reason}`,
+            );
+          },
+        });
+        const current = readWatchRegistry({
+          registryPath: this.watchRegistryPath,
+        }).watches.find((watch) => watch.watch_id === armed.watch_id);
+        if (!current) {
+          throw new Error(`Watch disappeared during wait: ${armed.watch_id}`);
+        }
+        const elapsed = Date.now() - startedAt;
+        if (current.state === "fired" || swept.fired.includes(armed.watch_id)) {
+          return { matched: true, elapsed, watch: current };
+        }
+        if (current.state === "failed") {
+          return { matched: false, elapsed, watch: current };
+        }
+        if (elapsed >= timeoutMs) {
+          return { matched: false, elapsed, watch: current };
+        }
+        await new Promise<void>((resolveSleep) => {
+          setTimeout(resolveSleep, Math.min(50, timeoutMs - elapsed));
+        });
       }
-      const elapsed = Date.now() - startedAt;
-      if (current.state === "fired" || swept.fired.includes(armed.watch_id)) {
-        await releaseWaiterBestEffort();
-        return { matched: true, elapsed, watch: current };
-      }
-      if (current.state === "failed") {
-        await releaseWaiterBestEffort();
-        return { matched: false, elapsed, watch: current };
-      }
-      if (elapsed >= timeoutMs) {
-        await releaseWaiterBestEffort();
-        return { matched: false, elapsed, watch: current };
-      }
-      await new Promise<void>((resolveSleep) => {
-        setTimeout(resolveSleep, Math.min(50, timeoutMs - elapsed));
-      });
+    } finally {
+      await releaseWaiterBestEffort();
     }
   }
 

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -989,9 +989,9 @@ export async function sweepWatches(
     );
   }
 
-  // skipcq: JS-R1005
   await withWriteLock(path, () => {
     const registry = readRegistryState(path);
+    // skipcq: JS-R1005
     const watches = registry.rows.map((row) => {
       if (!isWatchRecord(row)) return row;
       const record = row;

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1199,15 +1199,16 @@ export async function sweepWatches(
           return record;
         }
         if (record.state === "failed") {
+          const attempts = (record.notification_attempts ?? 0) + 1;
           if (delivered) {
             return {
               ...record,
               notification_pending: false,
+              notification_attempts: attempts,
               notification_next_attempt_at_ms: undefined,
               notification_delivered_at_ms: observedAt,
             };
           }
-          const attempts = (record.notification_attempts ?? 0) + 1;
           const reason =
             terminalFailureReason ?? "terminal_notice_fire_once";
           exhausted = { notification, attempts, reason };

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -946,7 +946,6 @@ function notificationFor(
   };
 }
 
-// skipcq: JS-R1005 -- Keep observation, atomic registry transition, and notification settlement in one compatibility-critical sweep.
 export async function sweepWatches(
   opts: WatchSweepOptions = {},
 ): Promise<WatchSweepResult> {
@@ -990,6 +989,7 @@ export async function sweepWatches(
     );
   }
 
+  // skipcq: JS-R1005 -- Keep every registry transition in one atomic write-lock callback.
   await withWriteLock(path, () => {
     const registry = readRegistryState(path);
     const watches = registry.rows.map((row) => {

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1177,9 +1177,7 @@ export async function sweepWatches(
               notification_delivered_at_ms: observedAt,
             };
           }
-          const attempts =
-            (record.notification_attempts ?? 0) +
-            (terminalFailureReason ? 0 : 1);
+          const attempts = (record.notification_attempts ?? 0) + 1;
           const reason =
             terminalFailureReason ?? "terminal_notice_fire_once";
           exhausted = { notification, attempts, reason };

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -174,6 +174,8 @@ export interface WatchSweepOptions extends WatchRegistryOptions {
 export interface WatchSweepResult {
   fired: string[];
   failed: string[];
+  /** Final post-notification snapshots for watches that failed in this sweep. */
+  newly_failed_records: WatchRecord[];
   armed: string[];
 }
 
@@ -926,7 +928,13 @@ export async function sweepWatches(
   const path = registryPathFor(opts);
   const observedAt = nowMs(opts);
   const notifications: WatchNotification[] = [];
-  const result: WatchSweepResult = { fired: [], failed: [], armed: [] };
+  const result: WatchSweepResult = {
+    fired: [],
+    failed: [],
+    newly_failed_records: [],
+    armed: [],
+  };
+  const failedRecords = new Map<string, WatchRecord>();
 
   const snapshot = readRegistryState(path);
   const agentObservations = new Map<string, WatchAgentObservation>();
@@ -1027,7 +1035,7 @@ export async function sweepWatches(
         const notification = notificationFor(record, reason, observedAt);
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        const failedRecord: WatchRecord = {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1037,6 +1045,8 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
+        failedRecords.set(record.watch_id, failedRecord);
+        return failedRecord;
       }
 
       if (observedAt >= record.deadline) {
@@ -1047,7 +1057,7 @@ export async function sweepWatches(
         );
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        const failedRecord: WatchRecord = {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1057,6 +1067,8 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
+        failedRecords.set(record.watch_id, failedRecord);
+        return failedRecord;
       }
 
       const observedValue =
@@ -1109,7 +1121,7 @@ export async function sweepWatches(
         );
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        const failedRecord: WatchRecord = {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1120,6 +1132,8 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
+        failedRecords.set(record.watch_id, failedRecord);
+        return failedRecord;
       }
 
       result.armed.push(record.watch_id);
@@ -1170,18 +1184,20 @@ export async function sweepWatches(
         }
         if (record.state === "failed") {
           if (delivered) {
-            return {
+            const settledRecord: WatchRecord = {
               ...record,
               notification_pending: false,
               notification_next_attempt_at_ms: undefined,
               notification_delivered_at_ms: observedAt,
             };
+            failedRecords.set(record.watch_id, settledRecord);
+            return settledRecord;
           }
           const attempts = (record.notification_attempts ?? 0) + 1;
           const reason =
             terminalFailureReason ?? "terminal_notice_fire_once";
           exhausted = { notification, attempts, reason };
-          return {
+          const settledRecord: WatchRecord = {
             ...record,
             notification_pending: false,
             notification_attempts: attempts,
@@ -1189,6 +1205,8 @@ export async function sweepWatches(
             notification_exhausted_at_ms: observedAt,
             notification_exhausted_reason: reason,
           };
+          failedRecords.set(record.watch_id, settledRecord);
+          return settledRecord;
         }
         if (terminalFailureReason) {
           exhausted = {
@@ -1309,6 +1327,7 @@ export async function sweepWatches(
       }
     }
   }
+  result.newly_failed_records = [...failedRecords.values()];
   return result;
 }
 

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1168,6 +1168,30 @@ export async function sweepWatches(
         ) {
           return record;
         }
+        if (record.state === "failed") {
+          if (delivered) {
+            return {
+              ...record,
+              notification_pending: false,
+              notification_next_attempt_at_ms: undefined,
+              notification_delivered_at_ms: observedAt,
+            };
+          }
+          const attempts =
+            (record.notification_attempts ?? 0) +
+            (terminalFailureReason ? 0 : 1);
+          const reason =
+            terminalFailureReason ?? "terminal_notice_fire_once";
+          exhausted = { notification, attempts, reason };
+          return {
+            ...record,
+            notification_pending: false,
+            notification_attempts: attempts,
+            notification_next_attempt_at_ms: undefined,
+            notification_exhausted_at_ms: observedAt,
+            notification_exhausted_reason: reason,
+          };
+        }
         if (terminalFailureReason) {
           exhausted = {
             notification,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -989,7 +989,8 @@ export async function sweepWatches(
     );
   }
 
-  await withWriteLock(path, () => { // skipcq: JS-R1005
+  // skipcq: JS-R1005
+  await withWriteLock(path, () => {
     const registry = readRegistryState(path);
     const watches = registry.rows.map((row) => {
       if (!isWatchRecord(row)) return row;

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -67,6 +67,7 @@ export interface WatchRecord extends WatchSpec {
   notification_delivered_at_ms?: number;
   notification_exhausted_at_ms?: number;
   notification_exhausted_reason?: string;
+  waiter_expires_at_ms?: number;
 }
 
 export interface WatchRegistryFile {
@@ -145,6 +146,7 @@ export interface WatchAgentObservation {
 export interface WatchRegistryOptions {
   registryPath?: string;
   now?: () => number;
+  waiterExpiresAtMs?: number;
   contentFingerprintIo?: WatchContentFingerprintIo;
   agentObservation?: (
     agentId: string,
@@ -174,8 +176,6 @@ export interface WatchSweepOptions extends WatchRegistryOptions {
 export interface WatchSweepResult {
   fired: string[];
   failed: string[];
-  /** Final post-notification snapshots for watches that failed in this sweep. */
-  newly_failed_records: WatchRecord[];
   armed: string[];
 }
 
@@ -277,7 +277,9 @@ function hasValidNotificationMetadata(
     (value.notification_exhausted_at_ms === undefined ||
       isFiniteNumber(value.notification_exhausted_at_ms)) &&
     (value.notification_exhausted_reason === undefined ||
-      Boolean(cleanString(value.notification_exhausted_reason)))
+      Boolean(cleanString(value.notification_exhausted_reason))) &&
+    (value.waiter_expires_at_ms === undefined ||
+      isFiniteNumber(value.waiter_expires_at_ms))
   );
 }
 
@@ -851,6 +853,9 @@ export async function armWatch(
     liveness_source: agentObservation?.source ?? target,
     liveness: { value: true, source, observed_at_ms: observedAt },
     state: "armed",
+    ...(isFiniteNumber(opts.waiterExpiresAtMs)
+      ? { waiter_expires_at_ms: opts.waiterExpiresAtMs }
+      : {}),
   };
 
   const path = registryPathFor(opts);
@@ -876,6 +881,25 @@ export function removeWatches(
     });
     if (removed > 0) writeRegistry(path, registry.version, rows);
     return removed;
+  });
+}
+
+export function releaseWatchWaiter(
+  watchId: string,
+  opts: WatchRegistryOptions = {},
+): Promise<boolean> {
+  const path = registryPathFor(opts);
+  return withWriteLock(path, () => {
+    const registry = readRegistryState(path);
+    let released = false;
+    const rows = registry.rows.map((row) => {
+      if (!isWatchRecord(row) || row.watch_id !== watchId) return row;
+      const { waiter_expires_at_ms: _waiterExpiry, ...record } = row;
+      released = true;
+      return record;
+    });
+    if (released) writeRegistry(path, registry.version, rows);
+    return released;
   });
 }
 
@@ -931,10 +955,8 @@ export async function sweepWatches(
   const result: WatchSweepResult = {
     fired: [],
     failed: [],
-    newly_failed_records: [],
     armed: [],
   };
-  const failedRecords = new Map<string, WatchRecord>();
 
   const snapshot = readRegistryState(path);
   const agentObservations = new Map<string, WatchAgentObservation>();
@@ -1035,7 +1057,7 @@ export async function sweepWatches(
         const notification = notificationFor(record, reason, observedAt);
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        const failedRecord: WatchRecord = {
+        return {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1045,8 +1067,6 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
-        failedRecords.set(record.watch_id, failedRecord);
-        return failedRecord;
       }
 
       if (observedAt >= record.deadline) {
@@ -1057,7 +1077,7 @@ export async function sweepWatches(
         );
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        const failedRecord: WatchRecord = {
+        return {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1067,8 +1087,6 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
-        failedRecords.set(record.watch_id, failedRecord);
-        return failedRecord;
       }
 
       const observedValue =
@@ -1121,7 +1139,7 @@ export async function sweepWatches(
         );
         notifications.push(notification);
         result.failed.push(record.watch_id);
-        const failedRecord: WatchRecord = {
+        return {
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1132,8 +1150,6 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
-        failedRecords.set(record.watch_id, failedRecord);
-        return failedRecord;
       }
 
       result.armed.push(record.watch_id);
@@ -1184,20 +1200,18 @@ export async function sweepWatches(
         }
         if (record.state === "failed") {
           if (delivered) {
-            const settledRecord: WatchRecord = {
+            return {
               ...record,
               notification_pending: false,
               notification_next_attempt_at_ms: undefined,
               notification_delivered_at_ms: observedAt,
             };
-            failedRecords.set(record.watch_id, settledRecord);
-            return settledRecord;
           }
           const attempts = (record.notification_attempts ?? 0) + 1;
           const reason =
             terminalFailureReason ?? "terminal_notice_fire_once";
           exhausted = { notification, attempts, reason };
-          const settledRecord: WatchRecord = {
+          return {
             ...record,
             notification_pending: false,
             notification_attempts: attempts,
@@ -1205,8 +1219,6 @@ export async function sweepWatches(
             notification_exhausted_at_ms: observedAt,
             notification_exhausted_reason: reason,
           };
-          failedRecords.set(record.watch_id, settledRecord);
-          return settledRecord;
         }
         if (terminalFailureReason) {
           exhausted = {
@@ -1327,7 +1339,6 @@ export async function sweepWatches(
       }
     }
   }
-  result.newly_failed_records = [...failedRecords.values()];
   return result;
 }
 

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1009,7 +1009,7 @@ export async function sweepWatches(
         ) {
           const notification = notificationFor(
             migrated,
-            migrated.terminal_reason!,
+            record.terminal_reason,
             migrated.terminal_at_ms ?? observedAt,
             migrated.observed_value,
           );

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -952,6 +952,22 @@ export async function sweepWatches(
   const path = registryPathFor(opts);
   const observedAt = nowMs(opts);
   const notifications: WatchNotification[] = [];
+  const claimedFailedWatchIds = new Set<string>();
+  const claimFailedNotification = (
+    record: WatchRecord,
+    notification: WatchNotification,
+  ): WatchRecord => {
+    notifications.push(notification);
+    claimedFailedWatchIds.add(record.watch_id);
+    return {
+      ...record,
+      notification_pending: false,
+      notification_attempts: (record.notification_attempts ?? 0) + 1,
+      notification_next_attempt_at_ms: undefined,
+      notification_exhausted_at_ms: observedAt,
+      notification_exhausted_reason: "terminal_notice_fire_once",
+    };
+  };
   const result: WatchSweepResult = {
     fired: [],
     failed: [],
@@ -989,14 +1005,16 @@ export async function sweepWatches(
             record.notification_next_attempt_at_ms ?? observedAt,
         };
         if (migrated.notification_next_attempt_at_ms! <= observedAt) {
-          notifications.push(
-            notificationFor(
-              migrated,
-              migrated.terminal_reason!,
-              migrated.terminal_at_ms ?? observedAt,
-              migrated.observed_value,
-            ),
+          const notification = notificationFor(
+            migrated,
+            migrated.terminal_reason!,
+            migrated.terminal_at_ms ?? observedAt,
+            migrated.observed_value,
           );
+          if (migrated.state === "failed") {
+            return claimFailedNotification(migrated, notification);
+          }
+          notifications.push(notification);
         }
         return migrated;
       }
@@ -1006,14 +1024,16 @@ export async function sweepWatches(
           record.terminal_reason &&
           (record.notification_next_attempt_at_ms ?? 0) <= observedAt
         ) {
-          notifications.push(
-            notificationFor(
-              record,
-              record.terminal_reason,
-              record.terminal_at_ms ?? observedAt,
-              record.observed_value,
-            ),
+          const notification = notificationFor(
+            record,
+            record.terminal_reason,
+            record.terminal_at_ms ?? observedAt,
+            record.observed_value,
           );
+          if (record.state === "failed") {
+            return claimFailedNotification(record, notification);
+          }
+          notifications.push(notification);
         }
         return record;
       }
@@ -1055,9 +1075,8 @@ export async function sweepWatches(
         const reason: WatchNotificationReason =
           record.target_kind === "agent" ? "consumer_died" : "target_missing";
         const notification = notificationFor(record, reason, observedAt);
-        notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        return claimFailedNotification({
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1066,7 +1085,7 @@ export async function sweepWatches(
           notification_pending: true,
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
-        };
+        }, notification);
       }
 
       if (observedAt >= record.deadline) {
@@ -1075,9 +1094,8 @@ export async function sweepWatches(
           "deadline_elapsed",
           observedAt,
         );
-        notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        return claimFailedNotification({
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1086,7 +1104,7 @@ export async function sweepWatches(
           notification_pending: true,
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
-        };
+        }, notification);
       }
 
       const observedValue =
@@ -1137,9 +1155,8 @@ export async function sweepWatches(
           observedAt,
           observedValue,
         );
-        notifications.push(notification);
         result.failed.push(record.watch_id);
-        return {
+        return claimFailedNotification({
           ...record,
           ...heartbeat,
           state: "failed" as const,
@@ -1149,7 +1166,7 @@ export async function sweepWatches(
           notification_pending: true,
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
-        };
+        }, notification);
       }
 
       result.armed.push(record.watch_id);
@@ -1192,17 +1209,22 @@ export async function sweepWatches(
       const watches = registry.rows.map((row) => {
         if (!isWatchRecord(row)) return row;
         const record = row;
-        if (
-          record.watch_id !== notification.watch_id ||
-          !record.notification_pending
-        ) {
+        if (record.watch_id !== notification.watch_id) {
           return record;
         }
-        if (record.state === "failed") {
-          const attempts = (record.notification_attempts ?? 0) + 1;
+        if (
+          record.state === "failed" &&
+          claimedFailedWatchIds.has(record.watch_id)
+        ) {
+          const attempts = record.notification_attempts ?? 1;
           if (delivered) {
+            const {
+              notification_exhausted_at_ms: _exhaustedAt,
+              notification_exhausted_reason: _exhaustedReason,
+              ...claimed
+            } = record;
             return {
-              ...record,
+              ...claimed,
               notification_pending: false,
               notification_attempts: attempts,
               notification_next_attempt_at_ms: undefined,
@@ -1221,6 +1243,7 @@ export async function sweepWatches(
             notification_exhausted_reason: reason,
           };
         }
+        if (!record.notification_pending) return record;
         if (terminalFailureReason) {
           exhausted = {
             notification,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -946,23 +946,7 @@ function notificationFor(
   };
 }
 
-async function collectAgentObservations(
-  records: WatchRecord[],
-  observer: WatchSweepOptions["agentObservation"],
-): Promise<Map<string, WatchAgentObservation>> {
-  const observations = new Map<string, WatchAgentObservation>();
-  for (const record of records) {
-    if (record.state !== "armed" || record.target_kind !== "agent") continue;
-    if (!observer) {
-      throw new Error(
-        "Agent WatchSpec sweep requires an independent observation provider",
-      );
-    }
-    observations.set(record.target, await observer(record.target));
-  }
-  return observations;
-}
-
+// skipcq: JS-R1005 -- Keep observation, atomic registry transition, and notification settlement in one compatibility-critical sweep.
 export async function sweepWatches(
   opts: WatchSweepOptions = {},
 ): Promise<WatchSweepResult> {
@@ -992,10 +976,19 @@ export async function sweepWatches(
   };
 
   const snapshot = readRegistryState(path);
-  const agentObservations = await collectAgentObservations(
-    snapshot.watches,
-    opts.agentObservation,
-  );
+  const agentObservations = new Map<string, WatchAgentObservation>();
+  for (const record of snapshot.watches) {
+    if (record.state !== "armed" || record.target_kind !== "agent") continue;
+    if (!opts.agentObservation) {
+      throw new Error(
+        "Agent WatchSpec sweep requires an independent observation provider",
+      );
+    }
+    agentObservations.set(
+      record.target,
+      await opts.agentObservation(record.target),
+    );
+  }
 
   await withWriteLock(path, () => {
     const registry = readRegistryState(path);

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -946,6 +946,23 @@ function notificationFor(
   };
 }
 
+async function collectAgentObservations(
+  records: WatchRecord[],
+  observer: WatchSweepOptions["agentObservation"],
+): Promise<Map<string, WatchAgentObservation>> {
+  const observations = new Map<string, WatchAgentObservation>();
+  for (const record of records) {
+    if (record.state !== "armed" || record.target_kind !== "agent") continue;
+    if (!observer) {
+      throw new Error(
+        "Agent WatchSpec sweep requires an independent observation provider",
+      );
+    }
+    observations.set(record.target, await observer(record.target));
+  }
+  return observations;
+}
+
 export async function sweepWatches(
   opts: WatchSweepOptions = {},
 ): Promise<WatchSweepResult> {
@@ -975,19 +992,10 @@ export async function sweepWatches(
   };
 
   const snapshot = readRegistryState(path);
-  const agentObservations = new Map<string, WatchAgentObservation>();
-  for (const record of snapshot.watches) {
-    if (record.state !== "armed" || record.target_kind !== "agent") continue;
-    if (!opts.agentObservation) {
-      throw new Error(
-        "Agent WatchSpec sweep requires an independent observation provider",
-      );
-    }
-    agentObservations.set(
-      record.target,
-      await opts.agentObservation(record.target),
-    );
-  }
+  const agentObservations = await collectAgentObservations(
+    snapshot.watches,
+    opts.agentObservation,
+  );
 
   await withWriteLock(path, () => {
     const registry = readRegistryState(path);

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -989,8 +989,7 @@ export async function sweepWatches(
     );
   }
 
-  // skipcq: JS-R1005 -- Keep every registry transition in one atomic write-lock callback.
-  await withWriteLock(path, () => {
+  await withWriteLock(path, () => { // skipcq: JS-R1005
     const registry = readRegistryState(path);
     const watches = registry.rows.map((row) => {
       if (!isWatchRecord(row)) return row;

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -1004,7 +1004,9 @@ export async function sweepWatches(
           notification_next_attempt_at_ms:
             record.notification_next_attempt_at_ms ?? observedAt,
         };
-        if (migrated.notification_next_attempt_at_ms! <= observedAt) {
+        if (
+          (migrated.notification_next_attempt_at_ms ?? observedAt) <= observedAt
+        ) {
           const notification = notificationFor(
             migrated,
             migrated.terminal_reason!,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -903,6 +903,24 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,
     ).toHaveLength(1);
 
+    (
+      engine as unknown as {
+        childReportWatchPrunePending: boolean;
+      }
+    ).childReportWatchPrunePending = false;
+    await (
+      engine as unknown as {
+        sweepWatchesBestEffort: () => Promise<void>;
+      }
+    ).sweepWatchesBestEffort();
+    expect(
+      (
+        engine as unknown as {
+          childReportWatchPrunePending: boolean;
+        }
+      ).childReportWatchPrunePending,
+    ).toBe(true);
+
     const retainedRegistry = JSON.parse(
       readFileSync(watchRegistryPath, "utf8"),
     );
@@ -915,9 +933,9 @@ describe("P11 spawn_agent issues the coordination contract", () => {
 
     await (
       engine as unknown as {
-        pruneClosedChildReportWatches: () => Promise<void>;
+        retryClosedChildReportWatchPrune: () => Promise<void>;
       }
-    ).pruneClosedChildReportWatches();
+    ).retryClosedChildReportWatchPrune();
 
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -867,6 +867,105 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ]);
   });
 
+  it("prunes a settled failed watch on the next prune pass", async () => {
+    const engine = server._registeredTools.interact._engine;
+    const target = join(inboxDir, "settled-deadline.md");
+    writeFileSync(target, "", "utf8");
+    await engine.armWatch({
+      owner: "lead-parent",
+      target,
+      marker: "DONE",
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+    const registryFile = JSON.parse(readFileSync(watchRegistryPath, "utf8"));
+    registryFile.watches[0] = {
+      ...registryFile.watches[0],
+      state: "failed",
+      terminal_reason: "deadline_elapsed",
+      terminal_at_ms: 2_000,
+      notification_pending: false,
+      notification_attempts: 1,
+    };
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify(registryFile, null, 2)}\n`,
+      "utf8",
+    );
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([]);
+  });
+
+  it("fires a deadline-elapsed wait notice once and never again after restart", async () => {
+    await server.close();
+    let watchNow = 1_000;
+    const localDeadlineNotice = vi.fn().mockResolvedValue(false);
+    const serverOptions = withTestSurfaceObserver({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+      watchRegistryPath,
+      watchRegistryNow: () => watchNow,
+    });
+    server = createServer(serverOptions);
+    let engine = server._registeredTools.interact._engine;
+    engine.stateMgr.writeState(parentRecord());
+    engine.getRegistry().set("lead-parent", parentRecord());
+    (
+      engine as unknown as {
+        watchNotify: typeof localDeadlineNotice;
+      }
+    ).watchNotify = localDeadlineNotice;
+    const target = join(inboxDir, "deadline-fire-once.md");
+    writeFileSync(target, "", "utf8");
+    setTimeout(() => {
+      watchNow = 2_000;
+    }, 10);
+
+    const first = await engine.waitForWatch(
+      {
+        owner: "lead-parent",
+        target,
+        marker: "DONE",
+        deadline: 2_000,
+      },
+      500,
+    );
+
+    expect(first.watch).toMatchObject({
+      state: "failed",
+      terminal_reason: "deadline_elapsed",
+    });
+    expect(localDeadlineNotice).toHaveBeenCalledTimes(1);
+
+    await server.close();
+    watchNow = 3_000;
+    server = createServer(serverOptions);
+    engine = server._registeredTools.interact._engine;
+    engine.stateMgr.writeState(parentRecord());
+    engine.getRegistry().set("lead-parent", parentRecord());
+    (
+      engine as unknown as {
+        watchNotify: typeof localDeadlineNotice;
+      }
+    ).watchNotify = localDeadlineNotice;
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    await engine.sweepWatchesBestEffort();
+
+    expect(localDeadlineNotice).toHaveBeenCalledTimes(1);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([]);
+  });
+
   it("resolves a legacy bare owner seat to the live suffixed lead before delivery", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -974,6 +974,67 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ).toEqual([]);
   });
 
+  it("returns the failed deadline verdict when a concurrent prune removes its row", async () => {
+    await server.close();
+    let watchNow = 1_000;
+    const localDeadlineNotice = vi.fn().mockResolvedValue(false);
+    server = createServer(
+      withTestSurfaceObserver({
+        exec,
+        stateDir: STATE_DIR,
+        disableSpawnPreflight: true,
+        inboxBaseDir: inboxDir,
+        watchRegistryPath,
+        watchRegistryNow: () => watchNow,
+      }),
+    );
+    const engine = server._registeredTools.interact._engine;
+    engine.stateMgr.writeState(parentRecord());
+    engine.getRegistry().set("lead-parent", parentRecord());
+    (
+      engine as unknown as {
+        watchNotify: typeof localDeadlineNotice;
+        sweepDebugLog: () => void;
+      }
+    ).watchNotify = localDeadlineNotice;
+    (
+      engine as unknown as {
+        sweepDebugLog: () => void;
+      }
+    ).sweepDebugLog = () => {
+      writeFileSync(
+        watchRegistryPath,
+        `${JSON.stringify({ version: 1, watches: [] }, null, 2)}\n`,
+        "utf8",
+      );
+    };
+    const target = join(inboxDir, "deadline-pruned-during-wait.md");
+    writeFileSync(target, "", "utf8");
+    setTimeout(() => {
+      watchNow = 2_000;
+    }, 10);
+
+    const result = await engine.waitForWatch(
+      {
+        owner: "lead-parent",
+        target,
+        marker: "DONE",
+        deadline: 2_000,
+      },
+      500,
+    );
+
+    expect(localDeadlineNotice).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      matched: false,
+      watch: {
+        state: "failed",
+        terminal_reason: "deadline_elapsed",
+        notification_pending: false,
+      },
+    });
+  });
+
   it("resolves a legacy bare owner seat to the live suffixed lead before delivery", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -867,7 +867,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     ]);
   });
 
-  it("prunes a settled failed watch on the next prune pass", async () => {
+  it("retains a settled failed watch for its waiter, then prunes after release", async () => {
     const engine = server._registeredTools.interact._engine;
     const target = join(inboxDir, "settled-deadline.md");
     writeFileSync(target, "", "utf8");
@@ -885,10 +885,31 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       terminal_at_ms: 2_000,
       notification_pending: false,
       notification_attempts: 1,
+      waiter_expires_at_ms: Date.now() + 60_000,
     };
     writeFileSync(
       watchRegistryPath,
       `${JSON.stringify(registryFile, null, 2)}\n`,
+      "utf8",
+    );
+
+    await (
+      engine as unknown as {
+        pruneClosedChildReportWatches: () => Promise<void>;
+      }
+    ).pruneClosedChildReportWatches();
+
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toHaveLength(1);
+
+    const retainedRegistry = JSON.parse(
+      readFileSync(watchRegistryPath, "utf8"),
+    );
+    delete retainedRegistry.watches[0].waiter_expires_at_ms;
+    writeFileSync(
+      watchRegistryPath,
+      `${JSON.stringify(retainedRegistry, null, 2)}\n`,
       "utf8",
     );
 
@@ -945,14 +966,16 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       terminal_reason: "deadline_elapsed",
     });
     expect(localDeadlineNotice).toHaveBeenCalledTimes(1);
-    expect(
-      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
-    ).toMatchObject({
+    const settled = readWatchRegistry({
+      registryPath: watchRegistryPath,
+    }).watches[0];
+    expect(settled).toMatchObject({
       state: "failed",
       notification_pending: false,
       notification_attempts: 1,
       notification_exhausted_reason: "terminal_notice_fire_once",
     });
+    expect(settled).not.toHaveProperty("waiter_expires_at_ms");
 
     await server.close();
     watchNow = 3_000;
@@ -972,67 +995,6 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches,
     ).toEqual([]);
-  });
-
-  it("returns the failed deadline verdict when a concurrent prune removes its row", async () => {
-    await server.close();
-    let watchNow = 1_000;
-    const localDeadlineNotice = vi.fn().mockResolvedValue(false);
-    server = createServer(
-      withTestSurfaceObserver({
-        exec,
-        stateDir: STATE_DIR,
-        disableSpawnPreflight: true,
-        inboxBaseDir: inboxDir,
-        watchRegistryPath,
-        watchRegistryNow: () => watchNow,
-      }),
-    );
-    const engine = server._registeredTools.interact._engine;
-    engine.stateMgr.writeState(parentRecord());
-    engine.getRegistry().set("lead-parent", parentRecord());
-    (
-      engine as unknown as {
-        watchNotify: typeof localDeadlineNotice;
-        sweepDebugLog: () => void;
-      }
-    ).watchNotify = localDeadlineNotice;
-    (
-      engine as unknown as {
-        sweepDebugLog: () => void;
-      }
-    ).sweepDebugLog = () => {
-      writeFileSync(
-        watchRegistryPath,
-        `${JSON.stringify({ version: 1, watches: [] }, null, 2)}\n`,
-        "utf8",
-      );
-    };
-    const target = join(inboxDir, "deadline-pruned-during-wait.md");
-    writeFileSync(target, "", "utf8");
-    setTimeout(() => {
-      watchNow = 2_000;
-    }, 10);
-
-    const result = await engine.waitForWatch(
-      {
-        owner: "lead-parent",
-        target,
-        marker: "DONE",
-        deadline: 2_000,
-      },
-      500,
-    );
-
-    expect(localDeadlineNotice).toHaveBeenCalledOnce();
-    expect(result).toMatchObject({
-      matched: false,
-      watch: {
-        state: "failed",
-        terminal_reason: "deadline_elapsed",
-        notification_pending: false,
-      },
-    });
   });
 
   it("resolves a legacy bare owner seat to the live suffixed lead before delivery", async () => {

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -945,6 +945,14 @@ describe("P11 spawn_agent issues the coordination contract", () => {
       terminal_reason: "deadline_elapsed",
     });
     expect(localDeadlineNotice).toHaveBeenCalledTimes(1);
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+    ).toMatchObject({
+      state: "failed",
+      notification_pending: false,
+      notification_attempts: 1,
+      notification_exhausted_reason: "terminal_notice_fire_once",
+    });
 
     await server.close();
     watchNow = 3_000;

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -1013,6 +1013,52 @@ describe("WatchSpec arm contract", () => {
     });
   });
 
+  it("claims a failed notice before dispatch so concurrent sweepers fire once", async () => {
+    const target = join(TEST_DIR, "concurrent-deadline.md");
+    writeFileSync(target, "", "utf8");
+    await armWatch(
+      {
+        owner: "lead-a",
+        target,
+        marker: "DONE",
+        deadline: 2_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    let finishDelivery!: (delivered: boolean) => void;
+    const notify = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishDelivery = resolve;
+        }),
+    );
+
+    const firstSweep = sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledOnce());
+    const secondSweep = sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+    await secondSweep;
+
+    expect(notify).toHaveBeenCalledOnce();
+    finishDelivery(true);
+    await firstSweep;
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      state: "failed",
+      notification_pending: false,
+      notification_attempts: 1,
+      notification_delivered_at_ms: 2_000,
+    });
+  });
+
   it("fires a marker watch on count increase only", async () => {
     const target = join(TEST_DIR, "findings.md");
     writeFileSync(target, "DONE_P1\n", "utf8");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -1004,7 +1004,13 @@ describe("WatchSpec arm contract", () => {
     );
     expect(
       readWatchRegistry({ registryPath: registryPath() }).watches[0],
-    ).toMatchObject({ state: "failed", terminal_reason: "deadline_elapsed" });
+    ).toMatchObject({
+      state: "failed",
+      terminal_reason: "deadline_elapsed",
+      notification_pending: false,
+      notification_attempts: 1,
+      notification_delivered_at_ms: 2_000,
+    });
   });
 
   it("fires a marker watch on count increase only", async () => {


### PR DESCRIPTION
## Incident

On 2026-08-30, deadline-elapsed watches repeatedly injected the same local lifecycle notice into a live owner pane after daemon restarts, burning Stop-hook turns. This is separate from D168: that gate covers only the external fallback, while this incident uses `lifecycleAgentInputDeliverer` directly.

## Fix

- Atomically claim each failed-watch notice in the shared registry before dispatch, so concurrent engines cannot both send it; record the single attempt whether delivery succeeds or fails.
- Persist an expiring waiter lease so every process retains a terminal verdict until the waiting caller consumes it; release is best-effort and expiry provides crash recovery.
- Remove settled failed rows at the next prune after lease release/expiry, before report-watch liveness and owner-resolution logic.
- Cover the one-second never-matched deadline across restart, durable attempt accounting, waiter retention/release, and next-prune removal.

This PR does not change locking, owner resolution, or report-watch liveness semantics. #569 remains open and unmerged.

Both Run 9 live incidents used `/tmp` targets. That correlation is recorded for the design pass and intentionally not investigated here.

## Verification — exact head `fddaba57c9ce73fa7e7d9b148720fd6a9b665dcb`

- RED before fix: repeat notice after restart and settled failed-row retention both failed.
- Focused watch/P11/format suite: 79/79 pass, including two concurrent sweepers around a delayed notifier.
- Full suite, ambient env: 154/154 files; 3,583 pass; 1 skip.
- Full suite with `CMUX_SOCKET_PATH` and `CMUXLAYER_DAEMON_SOCKET` unset: 154/154 files; 3,583 pass; 1 skip.
- Typecheck and `bun run pre-pr`: pass; harness 66/66.
- Fast benchmark GREEN: `40129201-b51b-4c5f-8e3c-3a67ccba81e2`.
- Canonical 8x12 socket benchmark GREEN: `b923c498-4e71-4a62-8cd7-4aa2d7da4134`.
- Forced-CLI control expected RED: `dc97d8b5-18d4-454c-9059-7c4b5f2c332a`; all replay operations used CLI.
- Prior exact-head canonical noise receipt retained in the audit: `7ac4124e-0a76-4b56-9786-269424f2519f` RED solely on -0.53 MB RSS, with every latency and transport row passing.
- Local CodeRabbit reviewed the waiter-lease patch with no findings; its later follow-up attempt was rate-limited. Remote reviewers subsequently identified successful-attempt accounting and best-effort release, both fixed in the exact head above.

— cmuxlayerCodex-a3e9331e (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-a3e9331e","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0421a","ts":"2026-08-30T11:20:27Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes watch notification persistence and pruning around failed terminals and restarts; incorrect claiming or lease timing could drop rows early or still duplicate notices, but scope is limited to watch registry behavior.
> 
> **Overview**
> Fixes **duplicate lifecycle notices** after daemon restarts when a watch has already failed (e.g. deadline elapsed) by making failed-terminal notifications **claim-and-fire-once** in the shared registry during `sweepWatches`, so concurrent sweepers or a post-restart sweep cannot dispatch the same notice again.
> 
> Adds a **`waiter_expires_at_ms` lease** when `waitForWatch` arms a watch (timeout plus grace), **`releaseWatchWaiter`** on exit, and extends **`pruneClosedChildReportWatches`** to drop settled failed rows only after the lease is released or expired—while scheduling that prune when sweeps leave such rows behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e7ec33bf04e3b63008c17cee34e687e54850d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `sweepWatches` to fire deadline-elapsed notices once per failed watch
> - Failed watch notifications are now claimed before dispatch in `sweepWatches`, so only one sweeper sends the notice and the record is settled immediately with `notification_exhausted_reason='terminal_notice_fire_once'`
> - Adds `waiter_expires_at_ms` to `WatchRecord`; `waitForWatch` sets it to `now + timeoutMs + 60s` and clears it via the new `releaseWatchWaiter` on exit
> - `pruneClosedChildReportWatches` now retains settled failed watches until their `waiter_expires_at_ms` has passed, and `sweepWatchesBestEffort` schedules a prune pass when failed watches are detected
> - Risk: any code outside the tree that reads the registry must tolerate the new optional `waiter_expires_at_ms` field; `hasValidNotificationMetadata` in [watch-spec.ts](https://github.com/EtanHey/cmuxlayer/pull/572/files#diff-89bd36d2646bf04179ce3a04a7f876f6dc681b396e2c4a980ecdd27178926d02) is updated to permit it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e7ec33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved watch notifications to ensure deadline and failure alerts are delivered at most once.
  - Prevented active waiters from losing failed watch results before they can be retrieved.
  - Improved cleanup of completed and failed watches after their waiting period expires.
  - Added safeguards against duplicate notifications during concurrent processing or service restarts.
- **Reliability**
  - Watch status and notification outcomes are now persisted more consistently, providing clearer results after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->