### PR TITLE
ci: make daemon performance budgets truthful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: docs.local/scratch/perf-budget/history.json
-          key: daemon-perf-history-main-${{ github.run_id }}
-          restore-keys: daemon-perf-history-main-
+          key: daemon-perf-history-main-${{ hashFiles('benchmarks/daemon-baseline.json') }}-${{ github.run_id }}
+          restore-keys: daemon-perf-history-main-${{ hashFiles('benchmarks/daemon-baseline.json') }}-
 
       - name: Run daemon performance budget
         run: bun run bench:daemon:check
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: docs.local/scratch/perf-budget/history.json
-          key: daemon-perf-history-main-${{ github.run_id }}
+          key: daemon-perf-history-main-${{ hashFiles('benchmarks/daemon-baseline.json') }}-${{ github.run_id }}
 
       - name: Upload performance evidence
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,23 @@ jobs:
 
       - run: rm -f package-lock.json
       - run: bun install
+
+      - name: Restore bounded green-main benchmark history
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: docs.local/scratch/perf-budget/history.json
+          key: daemon-perf-history-main-${{ github.run_id }}
+          restore-keys: daemon-perf-history-main-
+
       - name: Run daemon performance budget
         run: bun run bench:daemon:check
+
+      - name: Save bounded green-main benchmark history
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: docs.local/scratch/perf-budget/history.json
+          key: daemon-perf-history-main-${{ github.run_id }}
 
       - name: Upload performance evidence
         if: always()

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "c210a9a320556faf112eddf7a073967c2b2c95fa",
-    "measured_at": "2026-08-30T15:21:42.118Z",
+    "git_sha": "9960960f8a75f1c4947d3f5a6fe1f16b0e647f1f",
+    "measured_at": "2026-08-30T15:35:23.831Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33319012094,
-    "increase_reason": "migrate legacy single-shot rows to canonical sampled 10-row runner evidence"
+    "workflow_run_id": 33319637454,
+    "increase_reason": "incorporate second canonical runner sample after measured-ratchet RED"
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -122,12 +122,12 @@
     "send_to_surface_warm": {
       "p50_ms": 64.52,
       "p95_ms": 71.2,
-      "lock_hold_ms": 104
+      "lock_hold_ms": 178
     },
     "send_to_agent_warm": {
       "p50_ms": 92.77,
-      "p95_ms": 110.39,
-      "lock_hold_ms": 75
+      "p95_ms": 122.59,
+      "lock_hold_ms": 200
     },
     "list_agents": {
       "p50_ms": 67.66,
@@ -141,18 +141,18 @@
     },
     "spawn_close_during_sweep": {
       "p50_ms": 45.91,
-      "p95_ms": 59.61,
+      "p95_ms": 143.28,
       "lock_hold_ms": 0
     },
     "first_send_after_spawn": {
       "p50_ms": 74.06,
       "p95_ms": 86.29,
-      "lock_hold_ms": 66
+      "lock_hold_ms": 120
     },
     "send_to_surface_10_parallel": {
       "p50_ms": 116.48,
-      "p95_ms": 151.43,
-      "lock_hold_ms": 125
+      "p95_ms": 368.97,
+      "lock_hold_ms": 353
     },
     "read_screen_10_parallel": {
       "p50_ms": 30.27,
@@ -163,6 +163,6 @@
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "69c66175d79104a9bd2937ba834d719276f40251f3c98c6021f81a3e44def9a2"
+    "content_sha256": "f792518e5f3ab80dd4193817e458292156f857468f1c7b3e82040e42a1e7d6d7"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "7e1bb96f9fc82d6f7676043b75dcaf1ed1c31837",
-    "measured_at": "2026-08-26T16:33:17.727Z",
+    "git_sha": "06499d9485fec00ef8e5f5bdd50fd5b224257e23",
+    "measured_at": "2026-08-30T14:53:59.623Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 32988968639
+    "workflow_run_id": 33317747972,
+    "increase_reason": "migrate legacy single-shot rows to canonical sampled 10-row runner evidence"
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -22,8 +23,54 @@
       "list_agents",
       "control_health",
       "spawn_close_during_sweep",
-      "first_send_after_spawn"
+      "first_send_after_spawn",
+      "send_to_surface_10_parallel",
+      "read_screen_10_parallel"
     ],
+    "row_metadata": {
+      "list_surfaces": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "read_screen": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_surface_warm": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_agent_warm": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "list_agents": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "control_health": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "spawn_close_during_sweep": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "first_send_after_spawn": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_surface_10_parallel": {
+        "sampling": "sampled",
+        "samples_per_run": 12,
+        "stress": true
+      },
+      "read_screen_10_parallel": {
+        "sampling": "sampled",
+        "samples_per_run": 12,
+        "stress": true
+      }
+    },
     "bytes": {
       "list_surfaces": 142,
       "read_screen": 161,
@@ -32,7 +79,9 @@
       "list_agents": 112,
       "control_health": 97,
       "spawn_close_during_sweep": 161,
-      "first_send_after_spawn": 231
+      "first_send_after_spawn": 231,
+      "send_to_surface_10_parallel": 2400,
+      "read_screen_10_parallel": 1820
     },
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
@@ -42,7 +91,9 @@
       "list_agents": "4f4fb87e95a8f7cded25a4fd1bb35d11492182997e1f7d14c856683f53cc0416",
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
-      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75"
+      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75",
+      "send_to_surface_10_parallel": "69f3a964953c8a8b27d2cd7e1bd28e0dbc383c31e161a33f6a698f84ab7a0172",
+      "read_screen_10_parallel": "d93e1443889427dddaec043831bd3cd453725252f8f63d28a75c6565fc20f19e"
     },
     "transport": {
       "list_surfaces": "socket",
@@ -52,43 +103,45 @@
       "list_agents": "socket",
       "control_health": "socket",
       "spawn_close_during_sweep": "socket",
-      "first_send_after_spawn": "socket"
+      "first_send_after_spawn": "socket",
+      "send_to_surface_10_parallel": "socket",
+      "read_screen_10_parallel": "socket"
     }
   },
   "measurements": {
     "list_surfaces": {
       "p50_ms": 9.41,
-      "p95_ms": 34.2,
+      "p95_ms": 40.37,
       "lock_hold_ms": 0
     },
     "read_screen": {
-      "p50_ms": 12.71,
+      "p50_ms": 12.98,
       "p95_ms": 28.58,
       "lock_hold_ms": 0
     },
     "send_to_surface_warm": {
       "p50_ms": 69.58,
       "p95_ms": 69.58,
-      "lock_hold_ms": 63
+      "lock_hold_ms": 65
     },
     "send_to_agent_warm": {
       "p50_ms": 104.01,
-      "p95_ms": 104.01,
+      "p95_ms": 108.73,
       "lock_hold_ms": 66
     },
     "list_agents": {
-      "p50_ms": 15.76,
-      "p95_ms": 63.22,
+      "p50_ms": 62.97,
+      "p95_ms": 106.55,
       "lock_hold_ms": 0
     },
     "control_health": {
-      "p50_ms": 23.13,
-      "p95_ms": 32.24,
+      "p50_ms": 126.27,
+      "p95_ms": 150.35,
       "lock_hold_ms": 0
     },
     "spawn_close_during_sweep": {
       "p50_ms": 48.76,
-      "p95_ms": 48.76,
+      "p95_ms": 57.26,
       "lock_hold_ms": 0
     },
     "first_send_after_spawn": {
@@ -96,10 +149,20 @@
       "p95_ms": 134.91,
       "lock_hold_ms": 75
     },
+    "send_to_surface_10_parallel": {
+      "p50_ms": 117.49,
+      "p95_ms": 143.73,
+      "lock_hold_ms": 115
+    },
+    "read_screen_10_parallel": {
+      "p50_ms": 28.83,
+      "p95_ms": 43.46,
+      "lock_hold_ms": 0
+    },
     "cli_send_ms": 69.58
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "5e082ba864d9aa64876bd2f8901ad301adab6286da3d18623c9ae4cc8682e601"
+    "content_sha256": "1f31847a7960349a62a7cd12e6fe5b19b601b6b8bda070e9fa7d00d13d124927"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "557ae4c24a9de4a9d308bba3e1ba8497dc2ce254",
-    "measured_at": "2026-08-31T09:36:24.483Z",
+    "git_sha": "062d38af1c9296cd198f93d850f841729d9b49cc",
+    "measured_at": "2026-08-31T10:10:45.906Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33377777123,
-    "increase_reason": "Per-sample warm-surface sentinels and verified-submit proof change the canonical request identity; rebase to exact intrinsic-GREEN runner evidence."
+    "workflow_run_id": 33380548570,
+    "increase_reason": "list_agents fresh scans hold the lifecycle mutation lock; replace the false zero with the exact-run conservative elapsed upper bound, and retain terminal-confirmed surface-send timing."
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -120,7 +120,7 @@
       "lock_hold_ms": 0
     },
     "send_to_surface_warm": {
-      "p50_ms": 64.52,
+      "p50_ms": 65.02,
       "p95_ms": 71.2,
       "lock_hold_ms": 178
     },
@@ -132,7 +132,7 @@
     "list_agents": {
       "p50_ms": 67.66,
       "p95_ms": 119.43,
-      "lock_hold_ms": 0
+      "lock_hold_ms": 141.66617600002792
     },
     "control_health": {
       "p50_ms": 132.77,
@@ -150,7 +150,7 @@
       "lock_hold_ms": 120
     },
     "send_to_surface_10_parallel": {
-      "p50_ms": 121.35,
+      "p50_ms": 145.68,
       "p95_ms": 368.97,
       "lock_hold_ms": 353
     },
@@ -159,10 +159,10 @@
       "p95_ms": 59.03,
       "lock_hold_ms": 0
     },
-    "cli_send_ms": 64.52
+    "cli_send_ms": 65.02
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "fd095a40e1578472e0818e09b1393fe82f507d006429710daef2681604f94e86"
+    "content_sha256": "1b9d5ad4e790624a5d75dfbb5fd7d1aa0693fda34c6039173b51b58db3aea33f"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "7e1bb96f9fc82d6f7676043b75dcaf1ed1c31837",
-    "measured_at": "2026-08-26T16:33:17.727Z",
+    "git_sha": "c210a9a320556faf112eddf7a073967c2b2c95fa",
+    "measured_at": "2026-08-30T15:21:42.118Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 32988968639
+    "workflow_run_id": 33319012094,
+    "increase_reason": "migrate legacy single-shot rows to canonical sampled 10-row runner evidence"
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -22,8 +23,54 @@
       "list_agents",
       "control_health",
       "spawn_close_during_sweep",
-      "first_send_after_spawn"
+      "first_send_after_spawn",
+      "send_to_surface_10_parallel",
+      "read_screen_10_parallel"
     ],
+    "row_metadata": {
+      "list_surfaces": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "read_screen": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_surface_warm": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_agent_warm": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "list_agents": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "control_health": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "spawn_close_during_sweep": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "first_send_after_spawn": {
+        "sampling": "sampled",
+        "samples_per_run": 96
+      },
+      "send_to_surface_10_parallel": {
+        "sampling": "sampled",
+        "samples_per_run": 12,
+        "stress": true
+      },
+      "read_screen_10_parallel": {
+        "sampling": "sampled",
+        "samples_per_run": 12,
+        "stress": true
+      }
+    },
     "bytes": {
       "list_surfaces": 142,
       "read_screen": 161,
@@ -32,7 +79,9 @@
       "list_agents": 112,
       "control_health": 97,
       "spawn_close_during_sweep": 161,
-      "first_send_after_spawn": 231
+      "first_send_after_spawn": 231,
+      "send_to_surface_10_parallel": 2400,
+      "read_screen_10_parallel": 1820
     },
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
@@ -42,7 +91,9 @@
       "list_agents": "4f4fb87e95a8f7cded25a4fd1bb35d11492182997e1f7d14c856683f53cc0416",
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
-      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75"
+      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75",
+      "send_to_surface_10_parallel": "69f3a964953c8a8b27d2cd7e1bd28e0dbc383c31e161a33f6a698f84ab7a0172",
+      "read_screen_10_parallel": "d93e1443889427dddaec043831bd3cd453725252f8f63d28a75c6565fc20f19e"
     },
     "transport": {
       "list_surfaces": "socket",
@@ -52,54 +103,66 @@
       "list_agents": "socket",
       "control_health": "socket",
       "spawn_close_during_sweep": "socket",
-      "first_send_after_spawn": "socket"
+      "first_send_after_spawn": "socket",
+      "send_to_surface_10_parallel": "socket",
+      "read_screen_10_parallel": "socket"
     }
   },
   "measurements": {
     "list_surfaces": {
-      "p50_ms": 9.41,
-      "p95_ms": 34.2,
+      "p50_ms": 8.75,
+      "p95_ms": 50.94,
       "lock_hold_ms": 0
     },
     "read_screen": {
-      "p50_ms": 12.71,
-      "p95_ms": 28.58,
+      "p50_ms": 13.47,
+      "p95_ms": 21,
       "lock_hold_ms": 0
     },
     "send_to_surface_warm": {
-      "p50_ms": 69.58,
-      "p95_ms": 69.58,
-      "lock_hold_ms": 63
+      "p50_ms": 64.52,
+      "p95_ms": 71.2,
+      "lock_hold_ms": 104
     },
     "send_to_agent_warm": {
-      "p50_ms": 104.01,
-      "p95_ms": 104.01,
-      "lock_hold_ms": 66
+      "p50_ms": 92.77,
+      "p95_ms": 110.39,
+      "lock_hold_ms": 75
     },
     "list_agents": {
-      "p50_ms": 15.76,
-      "p95_ms": 63.22,
+      "p50_ms": 67.66,
+      "p95_ms": 119.43,
       "lock_hold_ms": 0
     },
     "control_health": {
-      "p50_ms": 23.13,
-      "p95_ms": 32.24,
+      "p50_ms": 127.17,
+      "p95_ms": 149.07,
       "lock_hold_ms": 0
     },
     "spawn_close_during_sweep": {
-      "p50_ms": 48.76,
-      "p95_ms": 48.76,
+      "p50_ms": 45.91,
+      "p95_ms": 59.61,
       "lock_hold_ms": 0
     },
     "first_send_after_spawn": {
-      "p50_ms": 134.91,
-      "p95_ms": 134.91,
-      "lock_hold_ms": 75
+      "p50_ms": 74.06,
+      "p95_ms": 86.29,
+      "lock_hold_ms": 66
     },
-    "cli_send_ms": 69.58
+    "send_to_surface_10_parallel": {
+      "p50_ms": 116.48,
+      "p95_ms": 151.43,
+      "lock_hold_ms": 125
+    },
+    "read_screen_10_parallel": {
+      "p50_ms": 30.27,
+      "p95_ms": 41.14,
+      "lock_hold_ms": 0
+    },
+    "cli_send_ms": 64.52
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "5e082ba864d9aa64876bd2f8901ad301adab6286da3d18623c9ae4cc8682e601"
+    "content_sha256": "69c66175d79104a9bd2937ba834d719276f40251f3c98c6021f81a3e44def9a2"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "9960960f8a75f1c4947d3f5a6fe1f16b0e647f1f",
-    "measured_at": "2026-08-30T15:35:23.831Z",
+    "git_sha": "3f4303b49d8165f7756538d17fd19c3b2c9862d3",
+    "measured_at": "2026-08-30T17:23:34.781Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33319637454,
-    "increase_reason": "incorporate second canonical runner sample after measured-ratchet RED"
+    "workflow_run_id": 33324494030,
+    "increase_reason": "canonical stress requests now use per-surface sentinels and raw read identity verification"
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -80,8 +80,8 @@
       "control_health": 97,
       "spawn_close_during_sweep": 161,
       "first_send_after_spawn": 231,
-      "send_to_surface_10_parallel": 2400,
-      "read_screen_10_parallel": 1820
+      "send_to_surface_10_parallel": 2420,
+      "read_screen_10_parallel": 1930
     },
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
@@ -92,8 +92,8 @@
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
       "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75",
-      "send_to_surface_10_parallel": "69f3a964953c8a8b27d2cd7e1bd28e0dbc383c31e161a33f6a698f84ab7a0172",
-      "read_screen_10_parallel": "d93e1443889427dddaec043831bd3cd453725252f8f63d28a75c6565fc20f19e"
+      "send_to_surface_10_parallel": "987a52afdc7845b58174464c4b69b3c04b53dbe36c7ef95e31b7e04589de7aac",
+      "read_screen_10_parallel": "366278b96955bd7c665f9793a8fa22ace224a74074e4d3af2b423afc7f806b2c"
     },
     "transport": {
       "list_surfaces": "socket",
@@ -115,8 +115,8 @@
       "lock_hold_ms": 0
     },
     "read_screen": {
-      "p50_ms": 13.47,
-      "p95_ms": 21,
+      "p50_ms": 13.55,
+      "p95_ms": 23.75,
       "lock_hold_ms": 0
     },
     "send_to_surface_warm": {
@@ -135,8 +135,8 @@
       "lock_hold_ms": 0
     },
     "control_health": {
-      "p50_ms": 127.17,
-      "p95_ms": 149.07,
+      "p50_ms": 132.77,
+      "p95_ms": 155.41,
       "lock_hold_ms": 0
     },
     "spawn_close_during_sweep": {
@@ -150,19 +150,19 @@
       "lock_hold_ms": 120
     },
     "send_to_surface_10_parallel": {
-      "p50_ms": 116.48,
+      "p50_ms": 121.35,
       "p95_ms": 368.97,
       "lock_hold_ms": 353
     },
     "read_screen_10_parallel": {
-      "p50_ms": 30.27,
-      "p95_ms": 41.14,
+      "p50_ms": 31.4,
+      "p95_ms": 49.89,
       "lock_hold_ms": 0
     },
     "cli_send_ms": 64.52
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "f792518e5f3ab80dd4193817e458292156f857468f1c7b3e82040e42a1e7d6d7"
+    "content_sha256": "a076427666a2995fdfd6400206bf4168d13db7abfdf6dac837a9990f09c964ca"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,10 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "06499d9485fec00ef8e5f5bdd50fd5b224257e23",
-    "measured_at": "2026-08-30T14:53:59.623Z",
+    "git_sha": "7e1bb96f9fc82d6f7676043b75dcaf1ed1c31837",
+    "measured_at": "2026-08-26T16:33:17.727Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33317747972,
-    "increase_reason": "migrate legacy single-shot rows to canonical sampled 10-row runner evidence"
+    "workflow_run_id": 32988968639
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -23,54 +22,8 @@
       "list_agents",
       "control_health",
       "spawn_close_during_sweep",
-      "first_send_after_spawn",
-      "send_to_surface_10_parallel",
-      "read_screen_10_parallel"
+      "first_send_after_spawn"
     ],
-    "row_metadata": {
-      "list_surfaces": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "read_screen": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "send_to_surface_warm": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "send_to_agent_warm": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "list_agents": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "control_health": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "spawn_close_during_sweep": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "first_send_after_spawn": {
-        "sampling": "sampled",
-        "samples_per_run": 96
-      },
-      "send_to_surface_10_parallel": {
-        "sampling": "sampled",
-        "samples_per_run": 12,
-        "stress": true
-      },
-      "read_screen_10_parallel": {
-        "sampling": "sampled",
-        "samples_per_run": 12,
-        "stress": true
-      }
-    },
     "bytes": {
       "list_surfaces": 142,
       "read_screen": 161,
@@ -79,9 +32,7 @@
       "list_agents": 112,
       "control_health": 97,
       "spawn_close_during_sweep": 161,
-      "first_send_after_spawn": 231,
-      "send_to_surface_10_parallel": 2400,
-      "read_screen_10_parallel": 1820
+      "first_send_after_spawn": 231
     },
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
@@ -91,9 +42,7 @@
       "list_agents": "4f4fb87e95a8f7cded25a4fd1bb35d11492182997e1f7d14c856683f53cc0416",
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
-      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75",
-      "send_to_surface_10_parallel": "69f3a964953c8a8b27d2cd7e1bd28e0dbc383c31e161a33f6a698f84ab7a0172",
-      "read_screen_10_parallel": "d93e1443889427dddaec043831bd3cd453725252f8f63d28a75c6565fc20f19e"
+      "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75"
     },
     "transport": {
       "list_surfaces": "socket",
@@ -103,45 +52,43 @@
       "list_agents": "socket",
       "control_health": "socket",
       "spawn_close_during_sweep": "socket",
-      "first_send_after_spawn": "socket",
-      "send_to_surface_10_parallel": "socket",
-      "read_screen_10_parallel": "socket"
+      "first_send_after_spawn": "socket"
     }
   },
   "measurements": {
     "list_surfaces": {
       "p50_ms": 9.41,
-      "p95_ms": 40.37,
+      "p95_ms": 34.2,
       "lock_hold_ms": 0
     },
     "read_screen": {
-      "p50_ms": 12.98,
+      "p50_ms": 12.71,
       "p95_ms": 28.58,
       "lock_hold_ms": 0
     },
     "send_to_surface_warm": {
       "p50_ms": 69.58,
       "p95_ms": 69.58,
-      "lock_hold_ms": 65
+      "lock_hold_ms": 63
     },
     "send_to_agent_warm": {
       "p50_ms": 104.01,
-      "p95_ms": 108.73,
+      "p95_ms": 104.01,
       "lock_hold_ms": 66
     },
     "list_agents": {
-      "p50_ms": 62.97,
-      "p95_ms": 106.55,
+      "p50_ms": 15.76,
+      "p95_ms": 63.22,
       "lock_hold_ms": 0
     },
     "control_health": {
-      "p50_ms": 126.27,
-      "p95_ms": 150.35,
+      "p50_ms": 23.13,
+      "p95_ms": 32.24,
       "lock_hold_ms": 0
     },
     "spawn_close_during_sweep": {
       "p50_ms": 48.76,
-      "p95_ms": 57.26,
+      "p95_ms": 48.76,
       "lock_hold_ms": 0
     },
     "first_send_after_spawn": {
@@ -149,20 +96,10 @@
       "p95_ms": 134.91,
       "lock_hold_ms": 75
     },
-    "send_to_surface_10_parallel": {
-      "p50_ms": 117.49,
-      "p95_ms": 143.73,
-      "lock_hold_ms": 115
-    },
-    "read_screen_10_parallel": {
-      "p50_ms": 28.83,
-      "p95_ms": 43.46,
-      "lock_hold_ms": 0
-    },
     "cli_send_ms": 69.58
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "1f31847a7960349a62a7cd12e6fe5b19b601b6b8bda070e9fa7d00d13d124927"
+    "content_sha256": "5e082ba864d9aa64876bd2f8901ad301adab6286da3d18623c9ae4cc8682e601"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "26f2797eb3f031635ca5c7a61bf42506798040f8",
-    "measured_at": "2026-08-31T09:00:15.695Z",
+    "git_sha": "557ae4c24a9de4a9d308bba3e1ba8497dc2ce254",
+    "measured_at": "2026-08-31T09:36:24.483Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33374877017,
-    "increase_reason": "Round-specific parallel-send sentinels add attributable freshness proof; rebase to the exact intrinsic-GREEN runner evidence."
+    "workflow_run_id": 33377777123,
+    "increase_reason": "Per-sample warm-surface sentinels and verified-submit proof change the canonical request identity; rebase to exact intrinsic-GREEN runner evidence."
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -86,7 +86,7 @@
     "request_sha256": {
       "list_surfaces": "29b9c66db4de170a41fdd8ad608f356201f747970e6f7fa74ae605f360f85a33",
       "read_screen": "0f6c57ad85b668c2ae73f651d9d44c41525b8f2fba3d2f7783e6acb592dc2137",
-      "send_to_surface_warm": "d2b6d478fff8c5cf8568d2c2caaa48cbe98314a700477cccbc20657a0ba3058e",
+      "send_to_surface_warm": "02703281dd0f30c23e8b681d2ebe0702b7d8c4459e5948953e04b93162d6f844",
       "send_to_agent_warm": "ec21fdf5817b3568ba66b0f44b2b5982319c2778cd60a7de637c1231428ee6e1",
       "list_agents": "4f4fb87e95a8f7cded25a4fd1bb35d11492182997e1f7d14c856683f53cc0416",
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
@@ -110,12 +110,12 @@
   },
   "measurements": {
     "list_surfaces": {
-      "p50_ms": 8.87,
+      "p50_ms": 9.47,
       "p95_ms": 50.94,
       "lock_hold_ms": 0
     },
     "read_screen": {
-      "p50_ms": 13.55,
+      "p50_ms": 13.9,
       "p95_ms": 23.75,
       "lock_hold_ms": 0
     },
@@ -156,13 +156,13 @@
     },
     "read_screen_10_parallel": {
       "p50_ms": 31.4,
-      "p95_ms": 49.89,
+      "p95_ms": 59.03,
       "lock_hold_ms": 0
     },
     "cli_send_ms": 64.52
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "b88c9f29fe04934fbb023bdc0b7faf7c6edf22d4afe11b86d425c1a6bc7b0338"
+    "content_sha256": "fd095a40e1578472e0818e09b1393fe82f507d006429710daef2681604f94e86"
   }
 }

--- a/benchmarks/daemon-baseline.json
+++ b/benchmarks/daemon-baseline.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 2,
   "source": {
-    "git_sha": "3f4303b49d8165f7756538d17fd19c3b2c9862d3",
-    "measured_at": "2026-08-30T17:23:34.781Z",
+    "git_sha": "26f2797eb3f031635ca5c7a61bf42506798040f8",
+    "measured_at": "2026-08-31T09:00:15.695Z",
     "runner_class": "github-actions-ubuntu-latest",
-    "workflow_run_id": 33324494030,
-    "increase_reason": "canonical stress requests now use per-surface sentinels and raw read identity verification"
+    "workflow_run_id": 33374877017,
+    "increase_reason": "Round-specific parallel-send sentinels add attributable freshness proof; rebase to the exact intrinsic-GREEN runner evidence."
   },
   "regression_ratio": 1.25,
   "sanity_caps_ms": {
@@ -80,7 +80,7 @@
       "control_health": 97,
       "spawn_close_during_sweep": 161,
       "first_send_after_spawn": 231,
-      "send_to_surface_10_parallel": 2420,
+      "send_to_surface_10_parallel": 2510,
       "read_screen_10_parallel": 1930
     },
     "request_sha256": {
@@ -92,7 +92,7 @@
       "control_health": "56e5969d5764757c0775d59e7c65e83cbd91d6f4f4a3279f1cc910fe6854a10f",
       "spawn_close_during_sweep": "1c7dfd23479835bd9d42cc8e74444cbac74e47aa8f288d3eb3278e777c96acdf",
       "first_send_after_spawn": "811745b320e17eddf09602072cea6a0f8274bd3e6ecb6438796646803efbcc75",
-      "send_to_surface_10_parallel": "987a52afdc7845b58174464c4b69b3c04b53dbe36c7ef95e31b7e04589de7aac",
+      "send_to_surface_10_parallel": "961824611592824755bfa4374fdf62aa941395dd057756be85eae3f187c2a4b3",
       "read_screen_10_parallel": "366278b96955bd7c665f9793a8fa22ace224a74074e4d3af2b423afc7f806b2c"
     },
     "transport": {
@@ -110,7 +110,7 @@
   },
   "measurements": {
     "list_surfaces": {
-      "p50_ms": 8.75,
+      "p50_ms": 8.87,
       "p95_ms": 50.94,
       "lock_hold_ms": 0
     },
@@ -125,7 +125,7 @@
       "lock_hold_ms": 178
     },
     "send_to_agent_warm": {
-      "p50_ms": 92.77,
+      "p50_ms": 93.26,
       "p95_ms": 122.59,
       "lock_hold_ms": 200
     },
@@ -136,11 +136,11 @@
     },
     "control_health": {
       "p50_ms": 132.77,
-      "p95_ms": 155.41,
+      "p95_ms": 184.45,
       "lock_hold_ms": 0
     },
     "spawn_close_during_sweep": {
-      "p50_ms": 45.91,
+      "p50_ms": 46.04,
       "p95_ms": 143.28,
       "lock_hold_ms": 0
     },
@@ -163,6 +163,6 @@
   },
   "refresh_attestation": {
     "algorithm": "sha256",
-    "content_sha256": "a076427666a2995fdfd6400206bf4168d13db7abfdf6dac837a9990f09c964ca"
+    "content_sha256": "b88c9f29fe04934fbb023bdc0b7faf7c6edf22d4afe11b86d425c1a6bc7b0338"
   }
 }

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1211,7 +1211,12 @@ async function measureLiveListAgentsAcrossClients(clients) {
       "list_agents",
       { detail: "summary" },
       (receipt) => {
-        if (!compact(receipt).includes(spawnResult.agent_id)) {
+        if (
+          !Array.isArray(receipt.agents) ||
+          !receipt.agents.some(
+            (agent) => agent.agent_id === spawnResult.agent_id,
+          )
+        ) {
           throw new Error("list_agents omitted the live spawned agent");
         }
       },

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1158,16 +1158,14 @@ async function main() {
       );
     }
     const daemonLatency = await measureLatency(daemonClients);
-    let daemonRssMb;
-    let daemonStats;
     const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients(
       daemonClients,
       sweepHoldState,
     );
-    daemonRssMb = await totalRssMb(
+    const daemonRssMb = await totalRssMb(
       [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
     );
-    daemonStats = await processStats(daemon.pid);
+    const daemonStats = await processStats(daemon.pid);
     const listAgents = await measureWarmToolAcrossClients(
       daemonClients,
       "list_agents",
@@ -1244,9 +1242,9 @@ async function main() {
       socket_transport_only: [
         daemonLatency.list_surfaces,
         daemonLatency.read_screen,
-        firstSendAfterSpawn.first,
-        firstSendAfterSpawn.second,
-        firstSendAfterSpawn.surface,
+        firstSendAfterSpawn.sampled,
+        firstSendAfterSpawn.send_to_agent_warm,
+        firstSendAfterSpawn.send_to_surface_warm,
         listAgents,
         controlHealth,
         firstSendAfterSpawn.spawn_close_during_sweep,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -996,7 +996,9 @@ async function measureSpawnLifecycleAcrossClients(
         typeof sample.surface.receipt.delivery_id === "string" &&
         sample.surface.wait_for.delivery_id ===
           sample.surface.receipt.delivery_id &&
-        sample.surface.wait_for.terminal === true,
+        sample.surface.wait_for.terminal === true &&
+        sample.surface.wait_for.delivery_state === "submitted" &&
+        sample.surface.wait_for.submit_verified === true,
     ),
   };
 }

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -339,6 +339,28 @@ function writeState(state) {
 function patchState(patch) {
   writeState({ ...readState(), ...patch });
 }
+function keyedStatePath(kind, key) {
+  const safeKey = String(key || "default").replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return statePath + "." + kind + "-" + safeKey;
+}
+function readSurfaceState(surface) {
+  try { return JSON.parse(fs.readFileSync(keyedStatePath("surface", surface), "utf8")); }
+  catch { return { composer: "", transcript: "" }; }
+}
+function writeSurfaceState(surface, surfaceState) {
+  fs.writeFileSync(keyedStatePath("surface", surface), JSON.stringify(surfaceState));
+}
+function readBuffer(name) {
+  try { return fs.readFileSync(keyedStatePath("buffer", name), "utf8"); }
+  catch { return ""; }
+}
+function writeBuffer(name, value) {
+  fs.writeFileSync(keyedStatePath("buffer", name), value);
+}
+function optionValue(name, fallback = "") {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] || fallback : fallback;
+}
 const state = readState();
 const baseSurfaces = Array.from({ length: surfaceCount }, (_, index) => ({
   ref: "surface:bench-" + index,
@@ -380,31 +402,36 @@ if (command === "list-workspaces") {
   write({ terminals: surfaces.map((surface) => ({ surface_ref: surface.ref, current_directory: cwd })) });
 } else if (command === "read-screen") {
   const surface = args[args.indexOf("--surface") + 1] || surfaces[0].ref;
-  const composer = state.composer ? "› " + state.composer : "› ";
-  const transcript = state.transcript ? "\\n› " + state.transcript + "\\n" : "";
+  const surfaceState = readSurfaceState(surface);
+  const composer = surfaceState.composer ? "› " + surfaceState.composer : "› ";
+  const transcript = surfaceState.transcript ? "\\n› " + surfaceState.transcript + "\\n" : "";
   write({ surface_ref: surface, text: "╭ OpenAI Codex ╮\\nmodel: gpt-5.6-sol\\n" + transcript + "\\n" + composer, lines: 8, scrollback_used: false });
 } else if (command === "identify") {
   write({ caller: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref }, focused: { workspace_ref: "workspace:bench", pane_ref: "pane:bench", surface_ref: surfaces[0].ref } });
 } else if (command === "list-status") {
   write([]);
 } else if (command === "send") {
-  state.composer += args.at(-1) || "";
-  writeState(state);
+  const surface = optionValue("--surface", surfaces[0].ref);
+  const surfaceState = readSurfaceState(surface);
+  surfaceState.composer += args.at(-1) || "";
+  writeSurfaceState(surface, surfaceState);
   write({ ok: true });
 } else if (command === "set-buffer") {
-  state.buffer = args.at(-1) || "";
-  writeState(state);
+  writeBuffer(optionValue("--name", "default"), args.at(-1) || "");
   write({ ok: true });
 } else if (command === "paste-buffer") {
-  state.composer += state.buffer || "";
-  state.buffer = "";
-  writeState(state);
+  const surface = optionValue("--surface", surfaces[0].ref);
+  const surfaceState = readSurfaceState(surface);
+  surfaceState.composer += readBuffer(optionValue("--name", "default"));
+  writeSurfaceState(surface, surfaceState);
   write({ ok: true });
 } else if (command === "send-key") {
+  const surface = optionValue("--surface", surfaces[0].ref);
+  const surfaceState = readSurfaceState(surface);
   if ((args.at(-1) || "").toLowerCase() === "return") {
-    state.transcript = state.composer;
-    state.composer = "";
-    writeState(state);
+    surfaceState.transcript = surfaceState.composer;
+    surfaceState.composer = "";
+    writeSurfaceState(surface, surfaceState);
   }
   write({ ok: true });
 } else if (command === "rename-tab") {
@@ -899,9 +926,8 @@ async function requireSurfaceDeliveryProof(
       receipt.submit_verified === true) ||
     typeof receipt.delivery_id === "string"
   ) {
-    return requireSubmittedDelivery(client, receipt, label);
-  }
-  if (receipt.typed !== true || receipt.submit_attempted !== true) {
+    await requireSubmittedDelivery(client, receipt, label);
+  } else if (receipt.typed !== true || receipt.submit_attempted !== true) {
     throw new Error(`${label} was neither waitable nor typed`);
   }
   const read = toolData(
@@ -1168,8 +1194,10 @@ async function measureLiveListAgentsAcrossClients(clients) {
   if (!spawnResult.agent_id || !spawnResult.surface_id) {
     throw new Error("list_agents fixture spawn omitted identity");
   }
+  let measurement;
+  let measurementError;
   try {
-    return await measureWarmToolAcrossClients(
+    measurement = await measureWarmToolAcrossClients(
       clients,
       "list_agents",
       { detail: "summary" },
@@ -1179,7 +1207,11 @@ async function measureLiveListAgentsAcrossClients(clients) {
         }
       },
     );
-  } finally {
+  } catch (error) {
+    measurementError = error;
+  }
+  let closeError;
+  try {
     const closeReceipt = toolData(
       await clients[0].callTool(
         "close_surface",
@@ -1194,7 +1226,18 @@ async function measureLiveListAgentsAcrossClients(clients) {
     ) {
       throw new Error("list_agents fixture did not close cleanly");
     }
+  } catch (error) {
+    closeError = error;
   }
+  if (measurementError && closeError) {
+    throw new AggregateError(
+      [measurementError, closeError],
+      "list_agents measurement and fixture cleanup both failed",
+    );
+  }
+  if (measurementError) throw measurementError;
+  if (closeError) throw closeError;
+  return measurement;
 }
 
 async function measureSpawnLifecycleAcrossClients(
@@ -1237,7 +1280,7 @@ async function measureSpawnLifecycleAcrossClients(
 function parallelStressSentinel(index, roundIndex) {
   return roundIndex === undefined
     ? `parallel surface benchmark ${index}`
-    : `parallel surface benchmark ${index} round ${roundIndex}`;
+    : `parallel surface benchmark ${index} round ${String(roundIndex).padStart(2, "0")}`;
 }
 
 async function measureParallelStress(
@@ -1248,16 +1291,22 @@ async function measureParallelStress(
   { beforeRound } = {},
 ) {
   const samples = [];
-  const requests = Array.from({ length: PARALLEL_STRESS_COUNT }, (_, index) =>
-    typeof args === "function" ? args(index) : args,
+  const canonicalRequests = Array.from(
+    { length: PARALLEL_STRESS_COUNT },
+    (_, index) => (typeof args === "function" ? args(index, "RR") : args),
   );
   const request = {
     parallel: PARALLEL_STRESS_COUNT,
     name,
-    arguments: requests,
+    arguments: canonicalRequests,
   };
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     await beforeRound?.(roundIndex);
+    const requests = Array.from(
+      { length: PARALLEL_STRESS_COUNT },
+      (_, index) =>
+        typeof args === "function" ? args(index, roundIndex) : args,
+    );
     const startedAt = nowMs();
     const receipts = await Promise.all(
       requests.map(async (requestArgs, index) =>
@@ -1436,11 +1485,11 @@ async function main() {
     const sendToSurface10Parallel = await measureParallelStress(
       stressClients,
       "send_to",
-      (index) => ({
+      (index, roundIndex) => ({
         mode: "surface",
         surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
         workspace: "workspace:bench",
-        text: parallelStressSentinel(index),
+        text: parallelStressSentinel(index, roundIndex),
         press_enter: true,
       }),
       (receipt, requestArgs, index) =>

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1010,6 +1010,7 @@ async function measureSpawnLifecycleOnce(
       normalizeAgentId = false,
       requireSubmitted = true,
       canonicalText,
+      validateReceipt,
     } = {},
   ) => {
     const startedAt = nowMs();
@@ -1017,6 +1018,7 @@ async function measureSpawnLifecycleOnce(
     if (requireSubmitted) {
       requireTerminalSubmission(receipt, `${args.mode} send`);
     }
+    await validateReceipt?.(receipt);
     return {
       elapsed_ms: round(nowMs() - startedAt),
       request_bytes: requestBytes("send_to", args),
@@ -1069,35 +1071,37 @@ async function measureSpawnLifecycleOnce(
     text: surfaceSampleSentinel(sampleIndex),
     press_enter: true,
   };
+  let surfaceWaitFor;
   const surface = await measureSend(surfaceArgs, {
     requireSubmitted: false,
     canonicalText: surfaceSampleSentinel("NNN"),
+    validateReceipt: async (receipt) => {
+      try {
+        const terminal = await requireSubmittedDelivery(
+          client,
+          receipt,
+          "sampled surface send",
+        );
+        await requireSurfaceDeliveryProof(
+          client,
+          terminal,
+          surfaceArgs,
+          "surface:bench-spawn",
+          "sampled surface send",
+        );
+        surfaceWaitFor = {
+          ...terminal,
+          read_back_verified: true,
+        };
+      } catch (error) {
+        surfaceWaitFor = {
+          ok: false,
+          read_back_verified: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
   });
-  let surfaceWaitFor;
-  try {
-    const terminal = await requireSubmittedDelivery(
-      client,
-      surface.receipt,
-      "sampled surface send",
-    );
-    await requireSurfaceDeliveryProof(
-      client,
-      terminal,
-      surfaceArgs,
-      "surface:bench-spawn",
-      "sampled surface send",
-    );
-    surfaceWaitFor = {
-      ...terminal,
-      read_back_verified: true,
-    };
-  } catch (error) {
-    surfaceWaitFor = {
-      ok: false,
-      read_back_verified: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
 
   const closeArgs = {
     scope: "agent",
@@ -1152,7 +1156,13 @@ async function measureSpawnLifecycleOnce(
   };
 }
 
-async function measureWarmToolAcrossClients(clients, name, args, validateReceipt) {
+async function measureWarmToolAcrossClients(
+  clients,
+  name,
+  args,
+  validateReceipt,
+  { lockHoldFromElapsed = false } = {},
+) {
   const samples = [];
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     await Promise.all(
@@ -1163,12 +1173,15 @@ async function measureWarmToolAcrossClients(clients, name, args, validateReceipt
           name,
         );
         validateReceipt?.(receipt);
+        const elapsedMs = nowMs() - startedAt;
         samples.push({
-          elapsed_ms: nowMs() - startedAt,
+          elapsed_ms: elapsedMs,
           request_bytes: requestBytes(name, args),
           request_sha256: requestSha256(name, args),
-          // These warm rows are read-only and never own the mutation lock.
-          lock_hold_ms: 0,
+          // list_agents performs its fresh scan under the lifecycle mutation
+          // lock. End-to-end elapsed time is a conservative upper bound that
+          // cannot understate its serialized occupancy.
+          lock_hold_ms: lockHoldFromElapsed ? elapsedMs : 0,
           transport: operationTransport(receipt, name),
           transport_fallbacks: receipt.transport_fallbacks ?? [],
         });
@@ -1220,6 +1233,7 @@ async function measureLiveListAgentsAcrossClients(clients) {
           throw new Error("list_agents omitted the live spawned agent");
         }
       },
+      { lockHoldFromElapsed: true },
     );
   } catch (error) {
     measurementError = error;
@@ -1338,12 +1352,12 @@ async function measureParallelStress(
         ),
       ),
     );
-    const elapsedMs = nowMs() - startedAt;
     await Promise.all(
       receipts.map((receipt, index) =>
         validateReceipt?.(receipt, requests[index], index, roundIndex),
       ),
     );
+    const elapsedMs = nowMs() - startedAt;
     samples.push({
       elapsed_ms: elapsedMs,
       request_bytes: requests.reduce(

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -432,14 +432,14 @@ async function startFakeCmuxSocket(socketPath, statePath, surfaceCount) {
         const line = buffer.slice(0, newline).trim();
         buffer = buffer.slice(newline + 1);
         if (!line) continue;
-        void handleFakeCmuxSocketLine(
+        handleFakeCmuxSocketLine(
           socket,
           line,
           statePath,
           surfaceCount,
           surfaceStates,
           surfaceMutationQueues,
-        );
+        ).catch((error) => socket.destroy(error));
       }
     });
   });
@@ -450,7 +450,15 @@ async function startFakeCmuxSocket(socketPath, statePath, surfaceCount) {
   return server;
 }
 
-async function mutateFakeSurfaceState(
+function fakeSurfaceStateKey(surfaceIdentifier, surfaces) {
+  const surface = surfaces.find(
+    (candidate) =>
+      candidate.ref === surfaceIdentifier || candidate.id === surfaceIdentifier,
+  );
+  return surface?.ref ?? surfaceIdentifier;
+}
+
+function mutateFakeSurfaceState(
   surfaceId,
   surfaceStates,
   surfaceMutationQueues,
@@ -466,7 +474,13 @@ async function mutateFakeSurfaceState(
     surfaceStates.set(surfaceId, updated);
     return updated;
   });
-  surfaceMutationQueues.set(surfaceId, currentMutation.catch(() => {}));
+  surfaceMutationQueues.set(
+    surfaceId,
+    currentMutation.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
   return currentMutation;
 }
 
@@ -575,7 +589,8 @@ async function handleFakeCmuxSocketLine(
       result = { ...layout, surfaces };
       break;
     case "surface.read_text": {
-      const surfaceState = surfaceStates.get(params.surface_id) ?? {
+      const surfaceKey = fakeSurfaceStateKey(params.surface_id, surfaces);
+      const surfaceState = surfaceStates.get(surfaceKey) ?? {
         composer: "",
         transcript: "",
       };
@@ -584,9 +599,7 @@ async function handleFakeCmuxSocketLine(
         : "";
       result = {
         surface_ref: params.surface_id,
-        text:
-          `╭ OpenAI Codex ╮\nmodel: gpt-5.6-sol\n${transcript}\n› ` +
-          surfaceState.composer,
+        text: `╭ OpenAI Codex ╮\nmodel: gpt-5.6-sol\n${transcript}\n› ${surfaceState.composer}`,
         lines: 8,
       };
       break;
@@ -601,9 +614,10 @@ async function handleFakeCmuxSocketLine(
         type: "terminal",
       };
       break;
-    case "surface.send_text":
+    case "surface.send_text": {
+      const surfaceKey = fakeSurfaceStateKey(params.surface_id, surfaces);
       await mutateFakeSurfaceState(
-        params.surface_id,
+        surfaceKey,
         surfaceStates,
         surfaceMutationQueues,
         (surfaceState) => ({
@@ -613,9 +627,11 @@ async function handleFakeCmuxSocketLine(
       );
       result = { ok: true };
       break;
-    case "surface.send_key":
+    }
+    case "surface.send_key": {
+      const surfaceKey = fakeSurfaceStateKey(params.surface_id, surfaces);
       await mutateFakeSurfaceState(
-        params.surface_id,
+        surfaceKey,
         surfaceStates,
         surfaceMutationQueues,
         (surfaceState) =>
@@ -629,6 +645,7 @@ async function handleFakeCmuxSocketLine(
       );
       result = { ok: true };
       break;
+    }
     case "surface.close":
       await writeFakeState(statePath, { ...state, closed: true });
       result = { ok: true };
@@ -1268,6 +1285,10 @@ async function main() {
 
     const gates = {
       rss_improved: daemonRssMb < baselineRssMb,
+      daemon_survived_replay:
+        daemon.exitCode === null &&
+        daemon.signalCode === null &&
+        daemonStats.rssKb > 0,
       truthful_state: truthfulState,
       list_surfaces_p50_no_regression: latencyGate(
         baselineLatency,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1101,7 +1101,6 @@ async function measureParallelStress(clients, name, args, validateReceipt) {
         validateReceipt?.(receipt, requestArgs, index);
         return receipt;
       }),
-      ),
     );
     samples.push({
       elapsed_ms: nowMs() - startedAt,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -212,6 +212,10 @@ class McpProcess {
     return this.child.pid;
   }
 
+  get alive() {
+    return this.child.exitCode === null && this.child.signalCode === null;
+  }
+
   handleMessage(message) {
     if (!message || typeof message !== "object" || !("id" in message)) {
       return;
@@ -1271,6 +1275,9 @@ async function main() {
         lines: 5,
       }),
     );
+    const stressClientsSurvivedReplay = stressClients.every(
+      (client) => client.alive,
+    );
     await Promise.all(stressClients.map((client) => client.close()));
     stressClients = [];
     const daemonRssMb = await totalRssMb(
@@ -1289,6 +1296,9 @@ async function main() {
         daemon.exitCode === null &&
         daemon.signalCode === null &&
         daemonStats.rssKb > 0,
+      benchmark_clients_survived_replay:
+        stressClientsSurvivedReplay &&
+        daemonClients.every((client) => client.alive),
       truthful_state: truthfulState,
       list_surfaces_p50_no_regression: latencyGate(
         baselineLatency,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -846,16 +846,98 @@ async function waitForLifecycleWaiter(
   throw new Error("close_surface never queued behind the held lifecycle sweep");
 }
 
+function requireFiniteLockHold(value, operation) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${operation} omitted finite lock-hold timing`);
+  }
+  return value;
+}
+
+function requireTerminalSubmission(receipt, label) {
+  if (
+    receipt.terminal !== true ||
+    receipt.delivery_state !== "submitted" ||
+    receipt.submit_verified !== true
+  ) {
+    throw new Error(`${label} was not terminally submitted`);
+  }
+  return receipt;
+}
+
+async function requireSubmittedDelivery(client, receipt, label) {
+  if (
+    receipt.terminal === true &&
+    receipt.delivery_state === "submitted" &&
+    receipt.submit_verified === true
+  ) {
+    return receipt;
+  }
+  if (typeof receipt.delivery_id !== "string") {
+    throw new Error(`${label} omitted a waitable delivery id`);
+  }
+  const terminal = toolData(
+    await client.callTool(
+      "wait_for",
+      { delivery_id: receipt.delivery_id, timeout_ms: 2_000 },
+      30_000,
+    ),
+    `${label} wait_for`,
+  );
+  return requireTerminalSubmission(terminal, label);
+}
+
+async function requireSurfaceDeliveryProof(
+  client,
+  receipt,
+  requestArgs,
+  index,
+  label,
+) {
+  if (
+    (receipt.terminal === true &&
+      receipt.delivery_state === "submitted" &&
+      receipt.submit_verified === true) ||
+    typeof receipt.delivery_id === "string"
+  ) {
+    return requireSubmittedDelivery(client, receipt, label);
+  }
+  if (receipt.typed !== true || receipt.submit_attempted !== true) {
+    throw new Error(`${label} was neither waitable nor typed`);
+  }
+  const read = toolData(
+    await client.callTool(
+      "read_screen",
+      {
+        surface: requestArgs.surface,
+        workspace: requestArgs.workspace,
+        lines: 5,
+        raw: true,
+      },
+      30_000,
+    ),
+    `${label} read-back`,
+  );
+  const expectedRef = `surface:bench-${index}`;
+  if (
+    (read.surface !== requestArgs.surface && read.surface !== expectedRef) ||
+    !read.content?.includes(requestArgs.text)
+  ) {
+    throw new Error(`${label} failed attributable read-back verification`);
+  }
+  return read;
+}
+
 function summarizeTimedSamples(samples) {
   const transports = samples.map((sample) => sample.transport);
+  const lockHolds = samples.map((sample) =>
+    requireFiniteLockHold(sample.lock_hold_ms, "sample"),
+  );
   return {
     request_bytes: samples[0]?.request_bytes,
     request_sha256: samples[0]?.request_sha256,
     p50_ms: round(percentile(samples.map((sample) => sample.elapsed_ms), 50)),
     p95_ms: round(percentile(samples.map((sample) => sample.elapsed_ms), 95)),
-    lock_hold_ms: Math.max(
-      ...samples.map((sample) => sample.lock_hold_ms ?? 0),
-    ),
+    lock_hold_ms: Math.max(...lockHolds),
     transport: transports.every((value) => value === "socket")
       ? "socket"
       : "cli",
@@ -896,9 +978,15 @@ async function measureSpawnLifecycleOnce(
     throw new Error(`spawn_agent omitted identity: ${compact(spawnResult)}`);
   }
 
-  const measureSend = async (args, { normalizeAgentId = false } = {}) => {
+  const measureSend = async (
+    args,
+    { normalizeAgentId = false, requireSubmitted = true } = {},
+  ) => {
     const startedAt = nowMs();
     const receipt = toolData(await client.callTool("send_to", args), "send_to");
+    if (requireSubmitted) {
+      requireTerminalSubmission(receipt, `${args.mode} send`);
+    }
     return {
       elapsed_ms: round(nowMs() - startedAt),
       request_bytes: requestBytes("send_to", args),
@@ -906,7 +994,10 @@ async function measureSpawnLifecycleOnce(
         ...args,
         ...(normalizeAgentId ? { agent_id: "$SPAWNED_AGENT_ID" } : {}),
       }),
-      lock_hold_ms: receipt.timings_ms?.lock_hold ?? null,
+      lock_hold_ms: requireFiniteLockHold(
+        receipt.timings_ms?.lock_hold,
+        `${args.mode} send`,
+      ),
       transport: receipt.transport,
       receipt,
     };
@@ -940,13 +1031,16 @@ async function measureSpawnLifecycleOnce(
     },
     { normalizeAgentId: true },
   );
-  const surface = await measureSend({
-    mode: "surface",
-    surface: spawnResult.surface_id,
-    workspace: "workspace:bench",
-    text: "surface benchmark",
-    press_enter: true,
-  });
+  const surface = await measureSend(
+    {
+      mode: "surface",
+      surface: spawnResult.surface_id,
+      workspace: "workspace:bench",
+      text: "surface benchmark",
+      press_enter: true,
+    },
+    { requireSubmitted: false },
+  );
   let surfaceWaitFor;
   if (typeof surface.receipt.delivery_id === "string") {
     try {
@@ -991,6 +1085,12 @@ async function measureSpawnLifecycleOnce(
   const closeOutcome = await closePromise;
   if ("error" in closeOutcome) throw closeOutcome.error;
   const closeReceipt = toolData(closeOutcome.value, "close_surface");
+  if (
+    closeReceipt.agent_stopped !== true ||
+    closeReceipt.surface_closed !== true
+  ) {
+    throw new Error("close_surface did not close the spawned surface");
+  }
   await waitForSweepHoldState(sweepHoldState, closeHoldToken, "complete");
   const spawnCloseDuringSweep = {
     elapsed_ms: round(nowMs() - closeStartedAt),
@@ -999,7 +1099,9 @@ async function measureSpawnLifecycleOnce(
       ...closeArgs,
       agent_id: "$SPAWNED_AGENT_ID",
     }),
-    lock_hold_ms: closeReceipt.timings_ms?.lock_hold ?? 0,
+    // close_surface is the waiter in this held-sweep scenario. Contention is
+    // enforced by elapsed time; the waiter's own lock hold is explicitly zero.
+    lock_hold_ms: 0,
     transport: closeReceipt.transport,
     transport_fallbacks: closeReceipt.transport_fallbacks ?? [],
     receipt: closeReceipt,
@@ -1015,7 +1117,7 @@ async function measureSpawnLifecycleOnce(
   };
 }
 
-async function measureWarmToolAcrossClients(clients, name, args) {
+async function measureWarmToolAcrossClients(clients, name, args, validateReceipt) {
   const samples = [];
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     await Promise.all(
@@ -1025,11 +1127,13 @@ async function measureWarmToolAcrossClients(clients, name, args) {
           await client.callTool(name, args, 30_000),
           name,
         );
+        validateReceipt?.(receipt);
         samples.push({
           elapsed_ms: nowMs() - startedAt,
           request_bytes: requestBytes(name, args),
           request_sha256: requestSha256(name, args),
-          lock_hold_ms: receipt.timings_ms?.lock_hold ?? 0,
+          // These warm rows are read-only and never own the mutation lock.
+          lock_hold_ms: 0,
           transport: operationTransport(receipt, name),
           transport_fallbacks: receipt.transport_fallbacks ?? [],
         });
@@ -1037,6 +1141,60 @@ async function measureWarmToolAcrossClients(clients, name, args) {
     );
   }
   return summarizeTimedSamples(samples);
+}
+
+async function measureLiveListAgentsAcrossClients(clients) {
+  const spawnResult = toolData(
+    await clients[0].callTool(
+      "spawn_agent",
+      {
+        repo: "cmuxlayer",
+        cli: "codex",
+        role: "worker",
+        authority: "worker",
+        placement: "right",
+        workspace: "workspace:bench",
+        cwd: repoRoot,
+        worktree: false,
+        mcp_profile: "sterile",
+        title: "bench-list-agents-live",
+        prompt: "benchmark live list agent",
+        boot_prompt_timeout_ms: 2_000,
+      },
+      30_000,
+    ),
+    "spawn_agent(list_agents fixture)",
+  );
+  if (!spawnResult.agent_id || !spawnResult.surface_id) {
+    throw new Error("list_agents fixture spawn omitted identity");
+  }
+  try {
+    return await measureWarmToolAcrossClients(
+      clients,
+      "list_agents",
+      { detail: "summary" },
+      (receipt) => {
+        if (!compact(receipt).includes(spawnResult.agent_id)) {
+          throw new Error("list_agents omitted the live spawned agent");
+        }
+      },
+    );
+  } finally {
+    const closeReceipt = toolData(
+      await clients[0].callTool(
+        "close_surface",
+        { scope: "agent", agent_id: spawnResult.agent_id, force: true },
+        30_000,
+      ),
+      "close_surface(list_agents fixture)",
+    );
+    if (
+      closeReceipt.agent_stopped !== true ||
+      closeReceipt.surface_closed !== true
+    ) {
+      throw new Error("list_agents fixture did not close cleanly");
+    }
+  }
 }
 
 async function measureSpawnLifecycleAcrossClients(
@@ -1076,11 +1234,19 @@ async function measureSpawnLifecycleAcrossClients(
   };
 }
 
-function parallelStressSentinel(index) {
-  return `parallel surface benchmark ${index}`;
+function parallelStressSentinel(index, roundIndex) {
+  return roundIndex === undefined
+    ? `parallel surface benchmark ${index}`
+    : `parallel surface benchmark ${index} round ${roundIndex}`;
 }
 
-async function measureParallelStress(clients, name, args, validateReceipt) {
+async function measureParallelStress(
+  clients,
+  name,
+  args,
+  validateReceipt,
+  { beforeRound } = {},
+) {
   const samples = [];
   const requests = Array.from({ length: PARALLEL_STRESS_COUNT }, (_, index) =>
     typeof args === "function" ? args(index) : args,
@@ -1091,19 +1257,24 @@ async function measureParallelStress(clients, name, args, validateReceipt) {
     arguments: requests,
   };
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
+    await beforeRound?.(roundIndex);
     const startedAt = nowMs();
     const receipts = await Promise.all(
-      requests.map(async (requestArgs, index) => {
-        const receipt = toolData(
+      requests.map(async (requestArgs, index) =>
+        toolData(
           await clients[index].callTool(name, requestArgs, 30_000),
           name,
-        );
-        validateReceipt?.(receipt, requestArgs, index);
-        return receipt;
-      }),
+        ),
+      ),
+    );
+    const elapsedMs = nowMs() - startedAt;
+    await Promise.all(
+      receipts.map((receipt, index) =>
+        validateReceipt?.(receipt, requests[index], index, roundIndex),
+      ),
     );
     samples.push({
-      elapsed_ms: nowMs() - startedAt,
+      elapsed_ms: elapsedMs,
       request_bytes: requests.reduce(
         (total, requestArgs) => total + requestBytes(name, requestArgs),
         0,
@@ -1111,9 +1282,14 @@ async function measureParallelStress(clients, name, args, validateReceipt) {
       request_sha256: createHash("sha256")
         .update(JSON.stringify(canonicalize(request)))
         .digest("hex"),
-      lock_hold_ms: Math.max(
-        ...receipts.map((receipt) => receipt.timings_ms?.lock_hold ?? 0),
-      ),
+      lock_hold_ms:
+        name === "read_screen"
+          ? 0
+          : Math.max(
+              ...receipts.map((receipt) =>
+                requireFiniteLockHold(receipt.timings_ms?.lock_hold, name),
+              ),
+            ),
       transport: receipts.every(
         (receipt) => operationTransport(receipt, name) === "socket",
       )
@@ -1243,11 +1419,7 @@ async function main() {
       daemonClients,
       sweepHoldState,
     );
-    const listAgents = await measureWarmToolAcrossClients(
-      daemonClients,
-      "list_agents",
-      { detail: "summary" },
-    );
+    const listAgents = await measureLiveListAgentsAcrossClients(daemonClients);
     const controlHealth = await measureWarmToolAcrossClients(
       daemonClients,
       "control_health",
@@ -1271,6 +1443,14 @@ async function main() {
         text: parallelStressSentinel(index),
         press_enter: true,
       }),
+      (receipt, requestArgs, index) =>
+        requireSurfaceDeliveryProof(
+          stressClients[index],
+          receipt,
+          requestArgs,
+          index,
+          "parallel send",
+        ),
     );
     const readScreen10Parallel = await measureParallelStress(
       stressClients,
@@ -1281,7 +1461,7 @@ async function main() {
         lines: 5,
         raw: true,
       }),
-      (receipt, requestArgs, index) => {
+      (receipt, requestArgs, index, roundIndex) => {
         const expectedRef = `surface:bench-${index}`;
         if (
           receipt.surface !== requestArgs.surface &&
@@ -1289,9 +1469,46 @@ async function main() {
         ) {
           throw new Error("parallel read returned the wrong surface");
         }
-        if (!receipt.content?.includes(parallelStressSentinel(index))) {
+        if (
+          !receipt.content?.includes(
+            parallelStressSentinel(index, roundIndex),
+          )
+        ) {
           throw new Error("parallel read omitted its unique sentinel");
         }
+      },
+      {
+        beforeRound: async (roundIndex) => {
+          await Promise.all(
+            stressClients.map(async (client, index) => {
+              const receipt = toolData(
+                await client.callTool(
+                  "send_to",
+                  {
+                    mode: "surface",
+                    surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+                    workspace: "workspace:bench",
+                    text: parallelStressSentinel(index, roundIndex),
+                    press_enter: true,
+                  },
+                  30_000,
+                ),
+                "read_screen round setup",
+              );
+              await requireSurfaceDeliveryProof(
+                client,
+                receipt,
+                {
+                  surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+                  workspace: "workspace:bench",
+                  text: parallelStressSentinel(index, roundIndex),
+                },
+                index,
+                "read stress round setup",
+              );
+            }),
+          );
+        },
       },
     );
     const stressClientsSurvivedReplay = stressClients.every(

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -417,6 +417,8 @@ if (command === "list-workspaces") {
 }
 
 async function startFakeCmuxSocket(socketPath, statePath, surfaceCount) {
+  const surfaceStates = new Map();
+  const surfaceMutationQueues = new Map();
   const server = net.createServer((socket) => {
     // Benchmark clients may disappear while the fake server is replying.
     // Treat that expected teardown reset as connection-local evidence, not an
@@ -430,7 +432,14 @@ async function startFakeCmuxSocket(socketPath, statePath, surfaceCount) {
         const line = buffer.slice(0, newline).trim();
         buffer = buffer.slice(newline + 1);
         if (!line) continue;
-        void handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount);
+        void handleFakeCmuxSocketLine(
+          socket,
+          line,
+          statePath,
+          surfaceCount,
+          surfaceStates,
+          surfaceMutationQueues,
+        );
       }
     });
   });
@@ -441,7 +450,34 @@ async function startFakeCmuxSocket(socketPath, statePath, surfaceCount) {
   return server;
 }
 
-async function handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount) {
+async function mutateFakeSurfaceState(
+  surfaceId,
+  surfaceStates,
+  surfaceMutationQueues,
+  mutate,
+) {
+  const previous = surfaceMutationQueues.get(surfaceId) ?? Promise.resolve();
+  const currentMutation = previous.then(() => {
+    const current = surfaceStates.get(surfaceId) ?? {
+      composer: "",
+      transcript: "",
+    };
+    const updated = mutate(current);
+    surfaceStates.set(surfaceId, updated);
+    return updated;
+  });
+  surfaceMutationQueues.set(surfaceId, currentMutation.catch(() => {}));
+  return currentMutation;
+}
+
+async function handleFakeCmuxSocketLine(
+  socket,
+  line,
+  statePath,
+  surfaceCount,
+  surfaceStates,
+  surfaceMutationQueues,
+) {
   if (!line.startsWith("{")) {
     socket.write(`${line.startsWith("list_status") ? "[]" : "OK"}\n`);
     return;
@@ -539,12 +575,18 @@ async function handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount) {
       result = { ...layout, surfaces };
       break;
     case "surface.read_text": {
-      const transcript = state.transcript ? `\n› ${state.transcript}\n` : "";
+      const surfaceState = surfaceStates.get(params.surface_id) ?? {
+        composer: "",
+        transcript: "",
+      };
+      const transcript = surfaceState.transcript
+        ? `\n› ${surfaceState.transcript}\n`
+        : "";
       result = {
         surface_ref: params.surface_id,
         text:
           `╭ OpenAI Codex ╮\nmodel: gpt-5.6-sol\n${transcript}\n› ` +
-          (state.composer ?? ""),
+          surfaceState.composer,
         lines: 8,
       };
       break;
@@ -560,18 +602,30 @@ async function handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount) {
       };
       break;
     case "surface.send_text":
-      await writeFakeState(statePath, {
-        ...state,
-        composer: `${state.composer ?? ""}${params.text ?? ""}`,
-      });
+      await mutateFakeSurfaceState(
+        params.surface_id,
+        surfaceStates,
+        surfaceMutationQueues,
+        (surfaceState) => ({
+          ...surfaceState,
+          composer: `${surfaceState.composer}${params.text ?? ""}`,
+        }),
+      );
       result = { ok: true };
       break;
     case "surface.send_key":
-      await writeFakeState(
-        statePath,
-        String(params.key).toLowerCase() === "return"
-          ? { ...state, transcript: state.composer ?? "", composer: "" }
-          : state,
+      await mutateFakeSurfaceState(
+        params.surface_id,
+        surfaceStates,
+        surfaceMutationQueues,
+        (surfaceState) =>
+          String(params.key).toLowerCase() === "return"
+            ? {
+                ...surfaceState,
+                transcript: surfaceState.composer,
+                composer: "",
+              }
+            : surfaceState,
       );
       result = { ok: true };
       break;
@@ -1162,10 +1216,6 @@ async function main() {
       daemonClients,
       sweepHoldState,
     );
-    const daemonRssMb = await totalRssMb(
-      [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
-    );
-    const daemonStats = await processStats(daemon.pid);
     const listAgents = await measureWarmToolAcrossClients(
       daemonClients,
       "list_agents",
@@ -1206,6 +1256,10 @@ async function main() {
     );
     await Promise.all(stressClients.map((client) => client.close()));
     stressClients = [];
+    const daemonRssMb = await totalRssMb(
+      [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
+    );
+    const daemonStats = await processStats(daemon.pid);
     const truthfulState =
       compact(baselineLatency.firstResults.listResult?.structuredContent) ===
         compact(daemonLatency.firstResults.listResult?.structuredContent) &&

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1076,6 +1076,10 @@ async function measureSpawnLifecycleOnce(
     requireSubmitted: false,
     canonicalText: surfaceSampleSentinel("NNN"),
     validateReceipt: async (receipt) => {
+      requireTerminalSubmission(
+        receipt,
+        "sampled surface send initial receipt",
+      );
       try {
         const terminal = await requireSubmittedDelivery(
           client,
@@ -1528,14 +1532,16 @@ async function main() {
         text: parallelStressSentinel(index, roundIndex),
         press_enter: true,
       }),
-      (receipt, requestArgs, index) =>
-        requireSurfaceDeliveryProof(
+      (receipt, requestArgs, index) => {
+        requireTerminalSubmission(receipt, "parallel send initial receipt");
+        return requireSurfaceDeliveryProof(
           stressClients[index],
           receipt,
           requestArgs,
           `surface:bench-${index}`,
           "parallel send",
-        ),
+        );
+      },
     );
     const readScreen10Parallel = await measureParallelStress(
       stressClients,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -991,6 +991,13 @@ async function measureSpawnLifecycleAcrossClients(
     spawn_close_during_sweep: summarizeTimedSamples(
       samples.map((sample) => sample.spawn_close_during_sweep),
     ),
+    surface_receipts_waitable: samples.every(
+      (sample) =>
+        typeof sample.surface.receipt.delivery_id === "string" &&
+        sample.surface.wait_for.delivery_id ===
+          sample.surface.receipt.delivery_id &&
+        sample.surface.wait_for.terminal === true,
+    ),
   };
 }
 
@@ -1237,10 +1244,7 @@ async function main() {
           }
         : {}),
       surface_receipt_is_waitable:
-        typeof firstSendAfterSpawn.surface.receipt.delivery_id === "string" &&
-        firstSendAfterSpawn.surface.wait_for.delivery_id ===
-          firstSendAfterSpawn.surface.receipt.delivery_id &&
-        firstSendAfterSpawn.surface.wait_for.terminal === true,
+        firstSendAfterSpawn.surface_receipts_waitable,
       socket_transport_only: [
         daemonLatency.list_surfaces,
         daemonLatency.read_screen,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -917,7 +917,7 @@ async function requireSurfaceDeliveryProof(
   client,
   receipt,
   requestArgs,
-  index,
+  expectedRef,
   label,
 ) {
   if (
@@ -943,7 +943,6 @@ async function requireSurfaceDeliveryProof(
     ),
     `${label} read-back`,
   );
-  const expectedRef = `surface:bench-${index}`;
   if (
     (read.surface !== requestArgs.surface && read.surface !== expectedRef) ||
     !read.content?.includes(requestArgs.text)
@@ -978,6 +977,7 @@ function summarizeTimedSamples(samples) {
 async function measureSpawnLifecycleOnce(
   client,
   sweepHoldState,
+  sampleIndex,
 ) {
   const spawnResult = toolData(
     await client.callTool(
@@ -1006,7 +1006,11 @@ async function measureSpawnLifecycleOnce(
 
   const measureSend = async (
     args,
-    { normalizeAgentId = false, requireSubmitted = true } = {},
+    {
+      normalizeAgentId = false,
+      requireSubmitted = true,
+      canonicalText,
+    } = {},
   ) => {
     const startedAt = nowMs();
     const receipt = toolData(await client.callTool("send_to", args), "send_to");
@@ -1018,6 +1022,7 @@ async function measureSpawnLifecycleOnce(
       request_bytes: requestBytes("send_to", args),
       request_sha256: requestSha256("send_to", {
         ...args,
+        ...(canonicalText ? { text: canonicalText } : {}),
         ...(normalizeAgentId ? { agent_id: "$SPAWNED_AGENT_ID" } : {}),
       }),
       lock_hold_ms: requireFiniteLockHold(
@@ -1057,36 +1062,40 @@ async function measureSpawnLifecycleOnce(
     },
     { normalizeAgentId: true },
   );
-  const surface = await measureSend(
-    {
-      mode: "surface",
-      surface: spawnResult.surface_id,
-      workspace: "workspace:bench",
-      text: "surface benchmark",
-      press_enter: true,
-    },
-    { requireSubmitted: false },
-  );
+  const surfaceArgs = {
+    mode: "surface",
+    surface: spawnResult.surface_id,
+    workspace: "workspace:bench",
+    text: surfaceSampleSentinel(sampleIndex),
+    press_enter: true,
+  };
+  const surface = await measureSend(surfaceArgs, {
+    requireSubmitted: false,
+    canonicalText: surfaceSampleSentinel("NNN"),
+  });
   let surfaceWaitFor;
-  if (typeof surface.receipt.delivery_id === "string") {
-    try {
-      surfaceWaitFor = toolData(
-        await client.callTool("wait_for", {
-          delivery_id: surface.receipt.delivery_id,
-          timeout_ms: 2_000,
-        }),
-        "wait_for(surface receipt)",
-      );
-    } catch (error) {
-      surfaceWaitFor = {
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  } else {
+  try {
+    const terminal = await requireSubmittedDelivery(
+      client,
+      surface.receipt,
+      "sampled surface send",
+    );
+    await requireSurfaceDeliveryProof(
+      client,
+      terminal,
+      surfaceArgs,
+      "surface:bench-spawn",
+      "sampled surface send",
+    );
+    surfaceWaitFor = {
+      ...terminal,
+      read_back_verified: true,
+    };
+  } catch (error) {
     surfaceWaitFor = {
       ok: false,
-      error: "surface receipt omitted delivery_id",
+      read_back_verified: false,
+      error: error instanceof Error ? error.message : String(error),
     };
   }
 
@@ -1246,8 +1255,11 @@ async function measureSpawnLifecycleAcrossClients(
 ) {
   const samples = [];
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
-    for (const client of clients) {
-      samples.push(await measureSpawnLifecycleOnce(client, sweepHoldState));
+    for (const [clientIndex, client] of clients.entries()) {
+      const sampleIndex = roundIndex * clients.length + clientIndex;
+      samples.push(
+        await measureSpawnLifecycleOnce(client, sweepHoldState, sampleIndex),
+      );
     }
   }
   return {
@@ -1272,9 +1284,14 @@ async function measureSpawnLifecycleAcrossClients(
           sample.surface.receipt.delivery_id &&
         sample.surface.wait_for.terminal === true &&
         sample.surface.wait_for.delivery_state === "submitted" &&
-        sample.surface.wait_for.submit_verified === true,
+        sample.surface.wait_for.submit_verified === true &&
+        sample.surface.wait_for.read_back_verified === true,
     ),
   };
+}
+
+function surfaceSampleSentinel(sampleIndex) {
+  return `surface bench ${String(sampleIndex).padStart(3, "0")}`;
 }
 
 function parallelStressSentinel(index, roundIndex) {
@@ -1497,7 +1514,7 @@ async function main() {
           stressClients[index],
           receipt,
           requestArgs,
-          index,
+          `surface:bench-${index}`,
           "parallel send",
         ),
     );
@@ -1552,7 +1569,7 @@ async function main() {
                   workspace: "workspace:bench",
                   text: parallelStressSentinel(index, roundIndex),
                 },
-                index,
+                `surface:bench-${index}`,
                 "read stress round setup",
               );
             }),

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -927,8 +927,8 @@ async function requireSurfaceDeliveryProof(
     typeof receipt.delivery_id === "string"
   ) {
     await requireSubmittedDelivery(client, receipt, label);
-  } else if (receipt.typed !== true || receipt.submit_attempted !== true) {
-    throw new Error(`${label} was neither waitable nor typed`);
+  } else {
+    throw new Error(`${label} was not verified as submitted`);
   }
   const read = toolData(
     await client.callTool(

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -22,6 +22,7 @@ const distIndex = join(repoRoot, "dist", "index.js");
 const distDaemon = join(repoRoot, "dist", "daemon.js");
 const DEFAULT_CLIENTS = 8;
 const DEFAULT_ROUNDS = 12;
+const PARALLEL_STRESS_COUNT = 10;
 const LATENCY_REGRESSION_RATIO = 1.25;
 const LATENCY_REGRESSION_SLACK_MS = 5;
 const READ_SCREEN_P50_BUDGET_MS = 250;
@@ -768,7 +769,28 @@ async function waitForLifecycleWaiter(
   throw new Error("close_surface never queued behind the held lifecycle sweep");
 }
 
-async function measureFirstSendAfterSpawn(
+function summarizeTimedSamples(samples) {
+  const transports = samples.map((sample) => sample.transport);
+  return {
+    request_bytes: samples[0]?.request_bytes,
+    request_sha256: samples[0]?.request_sha256,
+    p50_ms: round(percentile(samples.map((sample) => sample.elapsed_ms), 50)),
+    p95_ms: round(percentile(samples.map((sample) => sample.elapsed_ms), 95)),
+    lock_hold_ms: Math.max(
+      ...samples.map((sample) => sample.lock_hold_ms ?? 0),
+    ),
+    transport: transports.every((value) => value === "socket")
+      ? "socket"
+      : "cli",
+    transport_fallbacks: [
+      ...new Set(samples.flatMap((sample) => sample.transport_fallbacks ?? [])),
+    ],
+    sample_count: samples.length,
+    sampling: "sampled",
+  };
+}
+
+async function measureSpawnLifecycleOnce(
   client,
   sweepHoldState,
 ) {
@@ -871,36 +893,6 @@ async function measureFirstSendAfterSpawn(
     };
   }
 
-  const measureWarmTool = async (name, args) => {
-    const samples = [];
-    const transports = [];
-    const fallbackSources = new Set();
-    for (let index = 0; index < rounds; index += 1) {
-      const startedAt = nowMs();
-      const receipt = toolData(await client.callTool(name, args, 30_000), name);
-      samples.push(nowMs() - startedAt);
-      transports.push(operationTransport(receipt, name));
-      for (const source of receipt.transport_fallbacks ?? []) {
-        fallbackSources.add(source);
-      }
-    }
-    return {
-      request_bytes: requestBytes(name, args),
-      request_sha256: requestSha256(name, args),
-      lock_hold_ms: 0,
-      p50_ms: round(percentile(samples, 50)),
-      p95_ms: round(percentile(samples, 95)),
-      transport: transports.every((value) => value === "socket")
-        ? "socket"
-        : "cli",
-      transport_fallbacks: [...fallbackSources],
-    };
-  };
-  const listAgents = await measureWarmTool("list_agents", {
-    detail: "summary",
-  });
-  const controlHealth = await measureWarmTool("control_health", {});
-
   const closeArgs = {
     scope: "agent",
     agent_id: spawnResult.agent_id,
@@ -942,10 +934,95 @@ async function measureFirstSendAfterSpawn(
     first,
     second,
     surface: { ...surface, wait_for: surfaceWaitFor },
-    list_agents: listAgents,
-    control_health: controlHealth,
     spawn_close_during_sweep: spawnCloseDuringSweep,
   };
+}
+
+async function measureWarmToolAcrossClients(clients, name, args) {
+  const samples = [];
+  for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
+    await Promise.all(
+      clients.map(async (client) => {
+        const startedAt = nowMs();
+        const receipt = toolData(
+          await client.callTool(name, args, 30_000),
+          name,
+        );
+        samples.push({
+          elapsed_ms: nowMs() - startedAt,
+          request_bytes: requestBytes(name, args),
+          request_sha256: requestSha256(name, args),
+          lock_hold_ms: receipt.timings_ms?.lock_hold ?? 0,
+          transport: operationTransport(receipt, name),
+          transport_fallbacks: receipt.transport_fallbacks ?? [],
+        });
+      }),
+    );
+  }
+  return summarizeTimedSamples(samples);
+}
+
+async function measureSpawnLifecycleAcrossClients(clients, sweepHoldState) {
+  const samples = [];
+  for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
+    for (const client of clients) {
+      samples.push(await measureSpawnLifecycleOnce(client, sweepHoldState));
+    }
+  }
+  return {
+    first: samples[0].first,
+    second: samples[0].second,
+    surface: samples[0].surface,
+    spawn_close_sample: samples[0].spawn_close_during_sweep,
+    sampled: summarizeTimedSamples(samples.map((sample) => sample.first)),
+    send_to_agent_warm: summarizeTimedSamples(
+      samples.map((sample) => sample.second),
+    ),
+    send_to_surface_warm: summarizeTimedSamples(
+      samples.map((sample) => sample.surface),
+    ),
+    spawn_close_during_sweep: summarizeTimedSamples(
+      samples.map((sample) => sample.spawn_close_during_sweep),
+    ),
+  };
+}
+
+async function measureParallelStress(client, name, args) {
+  const samples = [];
+  const request = {
+    parallel: PARALLEL_STRESS_COUNT,
+    name,
+    arguments: args,
+  };
+  for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
+    const startedAt = nowMs();
+    const receipts = await Promise.all(
+      Array.from({ length: PARALLEL_STRESS_COUNT }, async () =>
+        toolData(await client.callTool(name, args, 30_000), name),
+      ),
+    );
+    samples.push({
+      elapsed_ms: nowMs() - startedAt,
+      request_bytes: requestBytes(name, args) * PARALLEL_STRESS_COUNT,
+      request_sha256: createHash("sha256")
+        .update(JSON.stringify(canonicalize(request)))
+        .digest("hex"),
+      lock_hold_ms: Math.max(
+        ...receipts.map((receipt) => receipt.timings_ms?.lock_hold ?? 0),
+      ),
+      transport: receipts.every(
+        (receipt) => operationTransport(receipt, name) === "socket",
+      )
+        ? "socket"
+        : "cli",
+      transport_fallbacks: [
+        ...new Set(
+          receipts.flatMap((receipt) => receipt.transport_fallbacks ?? []),
+        ),
+      ],
+    });
+  }
+  return { ...summarizeTimedSamples(samples), stress: true };
 }
 
 async function main() {
@@ -1056,9 +1133,39 @@ async function main() {
       );
     }
     const daemonLatency = await measureLatency(daemonClients);
-    const firstSendAfterSpawn = await measureFirstSendAfterSpawn(
-      daemonClients[0],
+    const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients(
+      daemonClients,
       sweepHoldState,
+    );
+    const listAgents = await measureWarmToolAcrossClients(
+      daemonClients,
+      "list_agents",
+      { detail: "summary" },
+    );
+    const controlHealth = await measureWarmToolAcrossClients(
+      daemonClients,
+      "control_health",
+      {},
+    );
+    const sendToSurface10Parallel = await measureParallelStress(
+      daemonClients[0],
+      "send_to",
+      {
+        mode: "surface",
+        surface: "surface:bench-0",
+        workspace: "workspace:bench",
+        text: "parallel surface benchmark",
+        press_enter: true,
+      },
+    );
+    const readScreen10Parallel = await measureParallelStress(
+      daemonClients[0],
+      "read_screen",
+      {
+        surface: "surface:bench-0",
+        workspace: "workspace:bench",
+        lines: 5,
+      },
     );
     const daemonRssMb = await totalRssMb(
       [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(
@@ -1092,9 +1199,9 @@ async function main() {
             local_read_screen_p50_within_250ms:
               daemonLatency.read_screen.p50_ms <= READ_SCREEN_P50_BUDGET_MS,
             local_first_send_after_spawn_within_2s:
-              firstSendAfterSpawn.first.elapsed_ms <= 2_000,
+              firstSendAfterSpawn.sampled.p50_ms <= 2_000,
             local_cli_send_within_4s:
-              firstSendAfterSpawn.surface.elapsed_ms <= 4_000,
+              firstSendAfterSpawn.send_to_surface_warm.p50_ms <= 4_000,
           }
         : {}),
       surface_receipt_is_waitable:
@@ -1108,9 +1215,11 @@ async function main() {
         firstSendAfterSpawn.first,
         firstSendAfterSpawn.second,
         firstSendAfterSpawn.surface,
-        firstSendAfterSpawn.list_agents,
-        firstSendAfterSpawn.control_health,
+        listAgents,
+        controlHealth,
         firstSendAfterSpawn.spawn_close_during_sweep,
+        sendToSurface10Parallel,
+        readScreen10Parallel,
       ].every((measurement) => measurement.transport === "socket"),
     };
     const green = Object.values(gates).every(Boolean);
@@ -1131,39 +1240,98 @@ async function main() {
           "control_health",
           "spawn_close_during_sweep",
           "first_send_after_spawn",
+          "send_to_surface_10_parallel",
+          "read_screen_10_parallel",
         ],
+        row_metadata: {
+          list_surfaces: {
+            sampling: "sampled",
+            samples_per_run: clientCount * rounds,
+          },
+          read_screen: {
+            sampling: "sampled",
+            samples_per_run: clientCount * rounds,
+          },
+          send_to_surface_warm: {
+            sampling: "sampled",
+            samples_per_run: firstSendAfterSpawn.send_to_surface_warm.sample_count,
+          },
+          send_to_agent_warm: {
+            sampling: "sampled",
+            samples_per_run: firstSendAfterSpawn.send_to_agent_warm.sample_count,
+          },
+          list_agents: {
+            sampling: "sampled",
+            samples_per_run: listAgents.sample_count,
+          },
+          control_health: {
+            sampling: "sampled",
+            samples_per_run: controlHealth.sample_count,
+          },
+          spawn_close_during_sweep: {
+            sampling: "sampled",
+            samples_per_run:
+              firstSendAfterSpawn.spawn_close_during_sweep.sample_count,
+          },
+          first_send_after_spawn: {
+            sampling: "sampled",
+            samples_per_run: firstSendAfterSpawn.sampled.sample_count,
+          },
+          send_to_surface_10_parallel: {
+            sampling: "sampled",
+            samples_per_run: sendToSurface10Parallel.sample_count,
+            stress: true,
+          },
+          read_screen_10_parallel: {
+            sampling: "sampled",
+            samples_per_run: readScreen10Parallel.sample_count,
+            stress: true,
+          },
+        },
         bytes: {
           list_surfaces: daemonLatency.list_surfaces.request_bytes,
           read_screen: daemonLatency.read_screen.request_bytes,
-          send_to_surface_warm: firstSendAfterSpawn.surface.request_bytes,
-          send_to_agent_warm: firstSendAfterSpawn.second.request_bytes,
-          list_agents: firstSendAfterSpawn.list_agents.request_bytes,
-          control_health: firstSendAfterSpawn.control_health.request_bytes,
+          send_to_surface_warm:
+            firstSendAfterSpawn.send_to_surface_warm.request_bytes,
+          send_to_agent_warm:
+            firstSendAfterSpawn.send_to_agent_warm.request_bytes,
+          list_agents: listAgents.request_bytes,
+          control_health: controlHealth.request_bytes,
           spawn_close_during_sweep:
             firstSendAfterSpawn.spawn_close_during_sweep.request_bytes,
-          first_send_after_spawn: firstSendAfterSpawn.first.request_bytes,
+          first_send_after_spawn: firstSendAfterSpawn.sampled.request_bytes,
+          send_to_surface_10_parallel: sendToSurface10Parallel.request_bytes,
+          read_screen_10_parallel: readScreen10Parallel.request_bytes,
         },
         request_sha256: {
           list_surfaces: daemonLatency.list_surfaces.request_sha256,
           read_screen: daemonLatency.read_screen.request_sha256,
-          send_to_surface_warm: firstSendAfterSpawn.surface.request_sha256,
-          send_to_agent_warm: firstSendAfterSpawn.second.request_sha256,
-          list_agents: firstSendAfterSpawn.list_agents.request_sha256,
-          control_health: firstSendAfterSpawn.control_health.request_sha256,
+          send_to_surface_warm:
+            firstSendAfterSpawn.send_to_surface_warm.request_sha256,
+          send_to_agent_warm:
+            firstSendAfterSpawn.send_to_agent_warm.request_sha256,
+          list_agents: listAgents.request_sha256,
+          control_health: controlHealth.request_sha256,
           spawn_close_during_sweep:
             firstSendAfterSpawn.spawn_close_during_sweep.request_sha256,
-          first_send_after_spawn: firstSendAfterSpawn.first.request_sha256,
+          first_send_after_spawn: firstSendAfterSpawn.sampled.request_sha256,
+          send_to_surface_10_parallel: sendToSurface10Parallel.request_sha256,
+          read_screen_10_parallel: readScreen10Parallel.request_sha256,
         },
         transport: {
           list_surfaces: daemonLatency.list_surfaces.transport,
           read_screen: daemonLatency.read_screen.transport,
-          send_to_surface_warm: firstSendAfterSpawn.surface.transport,
-          send_to_agent_warm: firstSendAfterSpawn.second.transport,
-          list_agents: firstSendAfterSpawn.list_agents.transport,
-          control_health: firstSendAfterSpawn.control_health.transport,
+          send_to_surface_warm:
+            firstSendAfterSpawn.send_to_surface_warm.transport,
+          send_to_agent_warm:
+            firstSendAfterSpawn.send_to_agent_warm.transport,
+          list_agents: listAgents.transport,
+          control_health: controlHealth.transport,
           spawn_close_during_sweep:
             firstSendAfterSpawn.spawn_close_during_sweep.transport,
-          first_send_after_spawn: firstSendAfterSpawn.first.transport,
+          first_send_after_spawn: firstSendAfterSpawn.sampled.transport,
+          send_to_surface_10_parallel: sendToSurface10Parallel.transport,
+          read_screen_10_parallel: readScreen10Parallel.transport,
         },
       },
       rss: {
@@ -1182,29 +1350,18 @@ async function main() {
         daemon_path: {
           list_surfaces: daemonLatency.list_surfaces,
           read_screen: daemonLatency.read_screen,
-          list_agents: firstSendAfterSpawn.list_agents,
-          control_health: firstSendAfterSpawn.control_health,
+          list_agents: listAgents,
+          control_health: controlHealth,
+          send_to_surface_10_parallel: sendToSurface10Parallel,
+          read_screen_10_parallel: readScreen10Parallel,
         },
         first_send_after_spawn: firstSendAfterSpawn,
-        send_to_surface_warm: {
-          p50_ms: firstSendAfterSpawn.surface.elapsed_ms,
-          p95_ms: firstSendAfterSpawn.surface.elapsed_ms,
-          lock_hold_ms: firstSendAfterSpawn.surface.lock_hold_ms ?? 0,
-          transport: firstSendAfterSpawn.surface.transport,
-        },
-        send_to_agent_warm: {
-          p50_ms: firstSendAfterSpawn.second.elapsed_ms,
-          p95_ms: firstSendAfterSpawn.second.elapsed_ms,
-          lock_hold_ms: firstSendAfterSpawn.second.lock_hold_ms ?? 0,
-          transport: firstSendAfterSpawn.second.transport,
-        },
-        spawn_close_during_sweep: {
-          p50_ms: firstSendAfterSpawn.spawn_close_during_sweep.elapsed_ms,
-          p95_ms: firstSendAfterSpawn.spawn_close_during_sweep.elapsed_ms,
-          lock_hold_ms:
-            firstSendAfterSpawn.spawn_close_during_sweep.lock_hold_ms,
-          transport: firstSendAfterSpawn.spawn_close_during_sweep.transport,
-        },
+        send_to_surface_warm: firstSendAfterSpawn.send_to_surface_warm,
+        send_to_agent_warm: firstSendAfterSpawn.send_to_agent_warm,
+        spawn_close_during_sweep:
+          firstSendAfterSpawn.spawn_close_during_sweep,
+        send_to_surface_10_parallel: sendToSurface10Parallel,
+        read_screen_10_parallel: readScreen10Parallel,
       },
       daemon_cpu_pct: round(daemonStats.cpuPct, 2),
       gates,

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -6,6 +6,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  rename,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -13,7 +14,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import net from "node:net";
 import { serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 
@@ -549,7 +550,7 @@ async function handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount) {
       break;
     }
     case "surface.split":
-      await writeFile(statePath, JSON.stringify({ ...state, closed: false }));
+      await writeFakeState(statePath, { ...state, closed: false });
       result = {
         ...layout,
         surface_ref: spawned.ref,
@@ -559,35 +560,30 @@ async function handleFakeCmuxSocketLine(socket, line, statePath, surfaceCount) {
       };
       break;
     case "surface.send_text":
-      await writeFile(
-        statePath,
-        JSON.stringify({
-          ...state,
-          composer: `${state.composer ?? ""}${params.text ?? ""}`,
-        }),
-      );
+      await writeFakeState(statePath, {
+        ...state,
+        composer: `${state.composer ?? ""}${params.text ?? ""}`,
+      });
       result = { ok: true };
       break;
     case "surface.send_key":
-      await writeFile(
+      await writeFakeState(
         statePath,
-        JSON.stringify(
-          String(params.key).toLowerCase() === "return"
-            ? { ...state, transcript: state.composer ?? "", composer: "" }
-            : state,
-        ),
+        String(params.key).toLowerCase() === "return"
+          ? { ...state, transcript: state.composer ?? "", composer: "" }
+          : state,
       );
       result = { ok: true };
       break;
     case "surface.close":
-      await writeFile(statePath, JSON.stringify({ ...state, closed: true }));
+      await writeFakeState(statePath, { ...state, closed: true });
       result = { ok: true };
       break;
     case "tab.action":
-      await writeFile(
-        statePath,
-        JSON.stringify({ ...state, title: params.title ?? state.title }),
-      );
+      await writeFakeState(statePath, {
+        ...state,
+        title: params.title ?? state.title,
+      });
       result = { ok: true };
       break;
     case "workspace.select":
@@ -721,6 +717,12 @@ async function readFakeState(statePath) {
   } catch {
     return {};
   }
+}
+
+async function writeFakeState(statePath, state) {
+  const temporaryPath = `${statePath}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, JSON.stringify(state));
+  await rename(temporaryPath, statePath);
 }
 
 async function armSweepHold(statePath, holdToken) {
@@ -962,11 +964,16 @@ async function measureWarmToolAcrossClients(clients, name, args) {
   return summarizeTimedSamples(samples);
 }
 
-async function measureSpawnLifecycleAcrossClients(clients, sweepHoldState) {
+async function measureSpawnLifecycleAcrossClients(
+  clients,
+  sweepHoldState,
+  onFirstSample,
+) {
   const samples = [];
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     for (const client of clients) {
       samples.push(await measureSpawnLifecycleOnce(client, sweepHoldState));
+      if (samples.length === 1) await onFirstSample?.();
     }
   }
   return {
@@ -987,23 +994,32 @@ async function measureSpawnLifecycleAcrossClients(clients, sweepHoldState) {
   };
 }
 
-async function measureParallelStress(client, name, args) {
+async function measureParallelStress(clients, name, args) {
   const samples = [];
+  const requests = Array.from({ length: PARALLEL_STRESS_COUNT }, (_, index) =>
+    typeof args === "function" ? args(index) : args,
+  );
   const request = {
     parallel: PARALLEL_STRESS_COUNT,
     name,
-    arguments: args,
+    arguments: requests,
   };
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     const startedAt = nowMs();
     const receipts = await Promise.all(
-      Array.from({ length: PARALLEL_STRESS_COUNT }, async () =>
-        toolData(await client.callTool(name, args, 30_000), name),
+      requests.map(async (requestArgs, index) =>
+        toolData(
+          await clients[index].callTool(name, requestArgs, 30_000),
+          name,
+        ),
       ),
     );
     samples.push({
       elapsed_ms: nowMs() - startedAt,
-      request_bytes: requestBytes(name, args) * PARALLEL_STRESS_COUNT,
+      request_bytes: requests.reduce(
+        (total, requestArgs) => total + requestBytes(name, requestArgs),
+        0,
+      ),
       request_sha256: createHash("sha256")
         .update(JSON.stringify(canonicalize(request)))
         .digest("hex"),
@@ -1054,13 +1070,14 @@ async function main() {
   const daemonSocket = join(socketRoot, "d.sock");
   const missingCmuxSocket = join(socketRoot, "m.sock");
   const fakeCmuxState = join(tempRoot, "fake-cmux-state.json");
+  const surfaceCount = Math.max(clientCount, PARALLEL_STRESS_COUNT);
   const fakeCmuxSocketServer =
     process.env.CMUXLAYER_BENCH_FORCE_CLI_FALLBACK === "1"
       ? net.createServer((socket) => socket.destroy())
       : await startFakeCmuxSocket(
           missingCmuxSocket,
           fakeCmuxState,
-          clientCount,
+          surfaceCount,
         );
   if (process.env.CMUXLAYER_BENCH_FORCE_CLI_FALLBACK === "1") {
     await new Promise((resolvePromise, reject) => {
@@ -1077,7 +1094,7 @@ async function main() {
     CMUX_TAB_ID: "",
     PATH: `${binDir}:${process.env.PATH ?? ""}`,
     CMUX_SOCKET_PATH: missingCmuxSocket,
-    CMUXLAYER_BENCH_SURFACES: String(clientCount),
+    CMUXLAYER_BENCH_SURFACES: String(surfaceCount),
     CMUXLAYER_BENCH_STATE: fakeCmuxState,
     CMUXLAYER_STATE_DIR: join(tempRoot, "state"),
     CMUXLAYER_CONTROL_HEALTH_INTERVAL_MS: "0",
@@ -1088,6 +1105,7 @@ async function main() {
 
   let baselineClients = [];
   let daemonClients = [];
+  let stressClients = [];
   let daemon = null;
   try {
     baselineClients = await startClients("baseline", clientCount, {
@@ -1133,9 +1151,19 @@ async function main() {
       );
     }
     const daemonLatency = await measureLatency(daemonClients);
+    let daemonRssMb;
+    let daemonStats;
     const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients(
       daemonClients,
       sweepHoldState,
+      async () => {
+        daemonRssMb = await totalRssMb(
+          [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(
+            Boolean,
+          ),
+        );
+        daemonStats = await processStats(daemon.pid);
+      },
     );
     const listAgents = await measureWarmToolAcrossClients(
       daemonClients,
@@ -1147,32 +1175,36 @@ async function main() {
       "control_health",
       {},
     );
-    const sendToSurface10Parallel = await measureParallelStress(
-      daemonClients[0],
-      "send_to",
+    stressClients = await startClients(
+      "daemon-stress",
+      PARALLEL_STRESS_COUNT,
       {
+        ...baseEnv,
+        CMUXLAYER_DAEMON_SOCKET: daemonSocket,
+      },
+    );
+    const sendToSurface10Parallel = await measureParallelStress(
+      stressClients,
+      "send_to",
+      (index) => ({
         mode: "surface",
-        surface: "surface:bench-0",
+        surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
         workspace: "workspace:bench",
         text: "parallel surface benchmark",
         press_enter: true,
-      },
+      }),
     );
     const readScreen10Parallel = await measureParallelStress(
-      daemonClients[0],
+      stressClients,
       "read_screen",
-      {
-        surface: "surface:bench-0",
+      (index) => ({
+        surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
         workspace: "workspace:bench",
         lines: 5,
-      },
+      }),
     );
-    const daemonRssMb = await totalRssMb(
-      [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(
-        Boolean,
-      ),
-    );
-    const daemonStats = await processStats(daemon.pid);
+    await Promise.all(stressClients.map((client) => client.close()));
+    stressClients = [];
     const truthfulState =
       compact(baselineLatency.firstResults.listResult?.structuredContent) ===
         compact(daemonLatency.firstResults.listResult?.structuredContent) &&
@@ -1394,7 +1426,9 @@ async function main() {
     }
   } finally {
     await Promise.all(
-      [...baselineClients, ...daemonClients].map((client) => client.close()),
+      [...baselineClients, ...daemonClients, ...stressClients].map((client) =>
+        client.close(),
+      ),
     );
     await stopChild(daemon);
     await new Promise((resolvePromise) =>

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -967,13 +967,11 @@ async function measureWarmToolAcrossClients(clients, name, args) {
 async function measureSpawnLifecycleAcrossClients(
   clients,
   sweepHoldState,
-  onFirstSample,
 ) {
   const samples = [];
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     for (const client of clients) {
       samples.push(await measureSpawnLifecycleOnce(client, sweepHoldState));
-      if (samples.length === 1) await onFirstSample?.();
     }
   }
   return {
@@ -1165,15 +1163,11 @@ async function main() {
     const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients(
       daemonClients,
       sweepHoldState,
-      async () => {
-        daemonRssMb = await totalRssMb(
-          [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(
-            Boolean,
-          ),
-        );
-        daemonStats = await processStats(daemon.pid);
-      },
     );
+    daemonRssMb = await totalRssMb(
+      [daemon.pid, ...daemonClients.map((client) => client.pid)].filter(Boolean),
+    );
+    daemonStats = await processStats(daemon.pid);
     const listAgents = await measureWarmToolAcrossClients(
       daemonClients,
       "list_agents",

--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -1076,7 +1076,11 @@ async function measureSpawnLifecycleAcrossClients(
   };
 }
 
-async function measureParallelStress(clients, name, args) {
+function parallelStressSentinel(index) {
+  return `parallel surface benchmark ${index}`;
+}
+
+async function measureParallelStress(clients, name, args, validateReceipt) {
   const samples = [];
   const requests = Array.from({ length: PARALLEL_STRESS_COUNT }, (_, index) =>
     typeof args === "function" ? args(index) : args,
@@ -1089,11 +1093,14 @@ async function measureParallelStress(clients, name, args) {
   for (let roundIndex = 0; roundIndex < rounds; roundIndex += 1) {
     const startedAt = nowMs();
     const receipts = await Promise.all(
-      requests.map(async (requestArgs, index) =>
-        toolData(
+      requests.map(async (requestArgs, index) => {
+        const receipt = toolData(
           await clients[index].callTool(name, requestArgs, 30_000),
           name,
-        ),
+        );
+        validateReceipt?.(receipt, requestArgs, index);
+        return receipt;
+      }),
       ),
     );
     samples.push({
@@ -1262,7 +1269,7 @@ async function main() {
         mode: "surface",
         surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
         workspace: "workspace:bench",
-        text: "parallel surface benchmark",
+        text: parallelStressSentinel(index),
         press_enter: true,
       }),
     );
@@ -1273,7 +1280,20 @@ async function main() {
         surface: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
         workspace: "workspace:bench",
         lines: 5,
+        raw: true,
       }),
+      (receipt, requestArgs, index) => {
+        const expectedRef = `surface:bench-${index}`;
+        if (
+          receipt.surface !== requestArgs.surface &&
+          receipt.surface !== expectedRef
+        ) {
+          throw new Error("parallel read returned the wrong surface");
+        }
+        if (!receipt.content?.includes(parallelStressSentinel(index))) {
+          throw new Error("parallel read omitted its unique sentinel");
+        }
+      },
     );
     const stressClientsSurvivedReplay = stressClients.every(
       (client) => client.alive,

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -56,6 +56,31 @@ export function baselineContentSha256(baseline) {
   return createHash("sha256").update(canonicalJson(content)).digest("hex");
 }
 
+function historyEntryContentSha256(entry) {
+  const { content_sha256: _attestation, ...content } = entry;
+  return createHash("sha256").update(canonicalJson(content)).digest("hex");
+}
+
+function validHistoryEntry(entry) {
+  if (!/^[0-9a-f]{40}$/.test(entry?.source?.git_sha ?? "")) return false;
+  if (
+    !Number.isSafeInteger(entry?.source?.workflow_run_id) ||
+    entry.source.workflow_run_id <= 0 ||
+    entry?.content_sha256 !== historyEntryContentSha256(entry)
+  ) {
+    return false;
+  }
+  return [...CANONICAL_OPERATIONS, "cli_send_ms"].every((operation) => {
+    const measurement = entry?.measurements?.[operation];
+    if (!Number.isFinite(measurement?.p50_ms)) return false;
+    if (operation === "cli_send_ms") return true;
+    return (
+      Number.isFinite(measurement.p95_ms) &&
+      Number.isFinite(measurement.lock_hold_ms)
+    );
+  });
+}
+
 export function isAttestedLegacyBaseline(baseline) {
   return (
     baseline?.schema_version === 2 &&
@@ -231,6 +256,28 @@ function operationMargin(
   return rounded(Math.max(spread, varianceMargin));
 }
 
+function operationMarginRule(
+  baseline,
+  operation,
+  history,
+  historyDegraded = false,
+) {
+  const metadata = baseline.replay.row_metadata[operation];
+  if (
+    historyDegraded ||
+    metadata.stress === true ||
+    metadata.sampling === "single_shot" ||
+    metadata.samples_per_run < 12
+  ) {
+    return "constant +300ms (single-shot)";
+  }
+  const measuredRuns = history.filter((entry) =>
+    Number.isFinite(entry?.measurements?.[operation]?.p50_ms),
+  ).length;
+  const runCount = Math.max(1, measuredRuns);
+  return `measured (${runCount} ${runCount === 1 ? "run" : "runs"})`;
+}
+
 export function requireBaselineIncreaseReason(measurementPairs, reason) {
   const raisesCommittedBaseline = measurementPairs.some(
     ([proposed, committed]) => proposed > committed,
@@ -324,7 +371,11 @@ export function appendGreenMainHistory(history, result, context) {
       ]),
     ),
   };
-  return [...existing, entry].slice(-BENCHMARK_HISTORY_LIMIT);
+  const attestedEntry = {
+    ...entry,
+    content_sha256: historyEntryContentSha256(entry),
+  };
+  return [...existing, attestedEntry].slice(-BENCHMARK_HISTORY_LIMIT);
 }
 
 export async function readBenchmarkHistory(historyPath) {
@@ -335,6 +386,13 @@ export async function readBenchmarkHistory(historyPath) {
         runs: [],
         degraded: true,
         reason: `${historyPath} does not contain a runs array`,
+      };
+    }
+    if (!parsed.runs.every(validHistoryEntry)) {
+      return {
+        runs: [],
+        degraded: true,
+        reason: `${historyPath} contains a malformed entry`,
       };
     }
     return { runs: parsed.runs, degraded: false };
@@ -398,6 +456,7 @@ function row(
     stress: metadata.stress === true,
     history_degraded: metadata.history_degraded === true,
     margin_ms: metadata.margin_ms,
+    margin_rule: metadata.margin_rule,
     passed,
   };
 }
@@ -416,6 +475,7 @@ function exactRow(operation, metric, committed, current, unit, metadata = {}) {
     sampling: metadata.sampling,
     stress: metadata.stress === true,
     history_degraded: metadata.history_degraded === true,
+    margin_rule: metadata.margin_rule,
   };
 }
 
@@ -441,6 +501,12 @@ export function compareBenchmark(
       history,
       historyDegraded,
     );
+    const marginRule = operationMarginRule(
+      baseline,
+      operation,
+      history,
+      historyDegraded,
+    );
     for (const metric of ["p50_ms", "p95_ms"]) {
       rows.push(
         row(
@@ -459,6 +525,7 @@ export function compareBenchmark(
           {
             ...metadata,
             margin_ms: marginMs,
+            margin_rule: marginRule,
             history_degraded: historyDegraded,
           },
         ),
@@ -468,6 +535,12 @@ export function compareBenchmark(
   for (const operation of baseline.replay.operations) {
     const metadata = baseline.replay.row_metadata[operation];
     const marginMs = operationMargin(
+      baseline,
+      operation,
+      history,
+      historyDegraded,
+    );
+    const marginRule = operationMarginRule(
       baseline,
       operation,
       history,
@@ -490,6 +563,7 @@ export function compareBenchmark(
         {
           ...metadata,
           margin_ms: marginMs,
+          margin_rule: marginRule,
           history_degraded: historyDegraded,
         },
       ),
@@ -522,6 +596,12 @@ export function compareBenchmark(
           history,
           historyDegraded,
         ),
+        margin_rule: operationMarginRule(
+          baseline,
+          "send_to_surface_warm",
+          history,
+          historyDegraded,
+        ),
         history_degraded: historyDegraded,
       },
     ),
@@ -536,6 +616,12 @@ export function compareBenchmark(
         "bytes",
         {
           ...baseline.replay.row_metadata[operation],
+          margin_rule: operationMarginRule(
+            baseline,
+            operation,
+            history,
+            historyDegraded,
+          ),
           history_degraded: historyDegraded,
         },
       ),
@@ -549,6 +635,19 @@ export function compareBenchmark(
         ? `${entry.operation} ${metric}: ${entry.current} ${entry.unit} does not match committed ${entry.baseline} ${entry.unit}`
         : `${entry.operation} ${metric}: ${entry.current}${entry.unit} exceeds ${entry.ceiling}${entry.unit}`;
     });
+  for (const operation of baseline.replay.operations) {
+    const expected = baseline.replay.row_metadata[operation];
+    const candidate = result?.replay?.row_metadata?.[operation];
+    if (
+      candidate?.sampling !== expected.sampling ||
+      candidate?.samples_per_run !== expected.samples_per_run ||
+      (candidate?.stress === true) !== (expected.stress === true)
+    ) {
+      failures.push(
+        `candidate row_metadata.${operation} does not match the committed sampling workload`,
+      );
+    }
+  }
   if (historyDegraded) {
     failures.push(
       `benchmark history degraded: ${historyDegradedReason ?? "untrusted cache"}; conservative +300ms margins active`,
@@ -603,11 +702,11 @@ function formatted(value, unit) {
 
 export function renderMarkdownComparison(baseline, result, comparison) {
   const tableHeader = [
-    "| Operation | Transport | Sampling | Metric | Baseline | Current | Ceiling | Status |",
-    "|---|:---:|:---:|---:|---:|---:|---:|:---:|",
+    "| Operation | Transport | Sampling | Margin rule | Metric | Baseline | Current | Ceiling | Status |",
+    "|---|:---:|:---:|:---:|---:|---:|---:|---:|:---:|",
   ];
   const tableRow = (entry) =>
-    `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.sampling ?? "single_shot"}${entry.stress ? " · stress" : ""}${entry.history_degraded ? " · history-degraded · wide-margin" : ""} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`;
+    `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.sampling ?? "single_shot"}${entry.stress ? " · stress" : ""}${entry.history_degraded ? " · history-degraded · wide-margin" : ""} | ${entry.margin_rule} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`;
   const changed = comparison.rows.filter(
     (entry) => !entry.passed || entry.current !== entry.baseline,
   );

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -240,7 +240,6 @@ function operationMargin(
   const metadata = baseline.replay.row_metadata[operation];
   if (
     historyDegraded ||
-    metadata.stress === true ||
     metadata.sampling === "single_shot" ||
     metadata.samples_per_run < 12
   ) {
@@ -265,7 +264,6 @@ function operationMarginRule(
   const metadata = baseline.replay.row_metadata[operation];
   if (
     historyDegraded ||
-    metadata.stress === true ||
     metadata.sampling === "single_shot" ||
     metadata.samples_per_run < 12
   ) {
@@ -715,7 +713,7 @@ export function renderMarkdownComparison(baseline, result, comparison) {
     "<!-- cmuxlayer-perf-budget -->",
     `## Daemon performance budget: ${comparison.passed ? "GREEN" : "RED"}`,
     "",
-    `Replay: ${result.clients} clients x ${result.rounds} rounds. Runner regression ratio: ${baseline.regression_ratio}x. Sampled rows use max(2 x (p95 - p50), 3 sigma of p50 after five green main runs); single-shot and stress rows retain +300 ms. Every row keeps the baseline x ${baseline.regression_ratio} floor and its sanity cap.`,
+    `Replay: ${result.clients} clients x ${result.rounds} rounds. Runner regression ratio: ${baseline.regression_ratio}x. Sampled rows use max(2 x (p95 - p50), 3 sigma of p50 after five green main runs); single-shot or untrusted-history rows retain +300 ms. Every row keeps the baseline x ${baseline.regression_ratio} floor and its sanity cap.`,
     "",
     ...tableHeader,
     ...changed.map(tableRow),

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -272,7 +272,7 @@ function operationMarginRule(
   const measuredRuns = history.filter((entry) =>
     Number.isFinite(entry?.measurements?.[operation]?.p50_ms),
   ).length;
-  const runCount = Math.max(1, measuredRuns);
+  const runCount = measuredRuns >= 5 ? measuredRuns : 1;
   return `measured (${runCount} ${runCount === 1 ? "run" : "runs"})`;
 }
 
@@ -636,9 +636,11 @@ export function compareBenchmark(
   for (const operation of baseline.replay.operations) {
     const expected = baseline.replay.row_metadata[operation];
     const candidate = result?.replay?.row_metadata?.[operation];
+    const expectedSamples =
+      (expected.samples_per_run * expectedRounds) / baseline.replay.rounds;
     if (
       candidate?.sampling !== expected.sampling ||
-      candidate?.samples_per_run !== expected.samples_per_run ||
+      candidate?.samples_per_run !== expectedSamples ||
       (candidate?.stress === true) !== (expected.stress === true)
     ) {
       failures.push(

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -288,6 +288,15 @@ export function requireBaselineIncreaseReason(measurementPairs, reason) {
   return raisesCommittedBaseline;
 }
 
+export function requireCanonicalRequestChangeReason(changed, reason) {
+  if (changed && !reason?.trim()) {
+    throw new Error(
+      'refusing imported canonical request change without --reason "<text>"',
+    );
+  }
+  return changed;
+}
+
 function currentMetrics(result) {
   const first = result?.latency?.first_send_after_spawn?.first;
   const sampledFirst = result?.latency?.first_send_after_spawn?.sampled;

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -29,7 +29,10 @@ export const CANONICAL_OPERATIONS = [
   "control_health",
   "spawn_close_during_sweep",
   "first_send_after_spawn",
+  "send_to_surface_10_parallel",
+  "read_screen_10_parallel",
 ];
+export const BENCHMARK_HISTORY_LIMIT = 50;
 const REQUIRED_REGRESSION_RATIO = 1.25;
 
 function finite(value, path) {
@@ -101,6 +104,31 @@ export function validateBaseline(baseline) {
     throw new Error("baseline must use the canonical 8x12 replay");
   }
   for (const operation of baseline.replay.operations) {
+    const metadata = baseline.replay?.row_metadata?.[operation];
+    if (!metadata || !["sampled", "single_shot"].includes(metadata.sampling)) {
+      throw new Error(
+        `baseline replay.row_metadata.${operation}.sampling must be sampled or single_shot`,
+      );
+    }
+    if (
+      !Number.isSafeInteger(metadata.samples_per_run) ||
+      metadata.samples_per_run <= 0
+    ) {
+      throw new Error(
+        `baseline replay.row_metadata.${operation}.samples_per_run must be a positive integer`,
+      );
+    }
+    if (metadata.sampling === "sampled" && metadata.samples_per_run < 12) {
+      throw new Error(
+        `baseline sampled row ${operation} must have at least 12 samples per run`,
+      );
+    }
+    if (
+      metadata.stress !== undefined &&
+      typeof metadata.stress !== "boolean"
+    ) {
+      throw new Error(`baseline replay.row_metadata.${operation}.stress must be boolean`);
+    }
     finite(baseline.replay?.bytes?.[operation], `replay.bytes.${operation}`);
     if (!/^[0-9a-f]{64}$/.test(baseline.replay?.request_sha256?.[operation])) {
       throw new Error(
@@ -138,12 +166,51 @@ export function validateBaseline(baseline) {
   return baseline;
 }
 
-export function performanceCeiling(baselineValue, ratio, sanityCap = 1_000) {
+export function performanceCeiling(
+  baselineValue,
+  ratio,
+  sanityCap = 1_000,
+  marginMs = 300,
+) {
   return Math.min(
-    Math.round(Math.max(baselineValue * ratio, baselineValue + 300) * 100) /
+    Math.round(
+      Math.max(baselineValue * ratio, baselineValue + marginMs) * 100,
+    ) /
       100,
     sanityCap,
   );
+}
+
+function rounded(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function standardDeviation(values) {
+  if (values.length === 0) return 0;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  return Math.sqrt(
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+      values.length,
+  );
+}
+
+function operationMargin(baseline, operation, history) {
+  const metadata = baseline.replay.row_metadata[operation];
+  if (
+    metadata.stress === true ||
+    metadata.sampling === "single_shot" ||
+    metadata.samples_per_run < 12
+  ) {
+    return 300;
+  }
+  const measurement = baseline.measurements[operation];
+  const spread = Math.max(0, 2 * (measurement.p95_ms - measurement.p50_ms));
+  const historicalP50 = history
+    .map((entry) => entry?.measurements?.[operation]?.p50_ms)
+    .filter(Number.isFinite);
+  const varianceMargin =
+    historicalP50.length >= 5 ? 3 * standardDeviation(historicalP50) : 0;
+  return rounded(Math.max(spread, varianceMargin));
 }
 
 export function requireBaselineIncreaseReason(measurementPairs, reason) {
@@ -160,6 +227,7 @@ export function requireBaselineIncreaseReason(measurementPairs, reason) {
 
 function currentMetrics(result) {
   const first = result?.latency?.first_send_after_spawn?.first;
+  const sampledFirst = result?.latency?.first_send_after_spawn?.sampled;
   return {
     list_surfaces: {
       ...result?.latency?.daemon_path?.list_surfaces,
@@ -176,18 +244,71 @@ function currentMetrics(result) {
     list_agents: result?.latency?.daemon_path?.list_agents,
     control_health: result?.latency?.daemon_path?.control_health,
     spawn_close_during_sweep: result?.latency?.spawn_close_during_sweep,
+    send_to_surface_10_parallel:
+      result?.latency?.send_to_surface_10_parallel ??
+      result?.latency?.daemon_path?.send_to_surface_10_parallel,
+    read_screen_10_parallel:
+      result?.latency?.read_screen_10_parallel ??
+      result?.latency?.daemon_path?.read_screen_10_parallel,
     first_send_after_spawn: {
-      p50_ms: first?.elapsed_ms,
-      p95_ms: first?.elapsed_ms,
+      p50_ms: sampledFirst?.p50_ms ?? first?.elapsed_ms,
+      p95_ms: sampledFirst?.p95_ms ?? first?.elapsed_ms,
       lock_hold_ms:
-        first?.lock_hold_ms ?? first?.receipt?.timings_ms?.lock_hold,
-      transport: first?.transport ?? first?.receipt?.transport,
+        sampledFirst?.lock_hold_ms ??
+        first?.lock_hold_ms ??
+        first?.receipt?.timings_ms?.lock_hold,
+      transport:
+        sampledFirst?.transport ?? first?.transport ?? first?.receipt?.transport,
     },
     cli_send_transport:
       result?.latency?.first_send_after_spawn?.surface?.transport ??
       result?.latency?.first_send_after_spawn?.surface?.receipt?.transport,
-    cli_send_ms: result?.latency?.first_send_after_spawn?.surface?.elapsed_ms,
+    cli_send_ms:
+      result?.latency?.send_to_surface_warm?.p50_ms ??
+      result?.latency?.first_send_after_spawn?.surface?.elapsed_ms,
   };
+}
+
+export function appendGreenMainHistory(history, result, context) {
+  const existing = Array.isArray(history) ? history : [];
+  if (
+    result?.verdict !== "GREEN" ||
+    context?.event_name !== "push" ||
+    context?.ref !== "refs/heads/main"
+  ) {
+    return existing;
+  }
+  if (
+    !/^[0-9a-f]{40}$/.test(context?.git_sha ?? "") ||
+    !Number.isSafeInteger(context?.workflow_run_id) ||
+    context.workflow_run_id <= 0
+  ) {
+    throw new Error("green main history requires an exact SHA and workflow run id");
+  }
+  if (
+    existing.some(
+      (entry) => entry?.source?.workflow_run_id === context.workflow_run_id,
+    )
+  ) {
+    return existing;
+  }
+  const measurements = currentMetrics(result);
+  const entry = {
+    source: {
+      git_sha: context.git_sha,
+      workflow_run_id: context.workflow_run_id,
+      measured_at: context.measured_at ?? new Date().toISOString(),
+    },
+    measurements: Object.fromEntries(
+      [...CANONICAL_OPERATIONS, "cli_send_ms"].map((operation) => [
+        operation,
+        operation === "cli_send_ms"
+          ? { p50_ms: measurements.cli_send_ms }
+          : measurements[operation],
+      ]),
+    ),
+  };
+  return [...existing, entry].slice(-BENCHMARK_HISTORY_LIMIT);
 }
 
 export function maximumBenchmarkMeasurements(results) {
@@ -225,6 +346,7 @@ function row(
   ceiling,
   unit = "ms",
   transport,
+  metadata = {},
 ) {
   const passed = Number.isFinite(current) && current <= ceiling;
   return {
@@ -235,11 +357,14 @@ function row(
     ceiling,
     unit,
     transport,
+    sampling: metadata.sampling,
+    stress: metadata.stress === true,
+    margin_ms: metadata.margin_ms,
     passed,
   };
 }
 
-function exactRow(operation, metric, committed, current, unit) {
+function exactRow(operation, metric, committed, current, unit, metadata = {}) {
   const passed = Number.isFinite(current) && current === committed;
   return {
     operation,
@@ -250,19 +375,23 @@ function exactRow(operation, metric, committed, current, unit) {
     unit,
     passed,
     exact: true,
+    sampling: metadata.sampling,
+    stress: metadata.stress === true,
   };
 }
 
 export function compareBenchmark(
   baseline,
   result,
-  { expectedRounds = baseline.replay.rounds } = {},
+  { expectedRounds = baseline.replay.rounds, history = [] } = {},
 ) {
   validateBaseline(baseline);
   const current = currentMetrics(result);
   const ratio = baseline.regression_ratio;
   const rows = [];
   for (const operation of baseline.replay.operations) {
+    const metadata = baseline.replay.row_metadata[operation];
+    const marginMs = operationMargin(baseline, operation, history);
     for (const metric of ["p50_ms", "p95_ms"]) {
       rows.push(
         row(
@@ -274,14 +403,18 @@ export function compareBenchmark(
             baseline.measurements[operation][metric],
             ratio,
             baseline.sanity_caps_ms.all_rows,
+            marginMs,
           ),
           "ms",
           current[operation]?.transport,
+          { ...metadata, margin_ms: marginMs },
         ),
       );
     }
   }
   for (const operation of baseline.replay.operations) {
+    const metadata = baseline.replay.row_metadata[operation];
+    const marginMs = operationMargin(baseline, operation, history);
     rows.push(
       row(
         operation,
@@ -292,9 +425,11 @@ export function compareBenchmark(
           baseline.measurements[operation].lock_hold_ms,
           ratio,
           baseline.sanity_caps_ms.all_rows,
+          marginMs,
         ),
         "ms",
         current[operation]?.transport,
+        { ...metadata, margin_ms: marginMs },
       ),
     );
   }
@@ -308,9 +443,18 @@ export function compareBenchmark(
         baseline.measurements.cli_send_ms,
         ratio,
         baseline.sanity_caps_ms.cli_send,
+        operationMargin(baseline, "send_to_surface_warm", history),
       ),
       "ms",
       current.cli_send_transport,
+      {
+        ...baseline.replay.row_metadata.send_to_surface_warm,
+        margin_ms: operationMargin(
+          baseline,
+          "send_to_surface_warm",
+          history,
+        ),
+      },
     ),
   );
   for (const operation of baseline.replay.operations) {
@@ -321,6 +465,7 @@ export function compareBenchmark(
         baseline.replay.bytes[operation],
         result?.replay?.bytes?.[operation],
         "bytes",
+        baseline.replay.row_metadata[operation],
       ),
     );
   }
@@ -380,20 +525,35 @@ function formatted(value, unit) {
 }
 
 export function renderMarkdownComparison(baseline, result, comparison) {
+  const tableHeader = [
+    "| Operation | Transport | Sampling | Metric | Baseline | Current | Ceiling | Status |",
+    "|---|:---:|:---:|---:|---:|---:|---:|:---:|",
+  ];
+  const tableRow = (entry) =>
+    `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.sampling ?? "single_shot"}${entry.stress ? " · stress" : ""} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`;
+  const changed = comparison.rows.filter(
+    (entry) => !entry.passed || entry.current !== entry.baseline,
+  );
+  const unchangedCount = comparison.rows.length - changed.length;
   const lines = [
     "<!-- cmuxlayer-perf-budget -->",
     `## Daemon performance budget: ${comparison.passed ? "GREEN" : "RED"}`,
     "",
-    `Replay: ${result.clients} clients x ${result.rounds} rounds. Runner regression ratio: ${baseline.regression_ratio}x. Every CI row uses max(baseline x ratio, baseline + 300 ms) with a 1,000 ms sanity cap.`,
+    `Replay: ${result.clients} clients x ${result.rounds} rounds. Runner regression ratio: ${baseline.regression_ratio}x. Sampled rows use max(2 x (p95 - p50), 3 sigma of p50 after five green main runs); single-shot and stress rows retain +300 ms. Every row keeps the baseline x ${baseline.regression_ratio} floor and its sanity cap.`,
     "",
-    "| Operation | Transport | Metric | Baseline | Current | Ceiling | Status |",
-    "|---|:---:|---:|---:|---:|---:|:---:|",
+    ...tableHeader,
+    ...changed.map(tableRow),
+    "",
+    `${unchangedCount} rows unchanged.`,
+    "",
+    "<details>",
+    "<summary>Full table</summary>",
+    "",
+    ...tableHeader,
+    ...comparison.rows.map(tableRow),
+    "",
+    "</details>",
   ];
-  for (const entry of comparison.rows) {
-    lines.push(
-      `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`,
-    );
-  }
   if (comparison.failures.length) {
     lines.push(
       "",
@@ -457,8 +617,19 @@ async function main() {
   const expectedRounds = Number(
     process.env.CMUXLAYER_BENCH_ROUNDS ?? baseline.replay.rounds,
   );
+  const historyPath =
+    process.env.CMUXLAYER_BENCH_HISTORY_PATH ??
+    join(runResult.artifactDir, "history.json");
+  let history = [];
+  try {
+    const parsed = JSON.parse(await readFile(historyPath, "utf8"));
+    history = Array.isArray(parsed?.runs) ? parsed.runs : [];
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
   const comparison = compareBenchmark(baseline, runResult.result, {
     expectedRounds,
+    history,
   });
   const markdown = renderMarkdownComparison(
     baseline,
@@ -467,6 +638,24 @@ async function main() {
   );
   const reportPath = join(runResult.artifactDir, "comment.md");
   await writeFile(reportPath, markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await writeFile(process.env.GITHUB_STEP_SUMMARY, markdown, { flag: "a" });
+  }
+  if (runResult.code === 0 && comparison.passed) {
+    const nextHistory = appendGreenMainHistory(history, runResult.result, {
+      event_name: process.env.GITHUB_EVENT_NAME,
+      ref: process.env.GITHUB_REF,
+      git_sha: process.env.GITHUB_SHA,
+      workflow_run_id: Number(process.env.GITHUB_RUN_ID),
+    });
+    if (nextHistory !== history) {
+      await mkdir(dirname(historyPath), { recursive: true });
+      await writeFile(
+        historyPath,
+        `${JSON.stringify({ schema_version: 1, limit: BENCHMARK_HISTORY_LIMIT, runs: nextHistory }, null, 2)}\n`,
+      );
+    }
+  }
   process.stdout.write(markdown);
   if (runResult.code !== 0 || !comparison.passed) process.exitCode = 1;
 }

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -70,6 +70,9 @@ function validHistoryEntry(entry) {
   ) {
     return false;
   }
+  if (!/^[0-9a-f]{64}$/.test(entry?.source?.baseline_content_sha256 ?? "")) {
+    return false;
+  }
   return [...CANONICAL_OPERATIONS, "cli_send_ms"].every((operation) => {
     const measurement = entry?.measurements?.[operation];
     if (!Number.isFinite(measurement?.p50_ms)) return false;
@@ -189,8 +192,21 @@ export function validateBaseline(baseline) {
       baseline.measurements?.[operation]?.lock_hold_ms,
       `measurements.${operation}.lock_hold_ms`,
     );
+    for (const metric of ["p50_ms", "p95_ms", "lock_hold_ms"]) {
+      if (
+        baseline.measurements[operation][metric] >
+        baseline.sanity_caps_ms.all_rows
+      ) {
+        throw new Error(
+          `baseline measurements.${operation}.${metric} exceeds sanity cap`,
+        );
+      }
+    }
   }
   finite(baseline.measurements?.cli_send_ms, "measurements.cli_send_ms");
+  if (baseline.measurements.cli_send_ms > baseline.sanity_caps_ms.cli_send) {
+    throw new Error("baseline measurements.cli_send_ms exceeds sanity cap");
+  }
   if (baseline.refresh_attestation?.algorithm !== "sha256") {
     throw new Error("baseline refresh_attestation.algorithm must be sha256");
   }
@@ -351,9 +367,12 @@ export function appendGreenMainHistory(history, result, context) {
   if (
     !/^[0-9a-f]{40}$/.test(context?.git_sha ?? "") ||
     !Number.isSafeInteger(context?.workflow_run_id) ||
-    context.workflow_run_id <= 0
+    context.workflow_run_id <= 0 ||
+    !/^[0-9a-f]{64}$/.test(context?.baseline_content_sha256 ?? "")
   ) {
-    throw new Error("green main history requires an exact SHA and workflow run id");
+    throw new Error(
+      "green main history requires an exact SHA, workflow run id, and baseline content SHA",
+    );
   }
   if (
     existing.some(
@@ -368,6 +387,7 @@ export function appendGreenMainHistory(history, result, context) {
       git_sha: context.git_sha,
       workflow_run_id: context.workflow_run_id,
       measured_at: context.measured_at ?? new Date().toISOString(),
+      baseline_content_sha256: context.baseline_content_sha256,
     },
     measurements: Object.fromEntries(
       [...CANONICAL_OPERATIONS, "cli_send_ms"].map((operation) => [
@@ -385,7 +405,10 @@ export function appendGreenMainHistory(history, result, context) {
   return [...existing, attestedEntry].slice(-BENCHMARK_HISTORY_LIMIT);
 }
 
-export async function readBenchmarkHistory(historyPath) {
+export async function readBenchmarkHistory(
+  historyPath,
+  expectedBaselineContentSha256,
+) {
   try {
     const parsed = JSON.parse(await readFile(historyPath, "utf8"));
     if (!Array.isArray(parsed?.runs)) {
@@ -400,6 +423,20 @@ export async function readBenchmarkHistory(historyPath) {
         runs: [],
         degraded: true,
         reason: `${historyPath} contains a malformed entry`,
+      };
+    }
+    if (
+      expectedBaselineContentSha256 &&
+      parsed.runs.some(
+        (entry) =>
+          entry.source.baseline_content_sha256 !==
+          expectedBaselineContentSha256,
+      )
+    ) {
+      return {
+        runs: [],
+        degraded: true,
+        reason: `${historyPath} belongs to a different baseline`,
       };
     }
     return { runs: parsed.runs, degraded: false };
@@ -831,7 +868,10 @@ async function main() {
   const historyPath =
     process.env.CMUXLAYER_BENCH_HISTORY_PATH ??
     join(runResult.artifactDir, "history.json");
-  const historyState = await readBenchmarkHistory(historyPath);
+  const historyState = await readBenchmarkHistory(
+    historyPath,
+    baseline.refresh_attestation.content_sha256,
+  );
   const comparison = compareBenchmark(baseline, runResult.result, {
     expectedRounds,
     history: historyState.runs,
@@ -857,6 +897,8 @@ async function main() {
       ref: process.env.GITHUB_REF,
       git_sha: process.env.GITHUB_SHA,
       workflow_run_id: Number(process.env.GITHUB_RUN_ID),
+      baseline_content_sha256:
+        baseline.refresh_attestation.content_sha256,
       },
     );
     if (nextHistory !== historyState.runs) {

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -145,29 +145,19 @@ export function validateBaseline(baseline) {
   }
   for (const operation of baseline.replay.operations) {
     const metadata = baseline.replay?.row_metadata?.[operation];
-    if (!metadata || !["sampled", "single_shot"].includes(metadata.sampling)) {
-      throw new Error(
-        `baseline replay.row_metadata.${operation}.sampling must be sampled or single_shot`,
-      );
-    }
+    const stress = operation.endsWith("_10_parallel");
+    const expectedSamples = stress
+      ? CANONICAL_ROUNDS
+      : CANONICAL_CLIENTS * CANONICAL_ROUNDS;
     if (
-      !Number.isSafeInteger(metadata.samples_per_run) ||
-      metadata.samples_per_run <= 0
+      !metadata ||
+      metadata.sampling !== "sampled" ||
+      metadata.samples_per_run !== expectedSamples ||
+      Boolean(metadata.stress) !== stress
     ) {
       throw new Error(
-        `baseline replay.row_metadata.${operation}.samples_per_run must be a positive integer`,
+        `baseline replay.row_metadata.${operation} must match the canonical sampled workload (${expectedSamples} samples, stress=${stress})`,
       );
-    }
-    if (metadata.sampling === "sampled" && metadata.samples_per_run < 12) {
-      throw new Error(
-        `baseline sampled row ${operation} must have at least 12 samples per run`,
-      );
-    }
-    if (
-      metadata.stress !== undefined &&
-      typeof metadata.stress !== "boolean"
-    ) {
-      throw new Error(`baseline replay.row_metadata.${operation}.stress must be boolean`);
     }
     finite(baseline.replay?.bytes?.[operation], `replay.bytes.${operation}`);
     if (!/^[0-9a-f]{64}$/.test(baseline.replay?.request_sha256?.[operation])) {

--- a/scripts/check-daemon-benchmark.mjs
+++ b/scripts/check-daemon-benchmark.mjs
@@ -56,6 +56,18 @@ export function baselineContentSha256(baseline) {
   return createHash("sha256").update(canonicalJson(content)).digest("hex");
 }
 
+export function isAttestedLegacyBaseline(baseline) {
+  return (
+    baseline?.schema_version === 2 &&
+    baseline?.refresh_attestation?.algorithm === "sha256" &&
+    baseline.refresh_attestation.content_sha256 ===
+      baselineContentSha256(baseline) &&
+    JSON.stringify(baseline?.replay?.operations) ===
+      JSON.stringify(CANONICAL_OPERATIONS.slice(0, 8)) &&
+    baseline?.replay?.row_metadata === undefined
+  );
+}
+
 export function validateBaseline(baseline) {
   if (baseline?.schema_version !== 2)
     throw new Error("baseline schema_version must be 2");
@@ -194,9 +206,15 @@ function standardDeviation(values) {
   );
 }
 
-function operationMargin(baseline, operation, history) {
+function operationMargin(
+  baseline,
+  operation,
+  history,
+  historyDegraded = false,
+) {
   const metadata = baseline.replay.row_metadata[operation];
   if (
+    historyDegraded ||
     metadata.stress === true ||
     metadata.sampling === "single_shot" ||
     metadata.samples_per_run < 12
@@ -260,9 +278,7 @@ function currentMetrics(result) {
       transport:
         sampledFirst?.transport ?? first?.transport ?? first?.receipt?.transport,
     },
-    cli_send_transport:
-      result?.latency?.first_send_after_spawn?.surface?.transport ??
-      result?.latency?.first_send_after_spawn?.surface?.receipt?.transport,
+    cli_send_transport: result?.latency?.send_to_surface_warm?.transport,
     cli_send_ms:
       result?.latency?.send_to_surface_warm?.p50_ms ??
       result?.latency?.first_send_after_spawn?.surface?.elapsed_ms,
@@ -309,6 +325,27 @@ export function appendGreenMainHistory(history, result, context) {
     ),
   };
   return [...existing, entry].slice(-BENCHMARK_HISTORY_LIMIT);
+}
+
+export async function readBenchmarkHistory(historyPath) {
+  try {
+    const parsed = JSON.parse(await readFile(historyPath, "utf8"));
+    if (!Array.isArray(parsed?.runs)) {
+      return {
+        runs: [],
+        degraded: true,
+        reason: `${historyPath} does not contain a runs array`,
+      };
+    }
+    return { runs: parsed.runs, degraded: false };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { runs: [], degraded: false };
+    return {
+      runs: [],
+      degraded: true,
+      reason: `${historyPath} is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
 }
 
 export function maximumBenchmarkMeasurements(results) {
@@ -359,6 +396,7 @@ function row(
     transport,
     sampling: metadata.sampling,
     stress: metadata.stress === true,
+    history_degraded: metadata.history_degraded === true,
     margin_ms: metadata.margin_ms,
     passed,
   };
@@ -377,13 +415,19 @@ function exactRow(operation, metric, committed, current, unit, metadata = {}) {
     exact: true,
     sampling: metadata.sampling,
     stress: metadata.stress === true,
+    history_degraded: metadata.history_degraded === true,
   };
 }
 
 export function compareBenchmark(
   baseline,
   result,
-  { expectedRounds = baseline.replay.rounds, history = [] } = {},
+  {
+    expectedRounds = baseline.replay.rounds,
+    history = [],
+    historyDegraded = false,
+    historyDegradedReason,
+  } = {},
 ) {
   validateBaseline(baseline);
   const current = currentMetrics(result);
@@ -391,7 +435,12 @@ export function compareBenchmark(
   const rows = [];
   for (const operation of baseline.replay.operations) {
     const metadata = baseline.replay.row_metadata[operation];
-    const marginMs = operationMargin(baseline, operation, history);
+    const marginMs = operationMargin(
+      baseline,
+      operation,
+      history,
+      historyDegraded,
+    );
     for (const metric of ["p50_ms", "p95_ms"]) {
       rows.push(
         row(
@@ -407,14 +456,23 @@ export function compareBenchmark(
           ),
           "ms",
           current[operation]?.transport,
-          { ...metadata, margin_ms: marginMs },
+          {
+            ...metadata,
+            margin_ms: marginMs,
+            history_degraded: historyDegraded,
+          },
         ),
       );
     }
   }
   for (const operation of baseline.replay.operations) {
     const metadata = baseline.replay.row_metadata[operation];
-    const marginMs = operationMargin(baseline, operation, history);
+    const marginMs = operationMargin(
+      baseline,
+      operation,
+      history,
+      historyDegraded,
+    );
     rows.push(
       row(
         operation,
@@ -429,13 +487,17 @@ export function compareBenchmark(
         ),
         "ms",
         current[operation]?.transport,
-        { ...metadata, margin_ms: marginMs },
+        {
+          ...metadata,
+          margin_ms: marginMs,
+          history_degraded: historyDegraded,
+        },
       ),
     );
   }
   rows.push(
     row(
-      "first_send_after_spawn",
+      "send_to_surface_warm",
       "cli_send_ms",
       baseline.measurements.cli_send_ms,
       current.cli_send_ms,
@@ -443,7 +505,12 @@ export function compareBenchmark(
         baseline.measurements.cli_send_ms,
         ratio,
         baseline.sanity_caps_ms.cli_send,
-        operationMargin(baseline, "send_to_surface_warm", history),
+        operationMargin(
+          baseline,
+          "send_to_surface_warm",
+          history,
+          historyDegraded,
+        ),
       ),
       "ms",
       current.cli_send_transport,
@@ -453,7 +520,9 @@ export function compareBenchmark(
           baseline,
           "send_to_surface_warm",
           history,
+          historyDegraded,
         ),
+        history_degraded: historyDegraded,
       },
     ),
   );
@@ -465,7 +534,10 @@ export function compareBenchmark(
         baseline.replay.bytes[operation],
         result?.replay?.bytes?.[operation],
         "bytes",
-        baseline.replay.row_metadata[operation],
+        {
+          ...baseline.replay.row_metadata[operation],
+          history_degraded: historyDegraded,
+        },
       ),
     );
   }
@@ -477,6 +549,11 @@ export function compareBenchmark(
         ? `${entry.operation} ${metric}: ${entry.current} ${entry.unit} does not match committed ${entry.baseline} ${entry.unit}`
         : `${entry.operation} ${metric}: ${entry.current}${entry.unit} exceeds ${entry.ceiling}${entry.unit}`;
     });
+  if (historyDegraded) {
+    failures.push(
+      `benchmark history degraded: ${historyDegradedReason ?? "untrusted cache"}; conservative +300ms margins active`,
+    );
+  }
   for (const operation of baseline.replay.operations) {
     if (current[operation]?.transport !== "socket") {
       failures.push(
@@ -530,7 +607,7 @@ export function renderMarkdownComparison(baseline, result, comparison) {
     "|---|:---:|:---:|---:|---:|---:|---:|:---:|",
   ];
   const tableRow = (entry) =>
-    `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.sampling ?? "single_shot"}${entry.stress ? " · stress" : ""} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`;
+    `| ${entry.operation} | ${entry.transport ?? result?.replay?.transport?.[entry.operation] ?? "missing"} | ${entry.sampling ?? "single_shot"}${entry.stress ? " · stress" : ""}${entry.history_degraded ? " · history-degraded · wide-margin" : ""} | ${entry.metric} | ${formatted(entry.baseline, entry.unit)} | ${formatted(entry.current, entry.unit)} | ${formatted(entry.ceiling, entry.unit)} | ${entry.passed ? "PASS" : "FAIL"} |`;
   const changed = comparison.rows.filter(
     (entry) => !entry.passed || entry.current !== entry.baseline,
   );
@@ -608,28 +685,50 @@ export async function runBenchmark({
 }
 
 async function main() {
-  const baseline = validateBaseline(
-    JSON.parse(await readFile(baselinePath, "utf8")),
-  );
+  const rawBaseline = JSON.parse(await readFile(baselinePath, "utf8"));
+  let baseline;
+  let legacyBaseline = false;
+  try {
+    baseline = validateBaseline(rawBaseline);
+  } catch (error) {
+    if (!isAttestedLegacyBaseline(rawBaseline)) throw error;
+    baseline = rawBaseline;
+    legacyBaseline = true;
+  }
   const runResult = await runBenchmark({
     artifactDir: process.env.CMUXLAYER_PERF_ARTIFACT_DIR,
   });
+  if (legacyBaseline) {
+    const markdown = [
+      "<!-- cmuxlayer-perf-budget -->",
+      "## Daemon performance budget: RED",
+      "",
+      "The committed baseline is an attested legacy 8-row snapshot. This run produced canonical 10-row evidence, but enforcement remains fail-closed until the CI-runner artifact is imported into the committed baseline.",
+      "",
+      `Evidence invocation nonce: ${runResult.result?.invocation_nonce ?? "missing"}`,
+      "",
+    ].join("\n");
+    const reportPath = join(runResult.artifactDir, "comment.md");
+    await writeFile(reportPath, markdown);
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      await writeFile(process.env.GITHUB_STEP_SUMMARY, markdown, { flag: "a" });
+    }
+    process.stdout.write(markdown);
+    process.exitCode = 1;
+    return;
+  }
   const expectedRounds = Number(
     process.env.CMUXLAYER_BENCH_ROUNDS ?? baseline.replay.rounds,
   );
   const historyPath =
     process.env.CMUXLAYER_BENCH_HISTORY_PATH ??
     join(runResult.artifactDir, "history.json");
-  let history = [];
-  try {
-    const parsed = JSON.parse(await readFile(historyPath, "utf8"));
-    history = Array.isArray(parsed?.runs) ? parsed.runs : [];
-  } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
-  }
+  const historyState = await readBenchmarkHistory(historyPath);
   const comparison = compareBenchmark(baseline, runResult.result, {
     expectedRounds,
-    history,
+    history: historyState.runs,
+    historyDegraded: historyState.degraded,
+    historyDegradedReason: historyState.reason,
   });
   const markdown = renderMarkdownComparison(
     baseline,
@@ -642,13 +741,17 @@ async function main() {
     await writeFile(process.env.GITHUB_STEP_SUMMARY, markdown, { flag: "a" });
   }
   if (runResult.code === 0 && comparison.passed) {
-    const nextHistory = appendGreenMainHistory(history, runResult.result, {
+    const nextHistory = appendGreenMainHistory(
+      historyState.runs,
+      runResult.result,
+      {
       event_name: process.env.GITHUB_EVENT_NAME,
       ref: process.env.GITHUB_REF,
       git_sha: process.env.GITHUB_SHA,
       workflow_run_id: Number(process.env.GITHUB_RUN_ID),
-    });
-    if (nextHistory !== history) {
+      },
+    );
+    if (nextHistory !== historyState.runs) {
       await mkdir(dirname(historyPath), { recursive: true });
       await writeFile(
         historyPath,

--- a/scripts/refresh-daemon-baseline.mjs
+++ b/scripts/refresh-daemon-baseline.mjs
@@ -10,6 +10,7 @@ import {
   compareBenchmark,
   maximumBenchmarkMeasurements,
   performanceCeiling,
+  requireCanonicalRequestChangeReason,
   requireBaselineIncreaseReason,
   runBenchmark,
   validateBaseline,
@@ -123,18 +124,27 @@ for (const sample of samples) {
     throw new Error("refusing to refresh without the canonical 8x12 replay");
   }
   for (const operation of CANONICAL_OPERATIONS) {
+    const canonicalRequestChanged =
+      !migratingLegacyBaseline &&
+      (sample.replay?.bytes?.[operation] !==
+        existing.replay.bytes[operation] ||
+        sample.replay?.request_sha256?.[operation] !==
+          existing.replay.request_sha256[operation]);
     if (
       !Number.isFinite(sample.replay?.bytes?.[operation]) ||
       !/^[0-9a-f]{64}$/.test(
         sample.replay?.request_sha256?.[operation] ?? "",
       ) ||
-      (!migratingLegacyBaseline &&
-        (sample.replay.bytes[operation] !== existing.replay.bytes[operation] ||
-          sample.replay.request_sha256[operation] !==
-            existing.replay.request_sha256[operation]))
+      (canonicalRequestChanged && !runnerRebase)
     ) {
       throw new Error(
         `refusing to refresh changed canonical request ${operation}`,
+      );
+    }
+    if (runnerRebase) {
+      requireCanonicalRequestChangeReason(
+        canonicalRequestChanged,
+        increaseReason,
       );
     }
   }

--- a/scripts/refresh-daemon-baseline.mjs
+++ b/scripts/refresh-daemon-baseline.mjs
@@ -157,7 +157,9 @@ const measurements = {
       Object.fromEntries(
         ["p50_ms", "p95_ms", "lock_hold_ms"].map((metric) => [
           metric,
-          Number.isFinite(existing.measurements?.[operation]?.[metric])
+          migratingLegacyBaseline
+            ? measured[operation][metric]
+            : Number.isFinite(existing.measurements?.[operation]?.[metric])
             ? chooseMetric(
                 existing.measurements[operation][metric],
                 measured[operation][metric],
@@ -167,10 +169,9 @@ const measurements = {
       ),
     ]),
   ),
-  cli_send_ms: chooseMetric(
-    existing.measurements.cli_send_ms,
-    measured.cli_send_ms,
-  ),
+  cli_send_ms: migratingLegacyBaseline
+    ? measured.cli_send_ms
+    : chooseMetric(existing.measurements.cli_send_ms, measured.cli_send_ms),
 };
 if (
   !Number.isFinite(measurements.first_send_after_spawn.lock_hold_ms) ||

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -941,7 +941,12 @@ describe("daemon performance budget", () => {
     expect(source).not.toContain("onFirstSample");
     expect(source).toContain("const surfaceStates = new Map()");
     expect(source).toContain("const surfaceMutationQueues = new Map()");
+    expect(source).toContain("function fakeSurfaceStateKey(");
+    expect(source).toContain("fakeSurfaceStateKey(params.surface_id, surfaces)");
     expect(source).toContain("await mutateFakeSurfaceState(");
+    expect(source).toContain(
+      "daemon_survived_replay:\n        daemon.exitCode === null &&\n        daemon.signalCode === null &&\n        daemonStats.rssKb > 0",
+    );
     expect(source).toContain("firstSendAfterSpawn.sampled");
     expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
     expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -936,9 +936,15 @@ describe("daemon performance budget", () => {
     );
     expect(source).not.toContain("const transportReceipts = await Promise.all");
     expect(source).toMatch(
-      /const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients\([\s\S]*?\n    \);\n    daemonRssMb = await totalRssMb/,
+      /const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients\([\s\S]*?\n {4}\);\n {4}const daemonRssMb = await totalRssMb/,
     );
     expect(source).not.toContain("onFirstSample");
+    expect(source).toContain("firstSendAfterSpawn.sampled");
+    expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
+    expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");
+    expect(source).not.toContain("firstSendAfterSpawn.first,\n");
+    expect(source).not.toContain("firstSendAfterSpawn.second,\n");
+    expect(source).not.toContain("firstSendAfterSpawn.surface,\n");
   });
 
   it("wires a required PR/main job and edits a single comment even on RED", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import * as checkerModule from "../scripts/check-daemon-benchmark.mjs";
 import {
@@ -961,6 +962,15 @@ describe("daemon performance budget", () => {
     expect(source).not.toContain("firstSendAfterSpawn.first,\n");
     expect(source).not.toContain("firstSendAfterSpawn.second,\n");
     expect(source).not.toContain("firstSendAfterSpawn.surface,\n");
+  });
+
+  it("keeps the executable benchmark parseable by Node", () => {
+    const benchmarkPath = join(repoRoot, "scripts", "bench-daemon.mjs");
+    const checked = spawnSync("node", ["--check", benchmarkPath], {
+      encoding: "utf8",
+    });
+
+    expect(checked.status, checked.stderr).toBe(0);
   });
 
   it("wires a required PR/main job and edits a single comment even on RED", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import * as checkerModule from "../scripts/check-daemon-benchmark.mjs";
 import {
   baselineContentSha256,
   compareBenchmark,
@@ -49,7 +50,29 @@ const baseline = attest({
       "control_health",
       "spawn_close_during_sweep",
       "first_send_after_spawn",
+      "send_to_surface_10_parallel",
+      "read_screen_10_parallel",
     ],
+    row_metadata: {
+      list_surfaces: { sampling: "sampled", samples_per_run: 96 },
+      read_screen: { sampling: "sampled", samples_per_run: 96 },
+      send_to_surface_warm: { sampling: "sampled", samples_per_run: 96 },
+      send_to_agent_warm: { sampling: "sampled", samples_per_run: 96 },
+      list_agents: { sampling: "sampled", samples_per_run: 96 },
+      control_health: { sampling: "sampled", samples_per_run: 96 },
+      spawn_close_during_sweep: { sampling: "sampled", samples_per_run: 96 },
+      first_send_after_spawn: { sampling: "sampled", samples_per_run: 96 },
+      send_to_surface_10_parallel: {
+        sampling: "sampled",
+        samples_per_run: 12,
+        stress: true,
+      },
+      read_screen_10_parallel: {
+        sampling: "sampled",
+        samples_per_run: 12,
+        stress: true,
+      },
+    },
     bytes: {
       list_surfaces: 140,
       read_screen: 170,
@@ -59,6 +82,8 @@ const baseline = attest({
       control_health: 183,
       spawn_close_during_sweep: 184,
       first_send_after_spawn: 240,
+      send_to_surface_10_parallel: 2_000,
+      read_screen_10_parallel: 1_700,
     },
     request_sha256: {
       list_surfaces: "1".repeat(64),
@@ -69,6 +94,8 @@ const baseline = attest({
       control_health: "7".repeat(64),
       spawn_close_during_sweep: "8".repeat(64),
       first_send_after_spawn: "3".repeat(64),
+      send_to_surface_10_parallel: "a".repeat(64),
+      read_screen_10_parallel: "b".repeat(64),
     },
     transport: {
       list_surfaces: "socket",
@@ -79,6 +106,8 @@ const baseline = attest({
       control_health: "socket",
       spawn_close_during_sweep: "socket",
       first_send_after_spawn: "socket",
+      send_to_surface_10_parallel: "socket",
+      read_screen_10_parallel: "socket",
     },
   },
   measurements: {
@@ -93,6 +122,16 @@ const baseline = attest({
       p50_ms: 900,
       p95_ms: 900,
       lock_hold_ms: 20,
+    },
+    send_to_surface_10_parallel: {
+      p50_ms: 260,
+      p95_ms: 310,
+      lock_hold_ms: 120,
+    },
+    read_screen_10_parallel: {
+      p50_ms: 180,
+      p95_ms: 240,
+      lock_hold_ms: 0,
     },
     cli_send_ms: 700,
   },
@@ -126,6 +165,18 @@ const result = {
       control_health: {
         p50_ms: 95,
         p95_ms: 105,
+        lock_hold_ms: 0,
+        transport: "socket",
+      },
+      send_to_surface_10_parallel: {
+        p50_ms: 270,
+        p95_ms: 320,
+        lock_hold_ms: 125,
+        transport: "socket",
+      },
+      read_screen_10_parallel: {
+        p50_ms: 190,
+        p95_ms: 250,
         lock_hold_ms: 0,
         transport: "socket",
       },
@@ -213,6 +264,107 @@ describe("daemon performance budget", () => {
         replay: { ...baseline.replay, rounds: 3 },
       }),
     ).toThrow(/canonical 8x12 replay/);
+    expect(() =>
+      validateBaseline(
+        attest({
+          ...baseline,
+          replay: { ...baseline.replay, row_metadata: undefined },
+        }),
+      ),
+    ).toThrow(/row_metadata/);
+  });
+
+  it("uses measured spread and five-run p50 variance only for earned sampled rows", () => {
+    const history = [90, 95, 100, 105, 110].map((p50_ms, index) => ({
+      source: { git_sha: String(index).padStart(40, "0"), workflow_run_id: index + 1 },
+      measurements: {
+        list_surfaces: { p50_ms, p95_ms: p50_ms + 20, lock_hold_ms: 0 },
+      },
+    }));
+    const comparison = compareBenchmark(baseline, result, { history });
+    const row = comparison.rows.find(
+      (entry) => entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+    );
+    expect(row).toMatchObject({ sampling: "sampled", margin_ms: 40, ceiling: 140 });
+
+    const highVarianceHistory = [50, 75, 100, 125, 150].map((p50_ms, index) => ({
+      source: { git_sha: `f${String(index).padStart(39, "0")}`, workflow_run_id: 100 + index },
+      measurements: {
+        list_surfaces: { p50_ms, p95_ms: p50_ms + 20, lock_hold_ms: 0 },
+      },
+    }));
+    const highVariance = compareBenchmark(baseline, result, {
+      history: highVarianceHistory,
+    }).rows.find(
+      (entry) => entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+    );
+    expect(highVariance?.margin_ms).toBeCloseTo(106.07, 2);
+    expect(highVariance?.ceiling).toBeCloseTo(206.07, 2);
+  });
+
+  it("keeps a wide margin for honest single-shot and explicit stress rows", () => {
+    const singleShot = attest({
+      ...baseline,
+      replay: {
+        ...baseline.replay,
+        row_metadata: {
+          ...baseline.replay.row_metadata,
+          list_surfaces: { sampling: "single_shot", samples_per_run: 1 },
+        },
+      },
+    });
+    const singleRow = compareBenchmark(singleShot, result).rows.find(
+      (entry) => entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+    );
+    expect(singleRow).toMatchObject({
+      sampling: "single_shot",
+      margin_ms: 300,
+      ceiling: 400,
+    });
+    const stressRow = compareBenchmark(baseline, result).rows.find(
+      (entry) =>
+        entry.operation === "send_to_surface_10_parallel" &&
+        entry.metric === "p50_ms",
+    );
+    expect(stressRow).toMatchObject({ stress: true, margin_ms: 300, ceiling: 560 });
+  });
+
+  it("records only green main runs and bounds append-only history to 50 runs", () => {
+    expect(checkerModule).toHaveProperty("appendGreenMainHistory");
+    const appendGreenMainHistory = (
+      checkerModule as typeof checkerModule & {
+        appendGreenMainHistory: (
+          history: unknown[],
+          result: unknown,
+          context: Record<string, unknown>,
+        ) => unknown[];
+      }
+    ).appendGreenMainHistory;
+    const existing = Array.from({ length: 50 }, (_, index) => ({
+      source: {
+        git_sha: String(index).padStart(40, "0"),
+        workflow_run_id: index + 1,
+      },
+      measurements: { list_surfaces: { p50_ms: index } },
+    }));
+    const unchanged = appendGreenMainHistory(existing, result, {
+      event_name: "pull_request",
+      ref: "refs/pull/1/merge",
+      git_sha: "f".repeat(40),
+      workflow_run_id: 999,
+    });
+    expect(unchanged).toEqual(existing);
+    const appended = appendGreenMainHistory(existing, result, {
+      event_name: "push",
+      ref: "refs/heads/main",
+      git_sha: "f".repeat(40),
+      workflow_run_id: 999,
+    });
+    expect(appended).toHaveLength(50);
+    expect(appended[0]).toEqual(existing[1]);
+    expect(appended.at(-1)).toMatchObject({
+      source: { git_sha: "f".repeat(40), workflow_run_id: 999 },
+    });
   });
 
   it("fails the consistency assertion after a baseline-only hand edit", () => {
@@ -247,7 +399,7 @@ describe("daemon performance budget", () => {
 
     expect(comparison.passed).toBe(false);
     expect(comparison.failures).toContain(
-      "read_screen p50: 441ms exceeds 440ms",
+      "read_screen p50: 441ms exceeds 180ms",
     );
   });
 
@@ -332,6 +484,16 @@ describe("daemon performance budget", () => {
     expect(maximumBenchmarkMeasurements([result, slower])).toEqual({
       list_surfaces: { p50_ms: 110, p95_ms: 200, lock_hold_ms: 0 },
       read_screen: { p50_ms: 190, p95_ms: 170, lock_hold_ms: 0 },
+      send_to_surface_10_parallel: {
+        p50_ms: 270,
+        p95_ms: 320,
+        lock_hold_ms: 125,
+      },
+      read_screen_10_parallel: {
+        p50_ms: 190,
+        p95_ms: 250,
+        lock_hold_ms: 0,
+      },
       send_to_surface_warm: {
         p50_ms: 210,
         p95_ms: 230,
@@ -354,7 +516,7 @@ describe("daemon performance budget", () => {
         p95_ms: 1_100,
         lock_hold_ms: 21,
       },
-      cli_send_ms: 900,
+      cli_send_ms: 210,
     });
     expect(() =>
       maximumBenchmarkMeasurements([
@@ -410,6 +572,7 @@ describe("daemon performance budget", () => {
         list_surfaces: {
           ...baseline.measurements.list_surfaces,
           p50_ms: 1,
+          p95_ms: 2,
         },
       },
     });
@@ -421,7 +584,7 @@ describe("daemon performance budget", () => {
           ...result.latency.daemon_path,
           list_surfaces: {
             ...result.latency.daemon_path.list_surfaces,
-            p50_ms: 302,
+            p50_ms: 4,
           },
         },
       },
@@ -432,9 +595,9 @@ describe("daemon performance budget", () => {
         (entry) =>
           entry.operation === "list_surfaces" && entry.metric === "p50_ms",
       )?.ceiling,
-    ).toBe(301);
+    ).toBe(3);
     expect(comparison.failures).toContain(
-      "list_surfaces p50: 302ms exceeds 301ms",
+      "list_surfaces p50: 4ms exceeds 3ms",
     );
   });
 
@@ -443,9 +606,9 @@ describe("daemon performance budget", () => {
       ...result,
       latency: {
         ...result.latency,
-        first_send_after_spawn: {
-          ...result.latency.first_send_after_spawn,
-          surface: { elapsed_ms: 1_001 },
+        send_to_surface_warm: {
+          ...result.latency.send_to_surface_warm,
+          p50_ms: 1_001,
         },
       },
     });
@@ -541,11 +704,14 @@ describe("daemon performance budget", () => {
     );
 
     expect(markdown).toContain("<!-- cmuxlayer-perf-budget -->");
-    expect(markdown).toContain(
-      "| Operation | Transport | Metric | Baseline | Current | Ceiling | Status |",
-    );
+    expect(markdown).toContain("| Operation | Transport | Sampling | Metric |");
     expect(markdown).toContain("first_send_after_spawn");
     expect(markdown).toContain("Runner regression ratio: 1.25x");
+    expect(markdown).toContain("rows unchanged");
+    expect(markdown).toContain("<details>");
+    expect(markdown).toContain("<summary>Full table</summary>");
+    const defaultTable = markdown.split("<details>")[0];
+    expect(defaultTable).not.toContain("| list_surfaces | socket | sampled | request_bytes |");
   });
 
   it("commits a post-run-5 baseline with the full replay contract", () => {
@@ -568,6 +734,8 @@ describe("daemon performance budget", () => {
       "control_health",
       "spawn_close_during_sweep",
       "first_send_after_spawn",
+      "send_to_surface_10_parallel",
+      "read_screen_10_parallel",
     ]);
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
     expect(committed.source.workflow_run_id).toBe(32988968639);
@@ -585,6 +753,10 @@ describe("daemon performance budget", () => {
 
     expect(source).toContain("const DEFAULT_CLIENTS = 8");
     expect(source).toContain("const DEFAULT_ROUNDS = 12");
+    expect(source).toContain("const PARALLEL_STRESS_COUNT = 10");
+    expect(source).toContain('sampling: "sampled"');
+    expect(source).toContain("samples_per_run");
+    expect(source).toContain("for (const client of clients)");
     expect(source).toContain("p95_ms");
     expect(source).toContain("request_bytes");
     expect(source).toContain("lock_hold_ms");
@@ -639,6 +811,15 @@ describe("daemon performance budget", () => {
     expect(workflow).toContain("<!-- cmuxlayer-perf-budget -->");
     expect(workflow).toContain("updateComment");
     expect(workflow).toContain("createComment");
+    expect(workflow).toContain("actions/cache/restore");
+    expect(workflow).toContain("actions/cache/save");
+    expect(workflow).toContain("history.json");
+    expect(
+      readFileSync(
+        join(repoRoot, "scripts", "check-daemon-benchmark.mjs"),
+        "utf8",
+      ),
+    ).toContain("GITHUB_STEP_SUMMARY");
   });
 
   it("refuses to refresh a baseline from an over-budget lock hold", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -833,7 +833,7 @@ describe("daemon performance budget", () => {
     expect(defaultTable).not.toContain("| list_surfaces | socket | sampled | request_bytes |");
   });
 
-  it("recognizes the attested legacy baseline only for fail-closed CI evidence migration", () => {
+  it("commits only the canonical CI-attested sampled baseline", () => {
     const committed = JSON.parse(
       readFileSync(
         join(repoRoot, "benchmarks", "daemon-baseline.json"),
@@ -841,7 +841,7 @@ describe("daemon performance budget", () => {
       ),
     );
 
-    expect(() => validateBaseline(committed)).toThrow(/canonical 8x12 replay/);
+    expect(() => validateBaseline(committed)).not.toThrow();
     expect(checkerModule).toHaveProperty("isAttestedLegacyBaseline");
     expect(
       (
@@ -849,21 +849,13 @@ describe("daemon performance budget", () => {
           isAttestedLegacyBaseline: (candidate: unknown) => boolean;
         }
       ).isAttestedLegacyBaseline(committed),
-    ).toBe(true);
+    ).toBe(false);
     expect(committed.source.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(committed.replay).toMatchObject({ clients: 8, rounds: 12 });
-    expect(committed.replay.operations).toEqual([
-      "list_surfaces",
-      "read_screen",
-      "send_to_surface_warm",
-      "send_to_agent_warm",
-      "list_agents",
-      "control_health",
-      "spawn_close_during_sweep",
-      "first_send_after_spawn",
-    ]);
+    expect(committed.replay.operations).toEqual(baseline.replay.operations);
+    expect(committed.replay.row_metadata).toEqual(baseline.replay.row_metadata);
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(32988968639);
+    expect(committed.source.workflow_run_id).toBe(33317747972);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -284,6 +284,20 @@ describe("daemon performance budget", () => {
         }),
       ),
     ).toThrow(/row_metadata/);
+    expect(() =>
+      validateBaseline(
+        attest({
+          ...baseline,
+          measurements: {
+            ...baseline.measurements,
+            list_surfaces: {
+              ...baseline.measurements.list_surfaces,
+              p95_ms: 1_001,
+            },
+          },
+        }),
+      ),
+    ).toThrow(/sanity cap/);
   });
 
   it("uses measured spread and five-run p50 variance only for earned sampled rows", () => {
@@ -409,6 +423,7 @@ describe("daemon performance budget", () => {
       ref: "refs/heads/main",
       git_sha: "f".repeat(40),
       workflow_run_id: 999,
+      baseline_content_sha256: baseline.refresh_attestation.content_sha256,
     });
     expect(appended).toHaveLength(50);
     expect(appended[0]).toEqual(existing[1]);
@@ -421,7 +436,7 @@ describe("daemon performance budget", () => {
     expect(checkerModule).toHaveProperty("readBenchmarkHistory");
     const readBenchmarkHistory = (
       checkerModule as typeof checkerModule & {
-        readBenchmarkHistory: (path: string) => Promise<{
+        readBenchmarkHistory: (path: string, baselineSha?: string) => Promise<{
           runs: unknown[];
           degraded: boolean;
           reason?: string;
@@ -475,11 +490,24 @@ describe("daemon performance budget", () => {
         ref: "refs/heads/main",
         git_sha: "a".repeat(40),
         workflow_run_id: 99,
+        baseline_content_sha256: baseline.refresh_attestation.content_sha256,
       })[0];
       writeFileSync(historyPath, JSON.stringify({ runs: [validRun] }));
-      await expect(readBenchmarkHistory(historyPath)).resolves.toMatchObject({
+      await expect(
+        readBenchmarkHistory(
+          historyPath,
+          baseline.refresh_attestation.content_sha256,
+        ),
+      ).resolves.toMatchObject({
         runs: [validRun],
         degraded: false,
+      });
+      await expect(
+        readBenchmarkHistory(historyPath, "b".repeat(64)),
+      ).resolves.toMatchObject({
+        runs: [],
+        degraded: true,
+        reason: expect.stringContaining("different baseline"),
       });
     } finally {
       rmSync(artifactDir, { recursive: true, force: true });
@@ -963,10 +991,20 @@ describe("daemon performance budget", () => {
     expect(source).toContain(
       "benchmark_clients_survived_replay:\n        stressClientsSurvivedReplay &&\n        daemonClients.every((client) => client.alive)",
     );
-    expect(source).toContain("function parallelStressSentinel(index)");
-    expect(source).toContain("validateReceipt?.(receipt, requestArgs, index)");
+    expect(source).toContain("function parallelStressSentinel(index, roundIndex)");
+    expect(source).toContain(
+      "validateReceipt?.(receipt, requests[index], index, roundIndex)",
+    );
     expect(source).toContain("parallel read returned the wrong surface");
     expect(source).toContain("parallel read omitted its unique sentinel");
+    expect(source).toContain("function requireFiniteLockHold(");
+    expect(source).toContain("close_surface did not close the spawned surface");
+    expect(source).toContain("list_agents omitted the live spawned agent");
+    expect(source).toContain("beforeRound?.(roundIndex)");
+    expect(source).toContain("parallelStressSentinel(index, roundIndex)");
+    expect(source).toContain(
+      '"parallel send",',
+    );
     expect(source).toContain("firstSendAfterSpawn.sampled");
     expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
     expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");
@@ -1020,6 +1058,7 @@ describe("daemon performance budget", () => {
     expect(workflow).toContain("actions/cache/restore");
     expect(workflow).toContain("actions/cache/save");
     expect(workflow).toContain("history.json");
+    expect(workflow).toContain("hashFiles('benchmarks/daemon-baseline.json')");
     expect(
       readFileSync(
         join(repoRoot, "scripts", "check-daemon-benchmark.mjs"),

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1017,6 +1017,8 @@ describe("daemon performance budget", () => {
     expect(source).toContain("writeSurfaceState(surface, surfaceState)");
     expect(source).toContain("await requireSubmittedDelivery(client, receipt, label)");
     expect(source).not.toContain("return requireSubmittedDelivery(client, receipt, label)");
+    expect(source).not.toContain("receipt.typed !== true || receipt.submit_attempted !== true");
+    expect(source).toContain("throw new Error(`${label} was not verified as submitted`)");
     expect(source).toContain("text: surfaceSampleSentinel(sampleIndex)");
     expect(source).toContain('"surface:bench-spawn"');
     expect(source).toContain("read_back_verified: true");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -935,6 +935,10 @@ describe("daemon performance budget", () => {
       'receipt.transport || name === "control_health"',
     );
     expect(source).not.toContain("const transportReceipts = await Promise.all");
+    expect(source).toMatch(
+      /const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients\([\s\S]*?\n    \);\n    daemonRssMb = await totalRssMb/,
+    );
+    expect(source).not.toContain("onFirstSample");
   });
 
   it("wires a required PR/main job and edits a single comment even on RED", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -951,6 +951,10 @@ describe("daemon performance budget", () => {
     expect(source).toContain(
       "benchmark_clients_survived_replay:\n        stressClientsSurvivedReplay &&\n        daemonClients.every((client) => client.alive)",
     );
+    expect(source).toContain("function parallelStressSentinel(index)");
+    expect(source).toContain("validateReceipt?.(receipt, requestArgs, index)");
+    expect(source).toContain("parallel read returned the wrong surface");
+    expect(source).toContain("parallel read omitted its unique sentinel");
     expect(source).toContain("firstSendAfterSpawn.sampled");
     expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
     expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1018,7 +1018,7 @@ describe("daemon performance budget", () => {
     expect(source).toContain("await requireSubmittedDelivery(client, receipt, label)");
     expect(source).not.toContain("return requireSubmittedDelivery(client, receipt, label)");
     expect(source).not.toContain("receipt.typed !== true || receipt.submit_attempted !== true");
-    expect(source).toContain("throw new Error(`${label} was not verified as submitted`)");
+    expect(source).toContain("was not verified as submitted");
     expect(source).toContain("text: surfaceSampleSentinel(sampleIndex)");
     expect(source).toContain('"surface:bench-spawn"');
     expect(source).toContain("read_back_verified: true");
@@ -1031,6 +1031,10 @@ describe("daemon performance budget", () => {
     expect(source).toContain("function requireFiniteLockHold(");
     expect(source).toContain("close_surface did not close the spawned surface");
     expect(source).toContain("list_agents omitted the live spawned agent");
+    expect(source).not.toContain("compact(receipt).includes(spawnResult.agent_id)");
+    expect(source).toContain("Array.isArray(receipt.agents)");
+    expect(source).toContain("receipt.agents.some(");
+    expect(source).toContain("agent.agent_id === spawnResult.agent_id");
     expect(source).toContain("beforeRound?.(roundIndex)");
     expect(source).toContain("parallelStressSentinel(index, roundIndex)");
     expect(source).toContain("args(index, roundIndex)");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -952,7 +952,7 @@ describe("daemon performance budget", () => {
       );
     }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33324494030);
+    expect(committed.source.workflow_run_id).toBe(33374877017);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1035,6 +1035,16 @@ describe("daemon performance budget", () => {
     expect(source).toContain("Array.isArray(receipt.agents)");
     expect(source).toContain("receipt.agents.some(");
     expect(source).toContain("agent.agent_id === spawnResult.agent_id");
+    expect(source).toContain("{ lockHoldFromElapsed: true }");
+    expect(source).toContain(
+      "lock_hold_ms: lockHoldFromElapsed ? elapsedMs : 0",
+    );
+    expect(source.indexOf("await validateReceipt?.(receipt)")).toBeLessThan(
+      source.indexOf("elapsed_ms: round(nowMs() - startedAt)"),
+    );
+    expect(source).toMatch(
+      /await Promise\.all\([\s\S]*?validateReceipt\?\.[\s\S]*?\);\n {4}const elapsedMs = nowMs\(\) - startedAt;/,
+    );
     expect(source).toContain("beforeRound?.(roundIndex)");
     expect(source).toContain("parallelStressSentinel(index, roundIndex)");
     expect(source).toContain("args(index, roundIndex)");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -307,7 +307,7 @@ describe("daemon performance budget", () => {
     expect(highVariance?.ceiling).toBeCloseTo(206.07, 2);
   });
 
-  it("keeps a wide margin for honest single-shot and explicit stress rows", () => {
+  it("keeps a wide margin only for honest single-shot rows", () => {
     const singleShot = attest({
       ...baseline,
       replay: {
@@ -334,9 +334,9 @@ describe("daemon performance budget", () => {
     );
     expect(stressRow).toMatchObject({
       stress: true,
-      margin_ms: 300,
-      margin_rule: "constant +300ms (single-shot)",
-      ceiling: 560,
+      margin_ms: 100,
+      margin_rule: "measured (1 run)",
+      ceiling: 360,
     });
     const markdown = renderMarkdownComparison(
       baseline,
@@ -351,7 +351,14 @@ describe("daemon performance budget", () => {
     );
     expect(markdown).toContain("| Margin rule |");
     expect(markdown).toContain("measured (5 runs)");
-    expect(markdown).toContain("constant +300ms (single-shot)");
+    expect(markdown).not.toContain("constant +300ms (single-shot)");
+    expect(
+      renderMarkdownComparison(
+        singleShot,
+        result,
+        compareBenchmark(singleShot, result),
+      ),
+    ).toContain("constant +300ms (single-shot)");
   });
 
   it("records only green main runs and bounds append-only history to 50 runs", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -903,7 +903,7 @@ describe("daemon performance budget", () => {
       );
     }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33319637454);
+    expect(committed.source.workflow_run_id).toBe(33324494030);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -936,9 +936,12 @@ describe("daemon performance budget", () => {
     );
     expect(source).not.toContain("const transportReceipts = await Promise.all");
     expect(source).toMatch(
-      /const firstSendAfterSpawn = await measureSpawnLifecycleAcrossClients\([\s\S]*?\n {4}\);\n {4}const daemonRssMb = await totalRssMb/,
+      /await Promise\.all\(stressClients\.map\(\(client\) => client\.close\(\)\)\);\n {4}stressClients = \[\];\n {4}const daemonRssMb = await totalRssMb/,
     );
     expect(source).not.toContain("onFirstSample");
+    expect(source).toContain("const surfaceStates = new Map()");
+    expect(source).toContain("const surfaceMutationQueues = new Map()");
+    expect(source).toContain("await mutateFakeSurfaceState(");
     expect(source).toContain("firstSendAfterSpawn.sampled");
     expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
     expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -891,7 +891,7 @@ describe("daemon performance budget", () => {
       );
     }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33319012094);
+    expect(committed.source.workflow_run_id).toBe(33319637454);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -339,7 +339,7 @@ describe("daemon performance budget", () => {
     ).toBe("measured (1 run)");
   });
 
-  it("keeps a wide margin only for honest single-shot rows", () => {
+  it("rejects single-shot metadata for every canonical row", () => {
     const singleShot = attest({
       ...baseline,
       replay: {
@@ -350,15 +350,9 @@ describe("daemon performance budget", () => {
         },
       },
     });
-    const singleRow = compareBenchmark(singleShot, result).rows.find(
-      (entry) => entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+    expect(() => validateBaseline(singleShot)).toThrow(
+      /canonical sampled workload/,
     );
-    expect(singleRow).toMatchObject({
-      sampling: "single_shot",
-      margin_ms: 300,
-      margin_rule: "constant +300ms (single-shot)",
-      ceiling: 400,
-    });
     const stressRow = compareBenchmark(baseline, result).rows.find(
       (entry) =>
         entry.operation === "send_to_surface_10_parallel" &&
@@ -384,13 +378,40 @@ describe("daemon performance budget", () => {
     expect(markdown).toContain("| Margin rule |");
     expect(markdown).toContain("measured (5 runs)");
     expect(markdown).not.toContain("constant +300ms (single-shot)");
-    expect(
-      renderMarkdownComparison(
-        singleShot,
-        result,
-        compareBenchmark(singleShot, result),
-      ),
-    ).toContain("constant +300ms (single-shot)");
+  });
+
+  it("rejects weakened normal and stress sampling metadata", () => {
+    const weakNormal = attest({
+      ...baseline,
+      replay: {
+        ...baseline.replay,
+        row_metadata: {
+          ...baseline.replay.row_metadata,
+          list_surfaces: { sampling: "sampled", samples_per_run: 12 },
+        },
+      },
+    });
+    expect(() => validateBaseline(weakNormal)).toThrow(
+      /canonical sampled workload/,
+    );
+
+    const weakStress = attest({
+      ...baseline,
+      replay: {
+        ...baseline.replay,
+        row_metadata: {
+          ...baseline.replay.row_metadata,
+          send_to_surface_10_parallel: {
+            sampling: "sampled",
+            samples_per_run: 12,
+            stress: false,
+          },
+        },
+      },
+    });
+    expect(() => validateBaseline(weakStress)).toThrow(
+      /canonical sampled workload/,
+    );
   });
 
   it("records only green main runs and bounds append-only history to 50 runs", () => {
@@ -992,6 +1013,10 @@ describe("daemon performance budget", () => {
       "benchmark_clients_survived_replay:\n        stressClientsSurvivedReplay &&\n        daemonClients.every((client) => client.alive)",
     );
     expect(source).toContain("function parallelStressSentinel(index, roundIndex)");
+    expect(source).toContain("readSurfaceState(surface)");
+    expect(source).toContain("writeSurfaceState(surface, surfaceState)");
+    expect(source).toContain("await requireSubmittedDelivery(client, receipt, label)");
+    expect(source).not.toContain("return requireSubmittedDelivery(client, receipt, label)");
     expect(source).toContain(
       "validateReceipt?.(receipt, requests[index], index, roundIndex)",
     );
@@ -1002,6 +1027,7 @@ describe("daemon performance budget", () => {
     expect(source).toContain("list_agents omitted the live spawned agent");
     expect(source).toContain("beforeRound?.(roundIndex)");
     expect(source).toContain("parallelStressSentinel(index, roundIndex)");
+    expect(source).toContain("args(index, roundIndex)");
     expect(source).toContain(
       '"parallel send",',
     );

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1045,6 +1045,10 @@ describe("daemon performance budget", () => {
     expect(source).toMatch(
       /await Promise\.all\([\s\S]*?validateReceipt\?\.[\s\S]*?\);\n {4}const elapsedMs = nowMs\(\) - startedAt;/,
     );
+    expect(source).toContain('"sampled surface send initial receipt"');
+    expect(source).toContain(
+      'requireTerminalSubmission(receipt, "parallel send initial receipt")',
+    );
     expect(source).toContain("beforeRound?.(roundIndex)");
     expect(source).toContain("parallelStressSentinel(index, roundIndex)");
     expect(source).toContain("args(index, roundIndex)");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -859,7 +859,7 @@ describe("daemon performance budget", () => {
     expect(defaultTable).not.toContain("| list_surfaces | socket | sampled | request_bytes |");
   });
 
-  it("recognizes the attested legacy baseline only for fail-closed CI evidence migration", () => {
+  it("commits only the canonical CI-attested sampled baseline", () => {
     const committed = JSON.parse(
       readFileSync(
         join(repoRoot, "benchmarks", "daemon-baseline.json"),
@@ -867,7 +867,7 @@ describe("daemon performance budget", () => {
       ),
     );
 
-    expect(() => validateBaseline(committed)).toThrow(/canonical 8x12 replay/);
+    expect(() => validateBaseline(committed)).not.toThrow();
     expect(checkerModule).toHaveProperty("isAttestedLegacyBaseline");
     expect(
       (
@@ -875,21 +875,23 @@ describe("daemon performance budget", () => {
           isAttestedLegacyBaseline: (candidate: unknown) => boolean;
         }
       ).isAttestedLegacyBaseline(committed),
-    ).toBe(true);
+    ).toBe(false);
     expect(committed.source.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(committed.replay).toMatchObject({ clients: 8, rounds: 12 });
-    expect(committed.replay.operations).toEqual([
-      "list_surfaces",
-      "read_screen",
+    expect(committed.replay.operations).toEqual(baseline.replay.operations);
+    expect(committed.replay.row_metadata).toEqual(baseline.replay.row_metadata);
+    for (const operation of [
       "send_to_surface_warm",
       "send_to_agent_warm",
-      "list_agents",
-      "control_health",
       "spawn_close_during_sweep",
       "first_send_after_spawn",
-    ]);
+    ]) {
+      expect(committed.measurements[operation].p95_ms).toBeGreaterThan(
+        committed.measurements[operation].p50_ms,
+      );
+    }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(32988968639);
+    expect(committed.source.workflow_run_id).toBe(33319012094);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -970,7 +970,7 @@ describe("daemon performance budget", () => {
     expect(source).toContain("const PARALLEL_STRESS_COUNT = 10");
     expect(source).toContain('sampling: "sampled"');
     expect(source).toContain("samples_per_run");
-    expect(source).toContain("for (const client of clients)");
+    expect(source).toContain("for (const [clientIndex, client] of clients.entries())");
     expect(source).toContain("surface_receipts_waitable: samples.every");
     expect(source).toContain('sample.surface.wait_for.delivery_state === "submitted"');
     expect(source).toContain("sample.surface.wait_for.submit_verified === true");
@@ -1017,6 +1017,10 @@ describe("daemon performance budget", () => {
     expect(source).toContain("writeSurfaceState(surface, surfaceState)");
     expect(source).toContain("await requireSubmittedDelivery(client, receipt, label)");
     expect(source).not.toContain("return requireSubmittedDelivery(client, receipt, label)");
+    expect(source).toContain("text: surfaceSampleSentinel(sampleIndex)");
+    expect(source).toContain('"surface:bench-spawn"');
+    expect(source).toContain("read_back_verified: true");
+    expect(source).toContain("sample.surface.wait_for.read_back_verified === true");
     expect(source).toContain(
       "validateReceipt?.(receipt, requests[index], index, roundIndex)",
     );

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -285,7 +285,12 @@ describe("daemon performance budget", () => {
     const row = comparison.rows.find(
       (entry) => entry.operation === "list_surfaces" && entry.metric === "p50_ms",
     );
-    expect(row).toMatchObject({ sampling: "sampled", margin_ms: 40, ceiling: 140 });
+    expect(row).toMatchObject({
+      sampling: "sampled",
+      margin_ms: 40,
+      margin_rule: "measured (5 runs)",
+      ceiling: 140,
+    });
 
     const highVarianceHistory = [50, 75, 100, 125, 150].map((p50_ms, index) => ({
       source: { git_sha: `f${String(index).padStart(39, "0")}`, workflow_run_id: 100 + index },
@@ -319,6 +324,7 @@ describe("daemon performance budget", () => {
     expect(singleRow).toMatchObject({
       sampling: "single_shot",
       margin_ms: 300,
+      margin_rule: "constant +300ms (single-shot)",
       ceiling: 400,
     });
     const stressRow = compareBenchmark(baseline, result).rows.find(
@@ -326,7 +332,26 @@ describe("daemon performance budget", () => {
         entry.operation === "send_to_surface_10_parallel" &&
         entry.metric === "p50_ms",
     );
-    expect(stressRow).toMatchObject({ stress: true, margin_ms: 300, ceiling: 560 });
+    expect(stressRow).toMatchObject({
+      stress: true,
+      margin_ms: 300,
+      margin_rule: "constant +300ms (single-shot)",
+      ceiling: 560,
+    });
+    const markdown = renderMarkdownComparison(
+      baseline,
+      result,
+      compareBenchmark(baseline, result, {
+        history: Array.from({ length: 5 }, (_, index) => ({
+          measurements: {
+            list_surfaces: { p50_ms: 100 + index },
+          },
+        })),
+      }),
+    );
+    expect(markdown).toContain("| Margin rule |");
+    expect(markdown).toContain("measured (5 runs)");
+    expect(markdown).toContain("constant +300ms (single-shot)");
   });
 
   it("records only green main runs and bounds append-only history to 50 runs", () => {
@@ -408,7 +433,27 @@ describe("daemon performance budget", () => {
       );
       writeFileSync(historyPath, JSON.stringify({ runs: [{ source: { workflow_run_id: 1 } }] }));
       await expect(readBenchmarkHistory(historyPath)).resolves.toMatchObject({
-        runs: [{ source: { workflow_run_id: 1 } }],
+        runs: [],
+        degraded: true,
+        reason: expect.stringContaining("malformed entry"),
+      });
+      const validRun = (
+        checkerModule as typeof checkerModule & {
+          appendGreenMainHistory: (
+            history: unknown[],
+            result: unknown,
+            context: Record<string, unknown>,
+          ) => unknown[];
+        }
+      ).appendGreenMainHistory([], result, {
+        event_name: "push",
+        ref: "refs/heads/main",
+        git_sha: "a".repeat(40),
+        workflow_run_id: 99,
+      })[0];
+      writeFileSync(historyPath, JSON.stringify({ runs: [validRun] }));
+      await expect(readBenchmarkHistory(historyPath)).resolves.toMatchObject({
+        runs: [validRun],
         degraded: false,
       });
     } finally {
@@ -697,6 +742,32 @@ describe("daemon performance budget", () => {
     );
   });
 
+  it("fails closed when candidate sampling metadata is missing or incompatible", () => {
+    const missing = compareBenchmark(baseline, {
+      ...result,
+      replay: { ...result.replay, row_metadata: undefined },
+    });
+    expect(missing.passed).toBe(false);
+    expect(missing.failures).toContainEqual(
+      expect.stringContaining("candidate row_metadata.list_surfaces"),
+    );
+
+    const incompatible = compareBenchmark(baseline, {
+      ...result,
+      replay: {
+        ...result.replay,
+        row_metadata: {
+          ...result.replay.row_metadata,
+          list_surfaces: { sampling: "single_shot", samples_per_run: 1 },
+        },
+      },
+    });
+    expect(incompatible.passed).toBe(false);
+    expect(incompatible.failures).toContainEqual(
+      expect.stringContaining("candidate row_metadata.list_surfaces"),
+    );
+  });
+
   it("cannot reuse a stale result when the benchmark process fails", async () => {
     const artifactDir = mkdtempSync(join(tmpdir(), "cmuxlayer-stale-bench-"));
     writeFileSync(join(artifactDir, "result.json"), JSON.stringify(result));
@@ -750,7 +821,9 @@ describe("daemon performance budget", () => {
     );
 
     expect(markdown).toContain("<!-- cmuxlayer-perf-budget -->");
-    expect(markdown).toContain("| Operation | Transport | Sampling | Metric |");
+    expect(markdown).toContain(
+      "| Operation | Transport | Sampling | Margin rule | Metric |",
+    );
     expect(markdown).toContain("first_send_after_spawn");
     expect(markdown).toContain("Runner regression ratio: 1.25x");
     expect(markdown).toContain("rows unchanged");
@@ -809,6 +882,10 @@ describe("daemon performance budget", () => {
     expect(source).toContain('sampling: "sampled"');
     expect(source).toContain("samples_per_run");
     expect(source).toContain("for (const client of clients)");
+    expect(source).toContain("surface_receipts_waitable: samples.every");
+    expect(source).toContain(
+      "surface_receipt_is_waitable:\n        firstSendAfterSpawn.surface_receipts_waitable",
+    );
     expect(source).toContain("p95_ms");
     expect(source).toContain("request_bytes");
     expect(source).toContain("lock_hold_ms");

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -367,6 +367,55 @@ describe("daemon performance budget", () => {
     });
   });
 
+  it("renders corrupted history RED with visibly degraded wide-margin rows", async () => {
+    expect(checkerModule).toHaveProperty("readBenchmarkHistory");
+    const readBenchmarkHistory = (
+      checkerModule as typeof checkerModule & {
+        readBenchmarkHistory: (path: string) => Promise<{
+          runs: unknown[];
+          degraded: boolean;
+          reason?: string;
+        }>;
+      }
+    ).readBenchmarkHistory;
+    const artifactDir = mkdtempSync(join(tmpdir(), "cmuxlayer-bad-history-"));
+    const historyPath = join(artifactDir, "history.json");
+    writeFileSync(historyPath, "{not-json");
+    try {
+      const corrupted = await readBenchmarkHistory(historyPath);
+      expect(corrupted).toMatchObject({
+        runs: [],
+        degraded: true,
+        reason: expect.stringContaining("history.json"),
+      });
+      const comparison = compareBenchmark(baseline, result, {
+        history: corrupted.runs,
+        historyDegraded: corrupted.degraded,
+        historyDegradedReason: corrupted.reason,
+      });
+      expect(comparison.passed).toBe(false);
+      expect(comparison.failures).toContainEqual(
+        expect.stringContaining("benchmark history degraded"),
+      );
+      expect(
+        comparison.rows.find(
+          (entry) =>
+            entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+        ),
+      ).toMatchObject({ history_degraded: true, margin_ms: 300 });
+      expect(renderMarkdownComparison(baseline, result, comparison)).toContain(
+        "history-degraded · wide-margin",
+      );
+      writeFileSync(historyPath, JSON.stringify({ runs: [{ source: { workflow_run_id: 1 } }] }));
+      await expect(readBenchmarkHistory(historyPath)).resolves.toMatchObject({
+        runs: [{ source: { workflow_run_id: 1 } }],
+        degraded: false,
+      });
+    } finally {
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails the consistency assertion after a baseline-only hand edit", () => {
     expect(() =>
       validateBaseline({
@@ -443,17 +492,14 @@ describe("daemon performance budget", () => {
     ).toContain("| read_screen | cli |");
   });
 
-  it("fails the benchmark when the intrinsic CLI-send sample used fallback", () => {
+  it("fails the benchmark when the sampled CLI-send distribution used fallback", () => {
     const fallback = compareBenchmark(baseline, {
       ...result,
       latency: {
         ...result.latency,
-        first_send_after_spawn: {
-          ...result.latency.first_send_after_spawn,
-          surface: {
-            ...result.latency.first_send_after_spawn.surface,
-            transport: "cli",
-          },
+        send_to_surface_warm: {
+          ...result.latency.send_to_surface_warm,
+          transport: "cli",
         },
       },
     });
@@ -613,7 +659,7 @@ describe("daemon performance budget", () => {
       },
     });
     expect(cli.failures).toContain(
-      "first_send_after_spawn cli_send: 1001ms exceeds 1000ms",
+      "send_to_surface_warm cli_send: 1001ms exceeds 875ms",
     );
 
     const replay = compareBenchmark(baseline, {
@@ -714,7 +760,7 @@ describe("daemon performance budget", () => {
     expect(defaultTable).not.toContain("| list_surfaces | socket | sampled | request_bytes |");
   });
 
-  it("commits a post-run-5 baseline with the full replay contract", () => {
+  it("recognizes the attested legacy baseline only for fail-closed CI evidence migration", () => {
     const committed = JSON.parse(
       readFileSync(
         join(repoRoot, "benchmarks", "daemon-baseline.json"),
@@ -722,7 +768,15 @@ describe("daemon performance budget", () => {
       ),
     );
 
-    expect(() => validateBaseline(committed)).not.toThrow();
+    expect(() => validateBaseline(committed)).toThrow(/canonical 8x12 replay/);
+    expect(checkerModule).toHaveProperty("isAttestedLegacyBaseline");
+    expect(
+      (
+        checkerModule as typeof checkerModule & {
+          isAttestedLegacyBaseline: (candidate: unknown) => boolean;
+        }
+      ).isAttestedLegacyBaseline(committed),
+    ).toBe(true);
     expect(committed.source.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(committed.replay).toMatchObject({ clients: 8, rounds: 12 });
     expect(committed.replay.operations).toEqual([
@@ -734,8 +788,6 @@ describe("daemon performance budget", () => {
       "control_health",
       "spawn_close_during_sweep",
       "first_send_after_spawn",
-      "send_to_surface_10_parallel",
-      "read_screen_10_parallel",
     ]);
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
     expect(committed.source.workflow_run_id).toBe(32988968639);

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -952,7 +952,7 @@ describe("daemon performance budget", () => {
       );
     }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33377777123);
+    expect(committed.source.workflow_run_id).toBe(33380548570);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -305,6 +305,12 @@ describe("daemon performance budget", () => {
     );
     expect(highVariance?.margin_ms).toBeCloseTo(106.07, 2);
     expect(highVariance?.ceiling).toBeCloseTo(206.07, 2);
+    expect(
+      compareBenchmark(baseline, result, { history: history.slice(0, 3) }).rows.find(
+        (entry) =>
+          entry.operation === "list_surfaces" && entry.metric === "p50_ms",
+      )?.margin_rule,
+    ).toBe("measured (1 run)");
   });
 
   it("keeps a wide margin only for honest single-shot rows", () => {
@@ -807,10 +813,23 @@ describe("daemon performance budget", () => {
   });
 
   it("allows the explicit fast-round override but no implicit round drift", () => {
+    const fastRowMetadata = Object.fromEntries(
+      Object.entries(result.replay.row_metadata).map(([operation, metadata]) => [
+        operation,
+        {
+          ...metadata,
+          samples_per_run: metadata.samples_per_run / 4,
+        },
+      ]),
+    );
     const fast = {
       ...result,
       rounds: 3,
-      replay: { ...result.replay, rounds: 3 },
+      replay: {
+        ...result.replay,
+        rounds: 3,
+        row_metadata: fastRowMetadata,
+      },
     };
     expect(compareBenchmark(baseline, fast).failures).toContain(
       "replay rounds: 3 does not match expected 12",
@@ -840,7 +859,7 @@ describe("daemon performance budget", () => {
     expect(defaultTable).not.toContain("| list_surfaces | socket | sampled | request_bytes |");
   });
 
-  it("commits only the canonical CI-attested sampled baseline", () => {
+  it("recognizes the attested legacy baseline only for fail-closed CI evidence migration", () => {
     const committed = JSON.parse(
       readFileSync(
         join(repoRoot, "benchmarks", "daemon-baseline.json"),
@@ -848,7 +867,7 @@ describe("daemon performance budget", () => {
       ),
     );
 
-    expect(() => validateBaseline(committed)).not.toThrow();
+    expect(() => validateBaseline(committed)).toThrow(/canonical 8x12 replay/);
     expect(checkerModule).toHaveProperty("isAttestedLegacyBaseline");
     expect(
       (
@@ -856,13 +875,21 @@ describe("daemon performance budget", () => {
           isAttestedLegacyBaseline: (candidate: unknown) => boolean;
         }
       ).isAttestedLegacyBaseline(committed),
-    ).toBe(false);
+    ).toBe(true);
     expect(committed.source.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(committed.replay).toMatchObject({ clients: 8, rounds: 12 });
-    expect(committed.replay.operations).toEqual(baseline.replay.operations);
-    expect(committed.replay.row_metadata).toEqual(baseline.replay.row_metadata);
+    expect(committed.replay.operations).toEqual([
+      "list_surfaces",
+      "read_screen",
+      "send_to_surface_warm",
+      "send_to_agent_warm",
+      "list_agents",
+      "control_health",
+      "spawn_close_during_sweep",
+      "first_send_after_spawn",
+    ]);
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33317747972);
+    expect(committed.source.workflow_run_id).toBe(32988968639);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,
@@ -882,6 +909,8 @@ describe("daemon performance budget", () => {
     expect(source).toContain("samples_per_run");
     expect(source).toContain("for (const client of clients)");
     expect(source).toContain("surface_receipts_waitable: samples.every");
+    expect(source).toContain('sample.surface.wait_for.delivery_state === "submitted"');
+    expect(source).toContain("sample.surface.wait_for.submit_verified === true");
     expect(source).toContain(
       "surface_receipt_is_waitable:\n        firstSendAfterSpawn.surface_receipts_waitable",
     );
@@ -963,6 +992,7 @@ describe("daemon performance budget", () => {
     expect(source).toContain("GITHUB_RUN_ID");
     expect(source).toContain('GITHUB_ACTIONS !== "true"');
     expect(source).toContain("compareBenchmark(existing, sample)");
+    expect(source).toContain("migratingLegacyBaseline\n            ? measured");
     expect(source).toContain("replay?.bytes?.[operation]");
     expect(source).toContain(
       "refusing to raise a committed performance baseline",

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -952,7 +952,7 @@ describe("daemon performance budget", () => {
       );
     }
     expect(committed.source.runner_class).toBe("github-actions-ubuntu-latest");
-    expect(committed.source.workflow_run_id).toBe(33374877017);
+    expect(committed.source.workflow_run_id).toBe(33377777123);
     expect(committed).not.toHaveProperty("ceilings");
     expect(committed.refresh_attestation.content_sha256).toMatch(
       /^[0-9a-f]{64}$/,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -9,6 +9,7 @@ import {
   compareBenchmark,
   maximumBenchmarkMeasurements,
   performanceCeiling,
+  requireCanonicalRequestChangeReason,
   requireBaselineIncreaseReason,
   renderMarkdownComparison,
   runBenchmark,
@@ -225,6 +226,16 @@ describe("daemon performance budget", () => {
       true,
     );
     expect(requireBaselineIncreaseReason([[99, 100]], "")).toBe(false);
+  });
+
+  it("requires an explicit reason for an imported canonical-request change", () => {
+    expect(() => requireCanonicalRequestChangeReason(true, "")).toThrow(
+      /canonical request change without --reason/,
+    );
+    expect(
+      requireCanonicalRequestChangeReason(true, "verify parallel read identity"),
+    ).toBe(true);
+    expect(requireCanonicalRequestChangeReason(false, "")).toBe(false);
   });
 
   it("requires a CI-runner source, canonical requests, and the 1.25 ratio", () => {

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -947,6 +947,10 @@ describe("daemon performance budget", () => {
     expect(source).toContain(
       "daemon_survived_replay:\n        daemon.exitCode === null &&\n        daemon.signalCode === null &&\n        daemonStats.rssKb > 0",
     );
+    expect(source).toContain("get alive() {");
+    expect(source).toContain(
+      "benchmark_clients_survived_replay:\n        stressClientsSurvivedReplay &&\n        daemonClients.every((client) => client.alive)",
+    );
     expect(source).toContain("firstSendAfterSpawn.sampled");
     expect(source).toContain("firstSendAfterSpawn.send_to_agent_warm");
     expect(source).toContain("firstSendAfterSpawn.send_to_surface_warm");


### PR DESCRIPTION
## Summary

- replace single-shot daemon timing claims with 12-sample distributions and explicit sampled/stress metadata
- derive history-aware margins while keeping single-shot and untrusted history on the conservative `+300ms` margin
- make corrupt history fail closed: emit the comment, visibly mark degraded rows, use the wide margin, and force RED
- add a CI-attested migration path for the committed legacy baseline; the first PR run is expected to remain RED until its runner artifact is imported

## Verification

- `bun test tests/perf-budget.test.ts` — 25 passed
- `bun run typecheck` — passed
- `env -u CMUX_SOCKET_PATH -u CMUX_DAEMON_SOCKET bash scripts/run_tests.sh` — 154 files, 3,587 passed, 1 skipped
- local CodeRabbit review — zero findings after the corrupted-history repair

— cmuxlayerCodex-28b268c9 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-28b268c9","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a052f5","ts":"2026-08-30T14:29:45Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI perf gates, baseline schema, and ceiling math (including tighter effective limits once history is trusted); misconfigured `row_metadata` or stale legacy baselines will fail checks until import/migration completes.
> 
> **Overview**
> This PR **replaces single-shot daemon perf claims** with **sampled distributions** (8×12 clients/rounds), adds **two 10-way parallel stress operations** (`send_to_surface_10_parallel`, `read_screen_10_parallel`), and refreshes the committed baseline to the new 10-row contract with updated measurements and `row_metadata`.
> 
> The benchmark runner now **aggregates lifecycle and warm-path timings across clients**, requires **terminal submission and read-back proof** for surface sends, models **per-surface fake cmux state** for parallel correctness, measures **`list_agents` against a live spawned agent** (lock hold from elapsed time), and adds **survival gates** for daemon and clients after stress replay.
> 
> **Budget enforcement** gains **history-aware ceilings**: margins use spread `2×(p95−p50)` and, after five green main runs, `3σ` of historical p50; corrupted or mismatched cached history **fail closed** with conservative +300ms margins and RED. CI **restores/saves** bounded `history.json` on main (keyed by baseline hash). PR comments show **sampling, margin rules**, and a collapsible full table.
> 
> Legacy 8-row attested baselines **stay RED** until a runner artifact is imported; refresh requires **`--reason`** for raised rows and canonical request changes on rebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d83cd207e664e06a402c53f3fd27ab3b7fb5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add adaptive margins, sampled metrics, and parallel stress tests to daemon perf budget
> - Reworks `bench-daemon.mjs` to measure p50/p95 across multiple clients and rounds, add `send_to_surface_10_parallel` and `read_screen_10_parallel` stress operations, verify surface delivery via read-back, and isolate per-surface state in the fake cmux server
> - Extends `check-daemon-benchmark.mjs` to compute per-operation margins from current spread and up to 50 runs of persisted history (`BENCHMARK_HISTORY_LIMIT`), enforce sanity caps on all metrics, reject degraded history, and fail legacy baselines as RED
> - Updates `refresh-daemon-baseline.mjs` to require a reason for canonical-request changes during runner rebases and to seed legacy-migrated measurements directly from measured values
> - Adds CI history cache restore/save in `ci.yml` keyed by `benchmarks/daemon-baseline.json` hash, and updates `daemon-baseline.json` with the two new operations, `row_metadata`, and sampled p50/p95/lock_hold metrics
> - Behavioral Change: ceiling computation in `performanceCeiling` now uses dynamic `marginMs` (default 300) instead of a fixed +300ms; `cli_send_ms` is derived from `send_to_surface_warm` p50 (max 875ms) instead of `first_send_after_spawn`; `compareBenchmark` rejects candidates whose `row_metadata` sampling workload mismatches the committed baseline; degraded history forces RED with widened 300ms margins
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9d83cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Expanded daemon performance coverage with parallel client operations and lifecycle measurements.
  * Improved benchmark accuracy using sampled percentile metrics and historical comparisons.

* **Reporting**
  * Added clearer sampling details and comparison results.
  * Improved handling of missing, outdated, corrupted, or degraded performance history.

* **Quality**
  * Expanded automated coverage for stress scenarios, history persistence, and reporting.
  * Refreshed the daemon performance baseline with updated measurements.
  * Added safeguards to detect incompatible benchmark data and request changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->