### PR TITLE
feat: add Nightly MCP-vs-CLI benchmark harness

### DIFF
--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -775,13 +775,13 @@ export function createWorkspaceReservation(
   lockRoot = "/tmp",
 ) {
   const key = createHash("sha256")
-    .update(`${resolve(cmuxSocketPath)}\0${workspace}`)
+    .update(resolve(cmuxSocketPath))
     .digest("hex")
     .slice(0, 24);
   const lockPath = join(lockRoot, `cmuxlayer-bench-workspace-${key}.lock`);
   return createPidLock(
     lockPath,
-    `Nightly workspace ${workspace} on ${cmuxSocketPath}`,
+    `Nightly socket ${cmuxSocketPath} (requested workspace ${workspace})`,
   );
 }
 
@@ -1601,6 +1601,18 @@ async function listRuntimeFiles(root) {
   return files;
 }
 
+async function resolveExecutable(command, env) {
+  const candidate = command.includes("/")
+    ? resolve(command)
+    : nonEmptyString(
+        (
+          await execCapture("/usr/bin/which", [command], { env })
+        ).stdout.trim(),
+      );
+  if (!candidate) throw new Error(`could not resolve executable ${command}`);
+  return realpath(candidate);
+}
+
 export async function assertArtifactProvenance(
   provenance,
   hashFile = sha256File,
@@ -1608,6 +1620,7 @@ export async function assertArtifactProvenance(
   const attested = [
     ...Object.values(provenance.entries),
     ...(provenance.runtime_files ?? []),
+    ...(provenance.cli_executable ? [provenance.cli_executable] : []),
   ];
   if (provenance.runtime_root && provenance.runtime_files) {
     const expectedPaths = provenance.runtime_files.map((entry) => entry.path);
@@ -1632,6 +1645,7 @@ export async function prepareBuiltEntries(config, deps = {}) {
   const exists = deps.exists ?? existsSync;
   const hashFile = deps.hashFile ?? sha256File;
   const enumerateRuntimeFiles = deps.listRuntimeFiles ?? listRuntimeFiles;
+  const resolveCliExecutable = deps.resolveExecutable ?? resolveExecutable;
   const expectedMcpEntry = join(root, "dist", "index.js");
   const expectedDaemonEntry = join(root, "dist", "daemon.js");
   if (
@@ -1669,6 +1683,7 @@ export async function prepareBuiltEntries(config, deps = {}) {
   }
   const runtimeRoot = join(root, "dist");
   const runtimeFiles = await enumerateRuntimeFiles(runtimeRoot);
+  const cliPath = await resolveCliExecutable(config.cmuxBin ?? "cmux", config.env);
   return {
     git_head: head.stdout.trim(),
     entries: {
@@ -1685,6 +1700,11 @@ export async function prepareBuiltEntries(config, deps = {}) {
     runtime_files: await Promise.all(
       runtimeFiles.map(async (path) => ({ path, sha256: await hashFile(path) })),
     ),
+    cli_executable: {
+      requested: config.cmuxBin ?? "cmux",
+      path: cliPath,
+      sha256: await hashFile(cliPath),
+    },
   };
 }
 
@@ -1797,6 +1817,7 @@ async function executeBenchmark(
     ...config,
     env: process.env,
   });
+  config.cmuxBin = artifactProvenance.cli_executable.path;
   await assertArtifactProvenance(artifactProvenance);
   abortSignal.throwIfAborted();
   const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -374,9 +374,9 @@ function mcpReceipt(result) {
 function execCapture(
   command,
   args,
-  { env, timeoutMs = 30_000, signal = null } = {},
+  { env, timeoutMs = 30_000, signal: abortSignal = null } = {},
 ) {
-  if (signal?.aborted) return Promise.reject(signal.reason);
+  if (abortSignal?.aborted) return Promise.reject(abortSignal.reason);
   return new Promise((resolvePromise, reject) => {
     const child = spawn(command, args, {
       cwd: repoRoot,
@@ -392,10 +392,10 @@ function execCapture(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
+      abortSignal?.removeEventListener("abort", onAbort);
       fn(value);
     };
-    const cancel = (reason) => {
+    function cancel(reason) {
       timedOut = true;
       terminateChild(child).then(
         () => settle(reject, reason),
@@ -408,9 +408,11 @@ function execCapture(
             ),
           ),
       );
-    };
-    const onAbort = () => cancel(signal.reason);
-    signal?.addEventListener("abort", onAbort, { once: true });
+    }
+    function onAbort() {
+      cancel(abortSignal.reason);
+    }
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
     timer = setTimeout(() => {
       const timeoutError = new Error(
         `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
@@ -426,13 +428,13 @@ function execCapture(
     child.once("error", (error) => {
       settle(reject, error);
     });
-    child.once("close", (code, signal) => {
+    child.once("close", (code, exitSignal) => {
       if (timedOut) return;
       if (code !== 0) {
         settle(
           reject,
           new Error(
-            `${command} ${args.join(" ")} exited code=${code} signal=${signal}: ${stderr.trim()}`,
+            `${command} ${args.join(" ")} exited code=${code} signal=${exitSignal}: ${stderr.trim()}`,
           ),
         );
         return;

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1271,6 +1271,32 @@ async function enumerateCliWorkspaces(config, exec = execCapture) {
   throw new Error("incomplete all-window workspace enumeration after retry");
 }
 
+export async function resolveStableWorkspaceId(
+  requestedWorkspace,
+  config,
+  exec = execCapture,
+) {
+  const workspaces = await enumerateCliWorkspaces(config, exec);
+  const matches = workspaces.filter(
+    (workspace) =>
+      isRecord(workspace) &&
+      (nonEmptyString(workspace.ref) === requestedWorkspace ||
+        nonEmptyString(workspace.id) === requestedWorkspace),
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `workspace ${requestedWorkspace} resolved to ${matches.length} all-window entries; refusing an ambiguous reservation`,
+    );
+  }
+  const stableId = nonEmptyString(matches[0].id);
+  if (!stableId) {
+    throw new Error(
+      `workspace ${requestedWorkspace} has no stable id; refusing a ref-only reservation`,
+    );
+  }
+  return stableId;
+}
+
 function workspaceRefs(workspaces) {
   return workspaces
     .map((workspace) =>
@@ -1582,9 +1608,14 @@ async function main() {
   const abortController = new AbortController();
   const removeSignalHandlers = installGracefulSignalAbort(abortController);
   try {
+    const stableWorkspaceId = await resolveStableWorkspaceId(config.workspace, {
+      cmuxBin: config.cmuxBin,
+      env: process.env,
+      signal: abortController.signal,
+    });
     const workspaceReservation = await createWorkspaceReservation(
       isolation.cmuxSocketPath,
-      config.workspace,
+      stableWorkspaceId,
     );
     try {
       abortController.signal.throwIfAborted();

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1074,16 +1074,20 @@ async function runCliTopology(
   } = {},
 ) {
   const runWorkspace = async (workspace) => {
-    let panes;
-    try {
-      const panesOut = await exec(config.cmuxBin, listPanesCliArgs(workspace), {
-        env: config.env,
-      });
-      panes = paneRefsFromListPanesStdout(panesOut.stdout);
-    } catch (error) {
-      if (bestEffort) return;
-      throw error;
-    }
+    const panes = await (async () => {
+      try {
+        const panesOut = await exec(
+          config.cmuxBin,
+          listPanesCliArgs(workspace),
+          { env: config.env },
+        );
+        return paneRefsFromListPanesStdout(panesOut.stdout);
+      } catch (error) {
+        if (bestEffort) return null;
+        throw error;
+      }
+    })();
+    if (panes === null) return;
     if (parallelPanes) {
       const work = panes.map((pane) =>
         exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -270,16 +270,24 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let settled = false;
     let timer = null;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(value);
+    };
     timer = setTimeout(() => {
       timedOut = true;
       const timeoutError = new Error(
         `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
       );
       terminateChild(child).then(
-        () => reject(timeoutError),
+        () => settle(reject, timeoutError),
         (terminationError) =>
-          reject(
+          settle(
+            reject,
             new AggregateError(
               [timeoutError, terminationError],
               "command timed out and child termination failed",
@@ -294,21 +302,20 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
       stderr += chunk.toString("utf8");
     });
     child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
+      settle(reject, error);
     });
     child.once("close", (code, signal) => {
-      clearTimeout(timer);
       if (timedOut) return;
       if (code !== 0) {
-        reject(
+        settle(
+          reject,
           new Error(
             `${command} ${args.join(" ")} exited code=${code} signal=${signal}: ${stderr.trim()}`,
           ),
         );
         return;
       }
-      resolvePromise({ stdout, stderr });
+      settle(resolvePromise, { stdout, stderr });
     });
   });
 }
@@ -494,20 +501,24 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
     rejectSpawnFailure = reject;
   });
   const onSpawnError = (error) => rejectSpawnFailure(error);
-  child.once("error", onSpawnError);
-  child.once("exit", (code, signal) => {
+  const onEarlyExit = (code, signal) => {
     earlyExit = { code, signal };
     rejectSpawnFailure(
       new Error(
         `isolated daemon exited before readiness: ${JSON.stringify(earlyExit)}`,
       ),
     );
-  });
+  };
+  child.once("error", onSpawnError);
+  child.once("exit", onEarlyExit);
   const socketWait = waitForSocket(daemonSocketPath);
   try {
     await Promise.race([socketWait.promise, spawnFailure, logFailure]);
     socketWait.cancel();
     child.off("error", onSpawnError);
+    child.off("exit", onEarlyExit);
+    spawnFailure.catch(() => undefined);
+    logFailure.catch(() => undefined);
     if (logError) throw logError;
     if (earlyExit) {
       throw new Error(
@@ -517,6 +528,9 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
   } catch (error) {
     socketWait.cancel();
     child.off("error", onSpawnError);
+    child.off("exit", onEarlyExit);
+    spawnFailure.catch(() => undefined);
+    logFailure.catch(() => undefined);
     terminationPromise ??= terminateChild(child);
     await terminationPromise;
     log.end();
@@ -651,6 +665,8 @@ export function operationArgs(row, surface, workspace, worker, sample) {
   return { workspace, verbose: false };
 }
 
+const CMUX_JSON_PREFIX = Object.freeze(["--json", "--id-format", "both"]);
+
 export function cliArgs(row, config, worker, sample) {
   if (row.operation === "send_to") {
     return [
@@ -673,10 +689,62 @@ export function cliArgs(row, config, worker, sample) {
       "20",
     ];
   }
-  return ["tree", "--workspace", config.workspace];
+  return [...CMUX_JSON_PREFIX, "list-workspaces"];
+}
+
+export function listPanesCliArgs(workspace) {
+  return [...CMUX_JSON_PREFIX, "list-panes", "--workspace", workspace];
+}
+
+export function listPaneSurfacesCliArgs(workspace, pane) {
+  return [
+    ...CMUX_JSON_PREFIX,
+    "list-pane-surfaces",
+    "--workspace",
+    workspace,
+    "--pane",
+    pane,
+  ];
+}
+
+export function paneRefsFromListPanesStdout(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `cmux list-panes returned non-JSON: ${JSON.stringify(stdout.trim())}`,
+    );
+  }
+  const panes = isRecord(parsed) && Array.isArray(parsed.panes) ? parsed.panes : [];
+  return panes
+    .map((pane) => (isRecord(pane) ? nonEmptyString(pane.ref) : null))
+    .filter((ref) => ref !== null);
+}
+
+async function runCliListSurfaces(config) {
+  await execCapture(config.cmuxBin, cliArgs({ operation: "list_surfaces" }, config), {
+    env: config.env,
+  });
+  const panesOut = await execCapture(
+    config.cmuxBin,
+    listPanesCliArgs(config.workspace),
+    { env: config.env },
+  );
+  for (const pane of paneRefsFromListPanesStdout(panesOut.stdout)) {
+    await execCapture(
+      config.cmuxBin,
+      listPaneSurfacesCliArgs(config.workspace, pane),
+      { env: config.env },
+    );
+  }
 }
 
 async function runCliOperation(row, config, worker, sample) {
+  if (row.operation === "list_surfaces") {
+    await runCliListSurfaces(config);
+    return { ok: true, transport: "cli", transport_fallbacks: [] };
+  }
   const args = cliArgs(row, config, worker, sample);
   await execCapture(config.cmuxBin, args, { env: config.env });
   return { ok: true, transport: "cli", transport_fallbacks: [] };

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1,0 +1,780 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createWriteStream, existsSync } from "node:fs";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+const DEFAULT_CONCURRENCY = Object.freeze([1, 5, 10]);
+const DEFAULT_PAYLOAD_SIZES = Object.freeze([250, 450, 520, 900]);
+const DEFAULT_SAMPLES_PER_WORKER = 12;
+const REQUIRED_NIGHTLY_SOCKET = "/tmp/cmux-nightly.sock";
+
+function round(value, digits = 2) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter((entry) => typeof entry[1] === "string"),
+  );
+}
+
+function listArg(raw, fallback) {
+  if (!raw) return [...fallback];
+  return raw.split(",").map((value) => {
+    const parsed = Number(value.trim());
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(`expected comma-separated positive integers, got ${raw}`);
+    }
+    return parsed;
+  });
+}
+
+function namedArg(argv, name) {
+  const index = argv.indexOf(name);
+  if (index < 0) return null;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+export function nearestRankPercentile(samples, percentile) {
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new Error("percentile requires at least one sample");
+  }
+  if (!(percentile > 0 && percentile <= 100)) {
+    throw new Error(`percentile must be in (0, 100], got ${percentile}`);
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  const rank = Math.ceil((percentile / 100) * sorted.length);
+  return sorted[Math.max(0, rank - 1)];
+}
+
+export function buildBenchmarkRows({
+  concurrency = DEFAULT_CONCURRENCY,
+  payloadSizes = DEFAULT_PAYLOAD_SIZES,
+  samplesPerWorker = DEFAULT_SAMPLES_PER_WORKER,
+  operations = ["send_to", "read_screen", "list_surfaces"],
+  clients = ["mcp", "cli"],
+} = {}) {
+  if (!Number.isInteger(samplesPerWorker) || samplesPerWorker < 12) {
+    throw new Error(
+      `samplesPerWorker must be at least 12, got ${samplesPerWorker}`,
+    );
+  }
+  const allowedOperations = new Set(["send_to", "read_screen", "list_surfaces"]);
+  const allowedClients = new Set(["mcp", "cli"]);
+  for (const operation of operations) {
+    if (!allowedOperations.has(operation)) {
+      throw new Error(`unsupported operation ${operation}`);
+    }
+  }
+  for (const client of clients) {
+    if (!allowedClients.has(client)) {
+      throw new Error(`unsupported client ${client}`);
+    }
+  }
+
+  const rows = [];
+  for (const operation of operations) {
+    for (const workerCount of concurrency) {
+      const sizes = operation === "send_to" ? payloadSizes : [null];
+      for (const payloadChars of sizes) {
+        for (const client of clients) {
+          rows.push({
+            operation,
+            client,
+            concurrency: workerCount,
+            payload_chars: payloadChars,
+            samples_per_worker: samplesPerWorker,
+          });
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export function summarizeTransport(samples) {
+  const transportCounts = {};
+  const fallbackCounts = {};
+  for (const sample of samples) {
+    const transport = nonEmptyString(sample.transport) ?? "unknown";
+    transportCounts[transport] = (transportCounts[transport] ?? 0) + 1;
+    const fallbacks = Array.isArray(sample.transport_fallbacks)
+      ? sample.transport_fallbacks
+      : [];
+    for (const fallback of fallbacks) {
+      const source = nonEmptyString(fallback) ?? "unknown";
+      fallbackCounts[source] = (fallbackCounts[source] ?? 0) + 1;
+    }
+  }
+  return {
+    transport_counts: transportCounts,
+    transport_fallback_counts: fallbackCounts,
+  };
+}
+
+export function markSurfaceTransportUntrusted(row) {
+  if (row.operation !== "send_to" || row.client !== "mcp") return row;
+  const inferredTransport = row.payload_chars > 500 ? "cli" : "socket";
+  const samples = row.samples.map((sample) => ({
+    ...sample,
+    reported_transport: sample.transport,
+    reported_transport_fallbacks: [...(sample.transport_fallbacks ?? [])],
+    transport: "UNTRUSTED",
+    transport_fallbacks: ["UNTRUSTED_D180"],
+    transport_trust: "untrusted",
+    inferred_transport: inferredTransport,
+    transport_note:
+      "D180: raw-surface send_to outer provenance overwrites the inner paste_text transport context",
+  }));
+  return {
+    ...row,
+    reported_transport_counts: { ...row.transport_counts },
+    reported_transport_fallback_counts: {
+      ...row.transport_fallback_counts,
+    },
+    transport_counts: { UNTRUSTED: samples.length },
+    transport_fallback_counts: { UNTRUSTED_D180: samples.length },
+    transport_trust: "untrusted",
+    inferred_transport: inferredTransport,
+    inference_basis:
+      "known 500-character route boundary corroborated by the measured timing signature; inferred, not attested",
+    transport_note:
+      "D180: raw-surface send_to outer provenance overwrites the inner paste_text transport context",
+    samples,
+  };
+}
+
+export async function runBenchmarkRow(row, deps) {
+  const nowMs = deps.nowMs ?? (() => Number(process.hrtime.bigint()) / 1_000_000);
+  const workerRuns = Array.from({ length: row.concurrency }, (_, worker) =>
+    (async () => {
+      const samples = [];
+      for (let sample = 0; sample < row.samples_per_worker; sample += 1) {
+        const started = nowMs();
+        try {
+          const receipt = await deps.runOperation({ row, worker, sample });
+          samples.push({
+            worker,
+            sample,
+            latency_ms: round(nowMs() - started),
+            ok: receipt.ok === true,
+            transport: nonEmptyString(receipt.transport) ?? "unknown",
+            transport_fallbacks: Array.isArray(receipt.transport_fallbacks)
+              ? [...receipt.transport_fallbacks]
+              : [],
+            ...(receipt.error ? { error: String(receipt.error) } : {}),
+          });
+        } catch (error) {
+          samples.push({
+            worker,
+            sample,
+            latency_ms: round(nowMs() - started),
+            ok: false,
+            transport: "unknown",
+            transport_fallbacks: [],
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      return samples;
+    })(),
+  );
+  const samples = (await Promise.all(workerRuns)).flat();
+  const latencies = samples.map((sample) => sample.latency_ms);
+  return {
+    ...row,
+    concurrency_profile: `c${row.concurrency}`,
+    sample_count: samples.length,
+    p50_ms: round(nearestRankPercentile(latencies, 50)),
+    p95_ms: round(nearestRankPercentile(latencies, 95)),
+    error_count: samples.filter((sample) => !sample.ok).length,
+    ...summarizeTransport(samples),
+    samples,
+  };
+}
+
+export function assertNightlyIsolation(env) {
+  const cmuxSocketPath = nonEmptyString(env.CMUX_SOCKET_PATH);
+  if (cmuxSocketPath !== REQUIRED_NIGHTLY_SOCKET) {
+    throw new Error(
+      `refusing non-nightly cmux socket ${cmuxSocketPath ?? "(unset)"}; set CMUX_SOCKET_PATH=${REQUIRED_NIGHTLY_SOCKET}`,
+    );
+  }
+  const daemonSocketPath = nonEmptyString(env.CMUXLAYER_DAEMON_SOCKET);
+  if (
+    !daemonSocketPath ||
+    daemonSocketPath.endsWith("/cmuxlayer-stated.sock") ||
+    !/(nightly|run10)/i.test(daemonSocketPath)
+  ) {
+    throw new Error(
+      "refusing shared daemon socket; set CMUXLAYER_DAEMON_SOCKET to an isolated daemon path containing Nightly/Run10",
+    );
+  }
+  return { cmuxSocketPath, daemonSocketPath };
+}
+
+function resultPayload(result) {
+  if (isRecord(result.structuredContent)) return result.structuredContent;
+  const text = result.content?.find((item) => item.type === "text")?.text;
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return { text };
+  }
+}
+
+function mcpReceipt(result) {
+  const payload = resultPayload(result);
+  return {
+    ok: result.isError !== true && payload.ok !== false,
+    transport: nonEmptyString(payload.transport) ?? "unknown",
+    transport_fallbacks: Array.isArray(payload.transport_fallbacks)
+      ? payload.transport_fallbacks.filter((value) => typeof value === "string")
+      : [],
+    ...(result.isError === true || payload.ok === false
+      ? { error: nonEmptyString(payload.error) ?? "MCP tool returned an error" }
+      : {}),
+  };
+}
+
+function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} exited code=${code} signal=${signal}: ${stderr.trim()}`,
+          ),
+        );
+        return;
+      }
+      resolvePromise({ stdout, stderr });
+    });
+  });
+}
+
+function waitForSocket(path, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolvePromise, reject) => {
+    const attempt = () => {
+      const socket = net.createConnection({ path });
+      let settled = false;
+      const finish = (connected) => {
+        if (settled) return;
+        settled = true;
+        socket.removeAllListeners();
+        socket.on("error", () => {});
+        socket.destroy();
+        if (connected) {
+          resolvePromise();
+        } else if (Date.now() >= deadline) {
+          reject(new Error(`timed out waiting for socket ${path}`));
+        } else {
+          setTimeout(attempt, 50);
+        }
+      };
+      socket.setTimeout(250, () => finish(false));
+      socket.once("connect", () => finish(true));
+      socket.once("error", () => finish(false));
+    };
+    attempt();
+  });
+}
+
+export function openExclusiveWriteStream(path) {
+  return new Promise((resolvePromise, reject) => {
+    const stream = createWriteStream(path, { flags: "wx" });
+    const onOpen = () => {
+      stream.off("error", onError);
+      resolvePromise(stream);
+    };
+    const onError = (error) => {
+      stream.off("open", onOpen);
+      reject(error);
+    };
+    stream.once("open", onOpen);
+    stream.once("error", onError);
+  });
+}
+
+async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
+  if (existsSync(daemonSocketPath)) {
+    throw new Error(
+      `isolated daemon socket already exists; refusing to reap an unowned path: ${daemonSocketPath}`,
+    );
+  }
+  const log = await openExclusiveWriteStream(logPath);
+  const child = spawn(process.execPath, [entry], {
+    cwd: repoRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.pipe(log, { end: false });
+  child.stderr.pipe(log, { end: false });
+  let earlyExit = null;
+  let rejectSpawnFailure;
+  const spawnFailure = new Promise((_, reject) => {
+    rejectSpawnFailure = reject;
+  });
+  const onSpawnError = (error) => rejectSpawnFailure(error);
+  child.once("error", onSpawnError);
+  child.once("exit", (code, signal) => {
+    earlyExit = { code, signal };
+  });
+  try {
+    await Promise.race([waitForSocket(daemonSocketPath), spawnFailure]);
+    child.off("error", onSpawnError);
+    if (earlyExit) {
+      throw new Error(
+        `isolated daemon exited before readiness: ${JSON.stringify(earlyExit)}`,
+      );
+    }
+  } catch (error) {
+    child.off("error", onSpawnError);
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+    }
+    log.end();
+    await rm(daemonSocketPath, { force: true });
+    throw error;
+  }
+  return {
+    pid: child.pid,
+    async stop() {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+        await Promise.race([
+          new Promise((resolveExit) => child.once("exit", resolveExit)),
+          new Promise((resolveTimeout) => setTimeout(resolveTimeout, 5_000)),
+        ]);
+      }
+      log.end();
+      await rm(daemonSocketPath, { force: true });
+    },
+  };
+}
+
+export async function readGitHead(
+  execGit = () => execCapture("git", ["rev-parse", "HEAD"]),
+) {
+  try {
+    const { stdout } = await execGit();
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+async function connectMcpClient(entry, env, label) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: repoRoot,
+    env: stringEnv(env),
+    stderr: "inherit",
+  });
+  const client = new Client({ name: `cmuxlayer-bench-e2e-${label}`, version: "1" });
+  await client.connect(transport);
+  return client;
+}
+
+export function payloadText(size, worker, sample) {
+  const prefix = `: run10-e2e w${worker}s${sample} `;
+  if (prefix.length > size) return prefix.slice(0, size);
+  return prefix + "x".repeat(size - prefix.length);
+}
+
+function createdSurfaceFromOutput(stdout) {
+  const match = stdout.match(/\b(surface:\d+)\b/);
+  if (!match) {
+    throw new Error(
+      `cmux new-split returned no surface ref: ${JSON.stringify(stdout.trim())}`,
+    );
+  }
+  return match[1];
+}
+
+export async function createScratchTargets(count, deps) {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`scratch target count must be positive, got ${count}`);
+  }
+  const targets = [];
+  let anchor = deps.controllerSurface;
+  const closeRecorded = async () => {
+    const failures = [];
+    for (const surface of [...targets].reverse()) {
+      try {
+        await deps.execCmux([
+          "close-surface",
+          "--workspace",
+          deps.workspace,
+          "--surface",
+          surface,
+        ]);
+      } catch (error) {
+        failures.push(
+          `${surface}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(`scratch teardown failed: ${failures.join("; ")}`);
+    }
+  };
+  try {
+    for (let index = 0; index < count; index += 1) {
+      const { stdout } = await deps.execCmux([
+        "new-split",
+        "right",
+        "--workspace",
+        deps.workspace,
+        "--surface",
+        anchor,
+        "--focus",
+        "false",
+      ]);
+      const surface = createdSurfaceFromOutput(stdout);
+      targets.push(surface);
+      anchor = surface;
+    }
+  } catch (error) {
+    await closeRecorded().catch(() => {});
+    throw error;
+  }
+  return { targets: Object.freeze([...targets]), close: closeRecorded };
+}
+
+export function operationArgs(row, surface, workspace, worker, sample) {
+  if (row.operation === "send_to") {
+    return {
+      mode: "surface",
+      surface,
+      text: payloadText(row.payload_chars, worker, sample),
+      press_enter: true,
+      allow_long_inline: true,
+    };
+  }
+  if (row.operation === "read_screen") {
+    return { surface, lines: 20, parsed_only: true };
+  }
+  return { workspace, verbose: false };
+}
+
+async function runCliOperation(row, config, worker, sample) {
+  let args;
+  if (row.operation === "send_to") {
+    args = [
+      "send",
+      "--workspace",
+      config.workspace,
+      "--surface",
+      config.surface,
+      `${payloadText(row.payload_chars, worker, sample)}\\n`,
+    ];
+  } else if (row.operation === "read_screen") {
+    args = [
+      "read-screen",
+      "--workspace",
+      config.workspace,
+      "--surface",
+      config.surface,
+      "--lines",
+      "20",
+    ];
+  } else {
+    args = ["tree", "--workspace", config.workspace];
+  }
+  await execCapture(config.cmuxBin, args, { env: config.env });
+  return { ok: true, transport: "cli", transport_fallbacks: [] };
+}
+
+function compactCounts(counts) {
+  const entries = Object.entries(counts);
+  return entries.length === 0
+    ? "none"
+    : entries.map(([name, count]) => `${name}:${count}`).join(",");
+}
+
+export function renderMarkdownTable(rows) {
+  const lines = [
+    "| operation | profile | payload | client | n | p50 ms | p95 ms | errors | transport | fallbacks |",
+    "|---|---:|---:|---|---:|---:|---:|---:|---|---|",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.operation} | ${row.concurrency_profile} | ${row.payload_chars ?? "-"} | ${row.client} | ${row.sample_count} | ${row.p50_ms} | ${row.p95_ms} | ${row.error_count} | ${compactCounts(row.transport_counts)} | ${compactCounts(row.transport_fallback_counts)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function parseConfig(argv, env) {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true };
+  const samplesPerWorker = Number(
+    namedArg(argv, "--samples-per-worker") ?? DEFAULT_SAMPLES_PER_WORKER,
+  );
+  const operations = (
+    namedArg(argv, "--operations") ?? "send_to,read_screen,list_surfaces"
+  ).split(",");
+  const clients = (namedArg(argv, "--clients") ?? "mcp,cli").split(",");
+  const out = resolve(
+    namedArg(argv, "--out") ??
+      join(repoRoot, "docs.local", "scratch", "run10-phase1", "bench-e2e.json"),
+  );
+  return {
+    help: false,
+    samplesPerWorker,
+    concurrency: listArg(namedArg(argv, "--concurrency"), DEFAULT_CONCURRENCY),
+    payloadSizes: listArg(namedArg(argv, "--payload-sizes"), DEFAULT_PAYLOAD_SIZES),
+    operations,
+    clients,
+    out,
+    surface: namedArg(argv, "--surface") ?? nonEmptyString(env.CMUX_SURFACE_ID),
+    workspace: namedArg(argv, "--workspace") ?? nonEmptyString(env.CMUX_WORKSPACE_ID),
+    cmuxBin: namedArg(argv, "--cmux-bin") ?? "cmux",
+    mcpEntry: resolve(namedArg(argv, "--mcp-entry") ?? join(repoRoot, "dist", "index.js")),
+    daemonEntry: resolve(
+      namedArg(argv, "--daemon-entry") ?? join(repoRoot, "dist", "daemon.js"),
+    ),
+  };
+}
+
+const HELP = `bench-e2e.mjs — isolated agent-side MCP vs direct cmux CLI benchmark
+
+Required environment:
+  CMUX_SOCKET_PATH=/tmp/cmux-nightly.sock
+  CMUXLAYER_DAEMON_SOCKET=<isolated path containing nightly or run10>
+
+Options:
+  --surface <surface:ref>        default: CMUX_SURFACE_ID
+  --workspace <workspace:ref>    default: CMUX_WORKSPACE_ID
+  --samples-per-worker <n>       minimum/default: 12
+  --concurrency <csv>            default: 1,5,10
+  --payload-sizes <csv>          default: 250,450,520,900
+  --operations <csv>             default: send_to,read_screen,list_surfaces
+  --clients <csv>                default: mcp,cli
+  --out <path>                   JSON receipt path
+`;
+
+async function main() {
+  const config = parseConfig(process.argv.slice(2), process.env);
+  if (config.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const isolation = assertNightlyIsolation(process.env);
+  if (!config.surface || !config.workspace) {
+    throw new Error(
+      "surface and workspace are required; run inside the Nightly terminal or pass --surface/--workspace",
+    );
+  }
+  for (const path of [config.mcpEntry, config.daemonEntry]) {
+    if (!existsSync(path)) throw new Error(`built entry does not exist: ${path}`);
+  }
+  const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);
+  if (!nightlySocket?.isSocket()) {
+    throw new Error(`nightly socket is not live: ${isolation.cmuxSocketPath}`);
+  }
+  await mkdir(dirname(config.out), { recursive: true });
+  const logPath = `${config.out}.daemon.log`;
+  const env = stringEnv({
+    ...process.env,
+    CMUX_SOCKET_PATH: isolation.cmuxSocketPath,
+    CMUXLAYER_DAEMON_SOCKET: isolation.daemonSocketPath,
+    CMUXLAYER_DEV: "1",
+  });
+  const rows = buildBenchmarkRows({
+    concurrency: config.concurrency,
+    payloadSizes: config.payloadSizes,
+    samplesPerWorker: config.samplesPerWorker,
+    operations: config.operations,
+    clients: config.clients,
+  });
+  const startedAt = new Date().toISOString();
+  const daemon = await startIsolatedDaemon(
+    config.daemonEntry,
+    env,
+    isolation.daemonSocketPath,
+    logPath,
+  );
+  const mcpClients = [];
+  const results = [];
+  let fixture = null;
+  let fatalError = null;
+  try {
+    const maxConcurrency = Math.max(1, ...rows.map((row) => row.concurrency));
+    fixture = await createScratchTargets(maxConcurrency, {
+      workspace: config.workspace,
+      controllerSurface: config.surface,
+      execCmux: (args) => execCapture(config.cmuxBin, args, { env }),
+    });
+    const maxMcpConcurrency = Math.max(
+      0,
+      ...rows.filter((row) => row.client === "mcp").map((row) => row.concurrency),
+    );
+    for (let index = 0; index < maxMcpConcurrency; index += 1) {
+      mcpClients.push(await connectMcpClient(config.mcpEntry, env, index));
+    }
+    await Promise.all(
+      mcpClients.map((client) =>
+        client.callTool(
+          { name: "list_surfaces", arguments: { workspace: config.workspace } },
+          undefined,
+          { timeout: 30_000 },
+        ),
+      ),
+    );
+    for (const [index, row] of rows.entries()) {
+      process.stderr.write(
+        `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client}\n`,
+      );
+      const measured = await runBenchmarkRow(row, {
+        runOperation: async ({ worker, sample }) => {
+          if (row.client === "cli") {
+            return runCliOperation(
+              row,
+              {
+                cmuxBin: config.cmuxBin,
+                env,
+                surface: fixture.targets[worker],
+                workspace: config.workspace,
+              },
+              worker,
+              sample,
+            );
+          }
+          const toolResult = await mcpClients[worker].callTool(
+            {
+              name: row.operation,
+              arguments: operationArgs(
+                row,
+                fixture.targets[worker],
+                config.workspace,
+                worker,
+                sample,
+              ),
+            },
+            undefined,
+            { timeout: 30_000 },
+          );
+          return mcpReceipt(toolResult);
+        },
+      });
+      const result = markSurfaceTransportUntrusted(measured);
+      results.push(result);
+    }
+  } catch (error) {
+    fatalError = error instanceof Error ? error.message : String(error);
+  } finally {
+    await Promise.allSettled(mcpClients.map((client) => client.close()));
+    if (fixture) {
+      try {
+        await fixture.close();
+      } catch (error) {
+        fatalError ??= error instanceof Error ? error.message : String(error);
+      }
+    }
+    await daemon.stop();
+  }
+
+  const receipt = {
+    schema_version: 1,
+    kind: "cmuxlayer-agent-side-e2e-benchmark",
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    git_head: await readGitHead(() =>
+      execCapture("git", ["rev-parse", "HEAD"], { env }),
+    ),
+    environment: {
+      cmux_socket_path: isolation.cmuxSocketPath,
+      daemon_socket_path: isolation.daemonSocketPath,
+      isolated_daemon_pid: daemon.pid,
+      daemon_log: logPath,
+      controller_surface: config.surface,
+      scratch_surfaces: fixture?.targets ?? [],
+      workspace: config.workspace,
+      load_model: "none (synthetic MCP/CLI clients; no LLM seats launched)",
+      estimated_model_cost_usd: 0,
+    },
+    row_schema: {
+      identity: ["operation", "client", "concurrency_profile", "payload_chars"],
+      aggregate: ["sample_count", "p50_ms", "p95_ms", "error_count"],
+      transport: ["transport_counts", "transport_fallback_counts"],
+      raw_sample: [
+        "worker",
+        "sample",
+        "latency_ms",
+        "ok",
+        "transport",
+        "transport_fallbacks",
+        "error?",
+      ],
+    },
+    rows: results,
+    fatal_error: fatalError,
+  };
+  await writeFile(config.out, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  process.stdout.write(`${renderMarkdownTable(results)}\n`);
+  process.stdout.write(`[bench-e2e] receipt ${config.out}\n`);
+  if (fatalError || results.some((row) => row.error_count > 0)) {
+    process.exitCode = 1;
+  }
+}
+
+if (resolve(process.argv[1] ?? "") === scriptPath) {
+  main().catch((error) => {
+    process.stderr.write(
+      `[bench-e2e] fatal ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -315,31 +315,51 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
 
 export async function terminateChild(child, graceMs = 5_000) {
   if (child.exitCode !== null || child.signalCode !== null) return;
-  const exitPromise = new Promise((resolveExit) => {
-    const onExit = () => {
-      child.off("exit", onExit);
-      child.off("close", onExit);
-      resolveExit();
-    };
-    child.once("exit", onExit);
-    child.once("close", onExit);
+  const isLive = () => child.exitCode === null && child.signalCode === null;
+  let resolveFailure = () => undefined;
+  const failurePromise = new Promise((resolveFailurePromise) => {
+    resolveFailure = resolveFailurePromise;
   });
-  child.kill("SIGTERM");
-  let timer = null;
-  const exitedGracefully = await Promise.race([
-    exitPromise.then(() => true),
-    new Promise((resolveTimeout) => {
-      timer = setTimeout(() => resolveTimeout(false), graceMs);
-    }),
-  ]);
-  clearTimeout(timer);
-  if (
-    !exitedGracefully &&
-    child.exitCode === null &&
-    child.signalCode === null
-  ) {
-    child.kill("SIGKILL");
-    await exitPromise;
+  const onError = (error) => resolveFailure({ kind: "error", error });
+  child.on("error", onError);
+  let resolveExit = () => undefined;
+  const exitPromise = new Promise((resolveExitPromise) => {
+    resolveExit = resolveExitPromise;
+  });
+  const onExit = () => resolveExit({ kind: "exit" });
+  child.once("exit", onExit);
+  child.once("close", onExit);
+  const waitBounded = async () => {
+    let timer = null;
+    const outcome = await Promise.race([
+      exitPromise,
+      failurePromise,
+      new Promise((resolveTimeout) => {
+        timer = setTimeout(() => resolveTimeout({ kind: "timeout" }), graceMs);
+      }),
+    ]);
+    clearTimeout(timer);
+    if (outcome.kind === "error") throw outcome.error;
+    return outcome.kind === "exit";
+  };
+  const deliver = (signal) => {
+    const delivered = child.kill(signal);
+    if (!delivered && isLive()) {
+      throw new Error(`failed to deliver ${signal} to child`);
+    }
+  };
+  try {
+    deliver("SIGTERM");
+    if (await waitBounded()) return;
+    if (!isLive()) return;
+    deliver("SIGKILL");
+    if (!(await waitBounded()) && isLive()) {
+      throw new Error("child did not exit after SIGKILL within the bounded wait");
+    }
+  } finally {
+    child.off("error", onError);
+    child.off("exit", onExit);
+    child.off("close", onExit);
   }
 }
 
@@ -439,6 +459,10 @@ export async function createSocketReservation(requestedPath) {
       await rm(ownerDirectory, { recursive: true, force: true });
     },
   };
+}
+
+export function daemonLogPath(receiptPath, pid = process.pid, now = Date.now()) {
+  return `${receiptPath}.daemon-${pid}-${now}.log`;
 }
 
 async function startIsolatedDaemon(entry, env, reservation, logPath) {
@@ -746,7 +770,7 @@ async function main() {
     throw new Error(`nightly socket is not live: ${isolation.cmuxSocketPath}`);
   }
   await mkdir(dirname(config.out), { recursive: true });
-  const logPath = `${config.out}.daemon.log`;
+  const logPath = daemonLogPath(config.out);
   const socketReservation = await createSocketReservation(
     isolation.daemonSocketPath,
   );

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -7,12 +7,13 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
 import net from "node:net";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -621,7 +622,11 @@ export async function createSocketReservation(requestedPath) {
 }
 
 export async function createOutputReservation(outputPath) {
-  const canonicalOutput = resolve(outputPath);
+  const absoluteOutput = resolve(outputPath);
+  await mkdir(dirname(absoluteOutput), { recursive: true });
+  const canonicalOutput = existsSync(absoluteOutput)
+    ? await realpath(absoluteOutput)
+    : join(await realpath(dirname(absoluteOutput)), basename(absoluteOutput));
   const lockPath = `${canonicalOutput}.lock`;
   const reservation = await createPidLock(
     lockPath,
@@ -880,6 +885,10 @@ export async function terminateUnexpectedDaemons(
         await pause(25);
       }
       if (processIsLive(pid, signalPid)) {
+        if (!(await verifyPid(pid, ownerToken))) {
+          // The owned daemon exited after TERM and the PID was reused.
+          continue;
+        }
         signalPid(pid, "SIGKILL");
         for (let attempt = 0; attempt < 20; attempt += 1) {
           if (!processIsLive(pid, signalPid)) break;
@@ -1107,6 +1116,7 @@ export async function createScratchTargets(count, deps) {
   };
   try {
     for (let index = 0; index < count; index += 1) {
+      deps.signal?.throwIfAborted();
       const { stdout } = await deps.execCmux([
         "new-split",
         "right",
@@ -1120,6 +1130,7 @@ export async function createScratchTargets(count, deps) {
       const surface = createdSurfaceFromOutput(stdout);
       targets.push(surface);
       anchor = surface;
+      deps.signal?.throwIfAborted();
     }
   } catch (error) {
     try {
@@ -1500,6 +1511,20 @@ async function sha256File(path) {
     .digest("hex");
 }
 
+export async function assertArtifactProvenance(
+  provenance,
+  hashFile = sha256File,
+) {
+  for (const entry of Object.values(provenance.entries)) {
+    const observed = await hashFile(entry.path);
+    if (observed !== entry.sha256) {
+      throw new Error(
+        `artifact changed after attestation: ${entry.path} expected ${entry.sha256}, observed ${observed}`,
+      );
+    }
+  }
+}
+
 export async function prepareBuiltEntries(config, deps = {}) {
   const root = deps.repoRoot ?? repoRoot;
   const exec = deps.exec ?? execCapture;
@@ -1639,6 +1664,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
     ...config,
     env: process.env,
   });
+  await assertArtifactProvenance(artifactProvenance);
   abortSignal.throwIfAborted();
   const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);
   if (!nightlySocket?.isSocket()) {
@@ -1673,12 +1699,15 @@ async function executeBenchmark(config, isolation, abortSignal) {
   let fixture = null;
   let fatalError = null;
   try {
+    await assertArtifactProvenance(artifactProvenance);
     abortSignal.throwIfAborted();
     const maxConcurrency = Math.max(1, ...rows.map((row) => row.concurrency));
     fixture = await createScratchTargets(maxConcurrency, {
       workspace: config.workspace,
       controllerSurface: config.surface,
-      execCmux: (args) => execCapture(config.cmuxBin, args, { env }),
+      signal: abortSignal,
+      execCmux: (args) =>
+        execCapture(config.cmuxBin, args, { env, signal: abortSignal }),
     });
     const maxMcpConcurrency = Math.max(
       0,
@@ -1690,6 +1719,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
       abortSignal.throwIfAborted();
       await daemon.assertHealthy();
       mcpClients.push(await connectMcpClient(config.mcpEntry, env, index));
+      await assertArtifactProvenance(artifactProvenance);
       await daemon.assertHealthy();
       abortSignal.throwIfAborted();
     }
@@ -1780,6 +1810,11 @@ async function executeBenchmark(config, isolation, abortSignal) {
     } catch (error) {
       fatalError = appendFatalError(fatalError, error, "daemon stop");
     }
+  }
+  try {
+    await assertArtifactProvenance(artifactProvenance);
+  } catch (error) {
+    fatalError = appendFatalError(fatalError, error, "artifact revalidation");
   }
 
   const receipt = {

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -4,12 +4,14 @@ import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
 import {
+  link,
   mkdir,
   mkdtemp,
   readFile,
   realpath,
   rm,
   stat,
+  unlink,
   writeFile,
 } from "node:fs/promises";
 import net from "node:net";
@@ -649,33 +651,78 @@ function processIsLive(pid, signalPid = process.kill) {
   }
 }
 
+async function readProcessStartIdentity(pid) {
+  const result = await execCapture(
+    "/bin/ps",
+    ["-p", String(pid), "-o", "lstart="],
+    { env: process.env },
+  ).catch(() => null);
+  return nonEmptyString(result?.stdout.trim());
+}
+
+function parseLockOwner(text) {
+  try {
+    const parsed = JSON.parse(text);
+    if (
+      isRecord(parsed) &&
+      Number.isSafeInteger(parsed.pid) &&
+      parsed.pid > 0
+    ) {
+      return {
+        pid: parsed.pid,
+        process_start: nonEmptyString(parsed.process_start),
+      };
+    }
+  } catch {
+    const legacyPid = Number.parseInt(text.trim(), 10);
+    if (Number.isSafeInteger(legacyPid) && legacyPid > 0) {
+      return { pid: legacyPid, process_start: null };
+    }
+  }
+  return null;
+}
+
 async function createPidLock(lockPath, label) {
   await mkdir(dirname(lockPath), { recursive: true });
+  const processStart = await readProcessStartIdentity(process.pid);
+  if (!processStart) {
+    throw new Error(`${label} could not attest process start identity`);
+  }
+  const ownerText = `${JSON.stringify({ pid: process.pid, process_start: processStart })}\n`;
+  const candidatePath = `${lockPath}.claim-${process.pid}-${randomUUID()}`;
+  await writeFile(candidatePath, ownerText, { flag: "wx", mode: 0o600 });
   let acquired = false;
-  for (let attempt = 0; attempt < 2 && !acquired; attempt += 1) {
-    acquired = await execCapture(
-      "/usr/bin/shlock",
-      ["-p", String(process.pid), "-f", lockPath],
-      { env: process.env },
-    ).then(
-      () => true,
-      () => false,
-    );
-    if (acquired) break;
-    const ownerText = await readFile(lockPath, "utf8").catch(() => "");
-    const ownerPid = Number.parseInt(ownerText.trim(), 10);
-    if (
-      Number.isSafeInteger(ownerPid) &&
-      ownerPid > 0 &&
-      processIsLive(ownerPid)
-    ) {
-      throw new Error(`${label} is already reserved by pid ${ownerPid}`);
+  try {
+    for (let attempt = 0; attempt < 3 && !acquired; attempt += 1) {
+      try {
+        await link(candidatePath, lockPath);
+        acquired = true;
+        break;
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+      }
+      const observedText = await readFile(lockPath, "utf8").catch((error) => {
+        if (error?.code === "ENOENT") return null;
+        throw error;
+      });
+      if (observedText === null) continue;
+      const owner = parseLockOwner(observedText);
+      if (owner && processIsLive(owner.pid)) {
+        const observedStart = await readProcessStartIdentity(owner.pid);
+        if (!owner.process_start || observedStart === owner.process_start) {
+          throw new Error(`${label} is already reserved by pid ${owner.pid}`);
+        }
+      }
+      // Re-read before unlinking so a contender that replaced the stale owner
+      // is never removed based on an earlier observation.
+      const currentText = await readFile(lockPath, "utf8").catch(() => null);
+      if (currentText !== observedText) continue;
+      await unlink(lockPath).catch((error) => {
+        if (error?.code !== "ENOENT") throw error;
+      });
     }
-    if (attempt === 0) {
-      // shlock deliberately refuses to reap a lock whose timestamp changed in
-      // the current second. Retry after that atomic-safety window expires.
-      await new Promise((resolvePause) => setTimeout(resolvePause, 1_100));
-    }
+  } finally {
+    await unlink(candidatePath).catch(() => undefined);
   }
   if (!acquired) {
     throw new Error(`${label} could not reclaim atomic lock ${lockPath}`);
@@ -685,8 +732,8 @@ async function createPidLock(lockPath, label) {
     lockPath,
     async release() {
       if (released) return;
-      const ownerText = await readFile(lockPath, "utf8");
-      if (Number.parseInt(ownerText.trim(), 10) !== process.pid) {
+      const currentText = await readFile(lockPath, "utf8");
+      if (currentText !== ownerText) {
         throw new Error(`${label} ownership changed before release`);
       }
       released = true;

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
-  open,
   readFile,
   rm,
   stat,
@@ -252,9 +251,11 @@ export async function runBenchmarkRow(row, deps) {
     (async () => {
       const samples = [];
       for (let sample = 0; sample < row.samples_per_worker; sample += 1) {
+        deps.signal?.throwIfAborted();
         const started = nowMs();
         try {
           const receipt = await deps.runOperation({ row, worker, sample });
+          deps.signal?.throwIfAborted();
           samples.push({
             worker,
             sample,
@@ -267,6 +268,7 @@ export async function runBenchmarkRow(row, deps) {
             ...(receipt.error ? { error: String(receipt.error) } : {}),
           });
         } catch (error) {
+          if (deps.signal?.aborted) throw deps.signal.reason;
           samples.push({
             worker,
             sample,
@@ -369,7 +371,12 @@ function mcpReceipt(result) {
   };
 }
 
-function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
+function execCapture(
+  command,
+  args,
+  { env, timeoutMs = 30_000, signal = null } = {},
+) {
+  if (signal?.aborted) return Promise.reject(signal.reason);
   return new Promise((resolvePromise, reject) => {
     const child = spawn(command, args, {
       cwd: repoRoot,
@@ -385,24 +392,30 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       fn(value);
     };
-    timer = setTimeout(() => {
+    const cancel = (reason) => {
       timedOut = true;
-      const timeoutError = new Error(
-        `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
-      );
       terminateChild(child).then(
-        () => settle(reject, timeoutError),
+        () => settle(reject, reason),
         (terminationError) =>
           settle(
             reject,
             new AggregateError(
-              [timeoutError, terminationError],
-              "command timed out and child termination failed",
+              [reason, terminationError],
+              "command cancellation and child termination failed",
             ),
           ),
       );
+    };
+    const onAbort = () => cancel(signal.reason);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    timer = setTimeout(() => {
+      const timeoutError = new Error(
+        `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+      );
+      cancel(timeoutError);
     }, timeoutMs);
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString("utf8");
@@ -629,50 +642,53 @@ function processIsLive(pid, signalPid = process.kill) {
   }
 }
 
-async function createPidLock(lockPath, label, signalPid = process.kill) {
+async function createPidLock(lockPath, label) {
   await mkdir(dirname(lockPath), { recursive: true });
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const opened = await open(lockPath, "wx", 0o600).then(
-      (handle) => ({ handle, error: null }),
-      (error) => ({ handle: null, error }),
+  let acquired = false;
+  for (let attempt = 0; attempt < 2 && !acquired; attempt += 1) {
+    acquired = await execCapture(
+      "/usr/bin/shlock",
+      ["-p", String(process.pid), "-f", lockPath],
+      { env: process.env },
+    ).then(
+      () => true,
+      () => false,
     );
-    if (opened.error) {
-      const error = opened.error;
-      if (error?.code !== "EEXIST") throw error;
-      const ownerText = await readFile(lockPath, "utf8").catch(() => "");
-      const ownerPid = Number.parseInt(ownerText.trim(), 10);
-      if (!Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
-        throw new Error(`${label} has an unreadable owner lock: ${lockPath}`);
-      }
-      if (processIsLive(ownerPid, signalPid)) {
-        throw new Error(`${label} is already reserved by pid ${ownerPid}`);
-      }
-      await rm(lockPath, { force: true });
-      continue;
+    if (acquired) break;
+    const ownerText = await readFile(lockPath, "utf8").catch(() => "");
+    const ownerPid = Number.parseInt(ownerText.trim(), 10);
+    if (
+      Number.isSafeInteger(ownerPid) &&
+      ownerPid > 0 &&
+      processIsLive(ownerPid)
+    ) {
+      throw new Error(`${label} is already reserved by pid ${ownerPid}`);
     }
-    const handle = opened.handle;
-    try {
-      await handle.writeFile(`${process.pid}\n`, "utf8");
-    } catch (error) {
-      await handle.close().catch(() => undefined);
-      await rm(lockPath, { force: true }).catch(() => undefined);
-      throw error;
+    if (attempt === 0) {
+      // shlock deliberately refuses to reap a lock whose timestamp changed in
+      // the current second. Retry after that atomic-safety window expires.
+      await new Promise((resolvePause) => setTimeout(resolvePause, 1_100));
     }
-    let released = false;
-    return {
-      lockPath,
-      async release() {
-        if (released) return;
-        released = true;
-        await handle.close();
-        await rm(lockPath, { force: false });
-      },
-    };
   }
-  throw new Error(`${label} lock reclamation raced with another run`);
+  if (!acquired) {
+    throw new Error(`${label} could not reclaim atomic lock ${lockPath}`);
+  }
+  let released = false;
+  return {
+    lockPath,
+    async release() {
+      if (released) return;
+      const ownerText = await readFile(lockPath, "utf8");
+      if (Number.parseInt(ownerText.trim(), 10) !== process.pid) {
+        throw new Error(`${label} ownership changed before release`);
+      }
+      released = true;
+      await rm(lockPath, { force: false });
+    },
+  };
 }
 
-export async function createWorkspaceReservation(
+export function createWorkspaceReservation(
   cmuxSocketPath,
   workspace,
   lockRoot = "/tmp",
@@ -767,6 +783,7 @@ export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
     CMUXLAYER_SEAT_REGISTRY_PATH: join(root, "seat-registry.json"),
     CMUXLAYER_LAUNCHER_REGISTRY_PATH: join(root, "launcher-registry.json"),
     CMUXLAYER_DAEMON_PID_RECEIPT: join(root, "unexpected-daemon-pids.txt"),
+    CMUXLAYER_BENCH_OWNER_TOKEN: randomUUID(),
     CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH: join(root, "fleet-sidebar.swift"),
     CMUXLAYER_HARNESS_HOME: join(root, "harness"),
     CMUXLAYER_DEV: "1",
@@ -826,8 +843,22 @@ export async function assertNoUnexpectedDaemons(path, ownedPid) {
 export async function terminateUnexpectedDaemons(
   path,
   ownedPid,
-  signalPid = process.kill,
-  pause = (ms) => new Promise((resolvePause) => setTimeout(resolvePause, ms)),
+  ownerToken,
+  {
+    signalPid = process.kill,
+    pause = (ms) =>
+      new Promise((resolvePause) => setTimeout(resolvePause, ms)),
+    verifyPid = async (pid, token) => {
+      const result = await execCapture(
+        "/bin/ps",
+        ["eww", "-p", String(pid), "-o", "command="],
+        { env: process.env },
+      ).catch(() => null);
+      return result?.stdout.includes(
+        `CMUXLAYER_BENCH_OWNER_TOKEN=${token}`,
+      );
+    },
+  } = {},
 ) {
   const unexpected = (await readRecordedDaemonPids(path)).filter(
     (pid) => pid !== ownedPid,
@@ -836,12 +867,23 @@ export async function terminateUnexpectedDaemons(
   for (const pid of unexpected) {
     try {
       if (!processIsLive(pid, signalPid)) continue;
+      if (!(await verifyPid(pid, ownerToken))) {
+        throw new Error(
+          `refusing to signal unowned or PID-reused process ${pid}`,
+        );
+      }
       signalPid(pid, "SIGTERM");
       for (let attempt = 0; attempt < 20; attempt += 1) {
         if (!processIsLive(pid, signalPid)) break;
         await pause(25);
       }
-      if (processIsLive(pid, signalPid)) signalPid(pid, "SIGKILL");
+      if (processIsLive(pid, signalPid)) {
+        signalPid(pid, "SIGKILL");
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          if (!processIsLive(pid, signalPid)) break;
+          await pause(25);
+        }
+      }
       if (processIsLive(pid, signalPid)) {
         throw new Error(`unowned daemon pid ${pid} survived SIGKILL`);
       }
@@ -867,6 +909,7 @@ export function appendSettledFailures(current, results, phase) {
 async function startIsolatedDaemon(entry, env, reservation, logPath) {
   const daemonSocketPath = reservation.socketPath;
   const daemonPidReceipt = env.CMUXLAYER_DAEMON_PID_RECEIPT;
+  const daemonOwnerToken = env.CMUXLAYER_BENCH_OWNER_TOKEN;
   let child = null;
   let logError = null;
   let terminationPromise = null;
@@ -959,7 +1002,11 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
       let cleanupError = null;
       let unexpectedDaemonError = null;
       try {
-        await terminateUnexpectedDaemons(daemonPidReceipt, child.pid);
+        await terminateUnexpectedDaemons(
+          daemonPidReceipt,
+          child.pid,
+          daemonOwnerToken,
+        );
       } catch (error) {
         unexpectedDaemonError = error;
       }
@@ -1173,6 +1220,7 @@ async function enumerateCliWorkspaces(config, exec = execCapture) {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const windowsOut = await exec(config.cmuxBin, listWindowsCliArgs(), {
       env: config.env,
+      signal: config.signal,
     });
     const parsedWindows = parseCliJson(windowsOut.stdout, "list-windows");
     const windows = Array.isArray(parsedWindows)
@@ -1194,7 +1242,7 @@ async function enumerateCliWorkspaces(config, exec = execCapture) {
         const output = await exec(
           config.cmuxBin,
           listWorkspacesCliArgs(target),
-          { env: config.env },
+          { env: config.env, signal: config.signal },
         );
         const parsed = parseCliJson(output.stdout, "list-workspaces");
         if (!isRecord(parsed) || !Array.isArray(parsed.workspaces)) {
@@ -1247,7 +1295,7 @@ async function runCliTopology(
         const panesOut = await exec(
           config.cmuxBin,
           listPanesCliArgs(workspace),
-          { env: config.env },
+          { env: config.env, signal: config.signal },
         );
         return paneRefsFromListPanesStdout(panesOut.stdout);
       } catch (error) {
@@ -1260,6 +1308,7 @@ async function runCliTopology(
       const work = panes.map((pane) =>
         exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
           env: config.env,
+          signal: config.signal,
         }),
       );
       if (bestEffort) await Promise.allSettled(work);
@@ -1269,6 +1318,7 @@ async function runCliTopology(
         try {
           await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
             env: config.env,
+            signal: config.signal,
           });
         } catch (error) {
           if (!bestEffort) throw error;
@@ -1306,7 +1356,7 @@ export async function runCliReadScreen(
   await exec(
     config.cmuxBin,
     cliArgs({ operation: "read_screen" }, config, worker, sample),
-    { env: config.env },
+    { env: config.env, signal: config.signal },
   );
   observedWork.push("read-screen:raw-surface");
   let workspaces = [];
@@ -1336,7 +1386,10 @@ async function runCliOperation(row, config, worker, sample) {
     throw new Error(FAIRNESS_CONTRACTS.send_to.reason);
   }
   const args = cliArgs(row, config, worker, sample);
-  await execCapture(config.cmuxBin, args, { env: config.env });
+  await execCapture(config.cmuxBin, args, {
+    env: config.env,
+    signal: config.signal,
+  });
   return { ok: true, transport: "cli", transport_fallbacks: [] };
 }
 
@@ -1613,7 +1666,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
         client.callTool(
           { name: "list_surfaces", arguments: { workspace: config.workspace } },
           undefined,
-          { timeout: 30_000 },
+          { timeout: 30_000, signal: abortSignal },
         ),
       ),
     );
@@ -1633,6 +1686,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
         `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client}\n`,
       );
       const measured = await runBenchmarkRow(row, {
+        signal: abortSignal,
         runOperation: async ({ worker, sample }) => {
           if (row.client === "cli") {
             return runCliOperation(
@@ -1640,6 +1694,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
               {
                 cmuxBin: config.cmuxBin,
                 env,
+                signal: abortSignal,
                 surface: fixture.targets[worker],
                 workspace: config.workspace,
               },
@@ -1659,7 +1714,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
               ),
             },
             undefined,
-            { timeout: 30_000 },
+            { timeout: 30_000, signal: abortSignal },
           );
           return mcpReceipt(toolResult);
         },

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -269,13 +269,16 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
     });
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
     const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(
-        new Error(
-          `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
-        ),
-      );
+      timedOut = true;
+      void terminateChild(child).finally(() => {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+          ),
+        );
+      });
     }, timeoutMs);
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString("utf8");
@@ -289,6 +292,7 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
     });
     child.once("close", (code, signal) => {
       clearTimeout(timer);
+      if (timedOut) return;
       if (code !== 0) {
         reject(
           new Error(
@@ -302,47 +306,111 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
   });
 }
 
-function waitForSocket(path, timeoutMs = 15_000) {
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolvePromise, reject) => {
-    const attempt = () => {
-      const socket = net.createConnection({ path });
-      let settled = false;
-      const finish = (connected) => {
-        if (settled) return;
-        settled = true;
-        socket.removeAllListeners();
-        socket.on("error", () => {});
-        socket.destroy();
-        if (connected) {
-          resolvePromise();
-        } else if (Date.now() >= deadline) {
-          reject(new Error(`timed out waiting for socket ${path}`));
-        } else {
-          setTimeout(attempt, 50);
-        }
-      };
-      socket.setTimeout(250, () => finish(false));
-      socket.once("connect", () => finish(true));
-      socket.once("error", () => finish(false));
+export async function terminateChild(child, graceMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exitPromise = new Promise((resolveExit) => {
+    const onExit = () => {
+      child.off("exit", onExit);
+      child.off("close", onExit);
+      resolveExit();
     };
-    attempt();
+    child.once("exit", onExit);
+    child.once("close", onExit);
   });
+  child.kill("SIGTERM");
+  let timer;
+  const exitedGracefully = await Promise.race([
+    exitPromise.then(() => true),
+    new Promise((resolveTimeout) => {
+      timer = setTimeout(() => resolveTimeout(false), graceMs);
+    }),
+  ]);
+  clearTimeout(timer);
+  if (
+    !exitedGracefully &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    child.kill("SIGKILL");
+    await exitPromise;
+  }
 }
 
-export function openExclusiveWriteStream(path) {
+export function waitForSocket(path, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  let activeSocket = null;
+  let retryTimer = null;
+  let settled = false;
+  let resolveWait;
+  let rejectWait;
+  const promise = new Promise((resolvePromise, reject) => {
+    resolveWait = resolvePromise;
+    rejectWait = reject;
+  });
+  const settle = (error = null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(retryTimer);
+    if (activeSocket) {
+      activeSocket.removeAllListeners();
+      activeSocket.on("error", () => undefined);
+      activeSocket.destroy();
+      activeSocket = null;
+    }
+    if (error) rejectWait(error);
+    else resolveWait();
+  };
+  const attempt = () => {
+    if (settled) return;
+    const socket = net.createConnection({ path });
+    activeSocket = socket;
+    let attemptSettled = false;
+    const finish = (connected) => {
+      if (attemptSettled) return;
+      attemptSettled = true;
+      socket.removeAllListeners();
+      socket.on("error", () => undefined);
+      socket.destroy();
+      if (activeSocket === socket) activeSocket = null;
+      if (connected) {
+        settle();
+      } else if (Date.now() >= deadline) {
+        settle(new Error(`timed out waiting for socket ${path}`));
+      } else {
+        retryTimer = setTimeout(attempt, 50);
+      }
+    };
+    socket.setTimeout(250, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  };
+  attempt();
+  return {
+    promise,
+    cancel(reason = new Error(`cancelled socket wait for ${path}`)) {
+      settle(reason);
+    },
+  };
+}
+
+export function openExclusiveWriteStream(path, onRuntimeError = null) {
   return new Promise((resolvePromise, reject) => {
     const stream = createWriteStream(path, { flags: "wx" });
+    let opened = false;
     const onOpen = () => {
-      stream.off("error", onError);
+      opened = true;
       resolvePromise(stream);
     };
     const onError = (error) => {
-      stream.off("open", onOpen);
-      reject(error);
+      if (!opened) {
+        stream.off("open", onOpen);
+        reject(error);
+      } else if (onRuntimeError) {
+        onRuntimeError(error);
+      }
     };
     stream.once("open", onOpen);
-    stream.once("error", onError);
+    stream.on("error", onError);
   });
 }
 
@@ -352,8 +420,21 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
       `isolated daemon socket already exists; refusing to reap an unowned path: ${daemonSocketPath}`,
     );
   }
-  const log = await openExclusiveWriteStream(logPath);
-  const child = spawn(process.execPath, [entry], {
+  let child = null;
+  let logError = null;
+  let terminationPromise = null;
+  let rejectLogFailure;
+  const logFailure = new Promise((_, reject) => {
+    rejectLogFailure = reject;
+  });
+  const log = await openExclusiveWriteStream(logPath, (error) => {
+    logError ??= error;
+    rejectLogFailure(error);
+    if (child) {
+      terminationPromise ??= terminateChild(child);
+    }
+  });
+  child = spawn(process.execPath, [entry], {
     cwd: repoRoot,
     env,
     stdio: ["ignore", "pipe", "pipe"],
@@ -370,35 +451,37 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
   child.once("exit", (code, signal) => {
     earlyExit = { code, signal };
   });
+  const socketWait = waitForSocket(daemonSocketPath);
   try {
-    await Promise.race([waitForSocket(daemonSocketPath), spawnFailure]);
+    await Promise.race([socketWait.promise, spawnFailure, logFailure]);
+    socketWait.cancel();
     child.off("error", onSpawnError);
+    if (logError) throw logError;
     if (earlyExit) {
       throw new Error(
         `isolated daemon exited before readiness: ${JSON.stringify(earlyExit)}`,
       );
     }
   } catch (error) {
+    socketWait.cancel();
     child.off("error", onSpawnError);
-    if (child.exitCode === null && child.signalCode === null) {
-      child.kill("SIGTERM");
-    }
+    terminationPromise ??= terminateChild(child);
+    await terminationPromise;
     log.end();
     await rm(daemonSocketPath, { force: true });
     throw error;
   }
   return {
     pid: child.pid,
+    assertHealthy() {
+      if (logError) throw logError;
+    },
     async stop() {
-      if (child.exitCode === null && child.signalCode === null) {
-        child.kill("SIGTERM");
-        await Promise.race([
-          new Promise((resolveExit) => child.once("exit", resolveExit)),
-          new Promise((resolveTimeout) => setTimeout(resolveTimeout, 5_000)),
-        ]);
-      }
+      terminationPromise ??= terminateChild(child);
+      await terminationPromise;
       log.end();
       await rm(daemonSocketPath, { force: true });
+      if (logError) throw logError;
     },
   };
 }
@@ -487,7 +570,14 @@ export async function createScratchTargets(count, deps) {
       anchor = surface;
     }
   } catch (error) {
-    await closeRecorded().catch(() => {});
+    try {
+      await closeRecorded();
+    } catch (teardownError) {
+      throw new AggregateError(
+        [error, teardownError],
+        "scratch target creation and teardown failed",
+      );
+    }
     throw error;
   }
   return { targets: Object.freeze([...targets]), close: closeRecorded };
@@ -509,19 +599,19 @@ export function operationArgs(row, surface, workspace, worker, sample) {
   return { workspace, verbose: false };
 }
 
-async function runCliOperation(row, config, worker, sample) {
-  let args;
+export function cliArgs(row, config, worker, sample) {
   if (row.operation === "send_to") {
-    args = [
+    return [
       "send",
       "--workspace",
       config.workspace,
       "--surface",
       config.surface,
-      `${payloadText(row.payload_chars, worker, sample)}\\n`,
+      `${payloadText(row.payload_chars, worker, sample)}\n`,
     ];
-  } else if (row.operation === "read_screen") {
-    args = [
+  }
+  if (row.operation === "read_screen") {
+    return [
       "read-screen",
       "--workspace",
       config.workspace,
@@ -530,9 +620,12 @@ async function runCliOperation(row, config, worker, sample) {
       "--lines",
       "20",
     ];
-  } else {
-    args = ["tree", "--workspace", config.workspace];
   }
+  return ["tree", "--workspace", config.workspace];
+}
+
+async function runCliOperation(row, config, worker, sample) {
+  const args = cliArgs(row, config, worker, sample);
   await execCapture(config.cmuxBin, args, { env: config.env });
   return { ok: true, transport: "cli", transport_fallbacks: [] };
 }
@@ -711,6 +804,7 @@ async function main() {
       });
       const result = markSurfaceTransportUntrusted(measured);
       results.push(result);
+      daemon.assertHealthy();
     }
   } catch (error) {
     fatalError = error instanceof Error ? error.message : String(error);
@@ -723,7 +817,11 @@ async function main() {
         fatalError ??= error instanceof Error ? error.message : String(error);
       }
     }
-    await daemon.stop();
+    try {
+      await daemon.stop();
+    } catch (error) {
+      fatalError ??= error instanceof Error ? error.message : String(error);
+    }
   }
 
   const receipt = {

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -656,7 +656,7 @@ async function readProcessStartIdentity(pid) {
   const result = await execCapture(
     "/bin/ps",
     ["-p", String(pid), "-o", "lstart="],
-    { env: process.env },
+    { env: { ...process.env, LC_ALL: "C", LANG: "C" } },
   ).catch(() => null);
   return nonEmptyString(result?.stdout.trim());
 }

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -722,9 +722,32 @@ export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
 }
 
 export function appendFatalError(current, error, phase) {
-  const detail = error instanceof Error ? error.message : String(error);
+  const details = [];
+  const seen = new Set();
+  const visit = (value) => {
+    if (value && typeof value === "object") {
+      if (seen.has(value)) return;
+      seen.add(value);
+    }
+    const message = value instanceof Error ? value.message : String(value);
+    if (message && !details.includes(message)) details.push(message);
+    if (Array.isArray(value?.errors)) {
+      for (const nested of value.errors) visit(nested);
+    }
+  };
+  visit(error);
+  const detail = details.join(" -> ");
   const entry = `${phase}: ${detail}`;
   return current ? `${current}; ${entry}` : entry;
+}
+
+export function assertOwnedDaemonHealthy(child, logError = null) {
+  if (logError) throw logError;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    throw new Error(
+      `owned isolated daemon pid ${child.pid ?? "unknown"} exited after readiness: ${JSON.stringify({ exitCode: child.exitCode, signalCode: child.signalCode })}`,
+    );
+  }
 }
 
 export function appendSettledFailures(current, results, phase) {
@@ -824,7 +847,7 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
   return {
     pid: child.pid,
     assertHealthy() {
-      if (logError) throw logError;
+      assertOwnedDaemonHealthy(child, logError);
     },
     async stop() {
       let cleanupError = null;
@@ -1427,8 +1450,11 @@ async function executeBenchmark(config, isolation) {
         .map((row) => row.concurrency),
     );
     for (let index = 0; index < maxMcpConcurrency; index += 1) {
+      daemon.assertHealthy();
       mcpClients.push(await connectMcpClient(config.mcpEntry, env, index));
+      daemon.assertHealthy();
     }
+    daemon.assertHealthy();
     await Promise.all(
       mcpClients.map((client) =>
         client.callTool(
@@ -1438,7 +1464,9 @@ async function executeBenchmark(config, isolation) {
         ),
       ),
     );
+    daemon.assertHealthy();
     for (const [index, row] of rows.entries()) {
+      daemon.assertHealthy();
       if (row.comparison_status === "NOT_COMPARABLE") {
         process.stderr.write(
           `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client} NOT_COMPARABLE\n`,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import net from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -206,13 +214,17 @@ export async function runBenchmarkRow(row, deps) {
     })(),
   );
   const samples = (await Promise.all(workerRuns)).flat();
-  const latencies = samples.map((sample) => sample.latency_ms);
+  const latencies = samples
+    .filter((sample) => sample.ok)
+    .map((sample) => sample.latency_ms);
   return {
     ...row,
     concurrency_profile: `c${row.concurrency}`,
     sample_count: samples.length,
-    p50_ms: round(nearestRankPercentile(latencies, 50)),
-    p95_ms: round(nearestRankPercentile(latencies, 95)),
+    p50_ms:
+      latencies.length > 0 ? round(nearestRankPercentile(latencies, 50)) : null,
+    p95_ms:
+      latencies.length > 0 ? round(nearestRankPercentile(latencies, 95)) : null,
     error_count: samples.filter((sample) => !sample.ok).length,
     ...summarizeTransport(samples),
     samples,
@@ -548,10 +560,13 @@ export function daemonLogPath(
 }
 
 export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
+  const cleanBaseEnv = { ...baseEnv };
+  delete cleanBaseEnv.CMUXLAYER_FORCE_INPROCESS;
+  delete cleanBaseEnv.CMUXLAYER_DEFAULT_PALETTE;
   const root = reservation.ownerDirectory;
   const isolatedHome = join(root, "home");
   return stringEnv({
-    ...baseEnv,
+    ...cleanBaseEnv,
     HOME: isolatedHome,
     CMUX_SOCKET_PATH: cmuxSocketPath,
     CMUXLAYER_DAEMON_SOCKET: reservation.socketPath,
@@ -933,25 +948,56 @@ async function enumerateCliWorkspaces(config, exec = execCapture) {
   throw new Error("incomplete all-window workspace enumeration after retry");
 }
 
+function workspaceRefs(workspaces) {
+  return workspaces
+    .map((workspace) =>
+      isRecord(workspace)
+        ? (nonEmptyString(workspace.ref) ?? nonEmptyString(workspace.id))
+        : null,
+    )
+    .filter((ref) => ref !== null);
+}
+
+async function runCliTopology(config, workspaces, exec = execCapture) {
+  for (const workspace of workspaces) {
+    const panesOut = await exec(config.cmuxBin, listPanesCliArgs(workspace), {
+      env: config.env,
+    });
+    for (const pane of paneRefsFromListPanesStdout(panesOut.stdout)) {
+      await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
+        env: config.env,
+      });
+    }
+  }
+}
+
 export async function runCliListSurfaces(config, exec = execCapture) {
   await enumerateCliWorkspaces(config, exec);
-  const panesOut = await exec(
+  await runCliTopology(config, [config.workspace], exec);
+}
+
+export async function runCliReadScreen(
+  config,
+  worker,
+  sample,
+  exec = execCapture,
+) {
+  await exec(
     config.cmuxBin,
-    listPanesCliArgs(config.workspace),
+    cliArgs({ operation: "read_screen" }, config, worker, sample),
     { env: config.env },
   );
-  for (const pane of paneRefsFromListPanesStdout(panesOut.stdout)) {
-    await exec(
-      config.cmuxBin,
-      listPaneSurfacesCliArgs(config.workspace, pane),
-      { env: config.env },
-    );
-  }
+  const workspaces = await enumerateCliWorkspaces(config, exec);
+  await runCliTopology(config, workspaceRefs(workspaces), exec);
 }
 
 async function runCliOperation(row, config, worker, sample) {
   if (row.operation === "list_surfaces") {
     await runCliListSurfaces(config);
+    return { ok: true, transport: "cli", transport_fallbacks: [] };
+  }
+  if (row.operation === "read_screen") {
+    await runCliReadScreen(config, worker, sample);
     return { ok: true, transport: "cli", transport_fallbacks: [] };
   }
   const args = cliArgs(row, config, worker, sample);
@@ -1016,6 +1062,83 @@ function parseConfig(argv, env) {
   };
 }
 
+export async function buildRowsAndReserve(
+  config,
+  requestedSocketPath,
+  reserve = createSocketReservation,
+) {
+  const rows = buildBenchmarkRows({
+    concurrency: config.concurrency,
+    payloadSizes: config.payloadSizes,
+    samplesPerWorker: config.samplesPerWorker,
+    operations: config.operations,
+    clients: config.clients,
+  });
+  const socketReservation = await reserve(requestedSocketPath);
+  return { rows, socketReservation };
+}
+
+async function sha256File(path) {
+  return createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
+}
+
+export async function prepareBuiltEntries(config, deps = {}) {
+  const root = deps.repoRoot ?? repoRoot;
+  const exec = deps.exec ?? execCapture;
+  const exists = deps.exists ?? existsSync;
+  const hashFile = deps.hashFile ?? sha256File;
+  const expectedMcpEntry = join(root, "dist", "index.js");
+  const expectedDaemonEntry = join(root, "dist", "daemon.js");
+  if (
+    config.mcpEntry !== expectedMcpEntry ||
+    config.daemonEntry !== expectedDaemonEntry
+  ) {
+    throw new Error(
+      "custom built entries have unverifiable source provenance; use the repository dist/index.js and dist/daemon.js",
+    );
+  }
+  const readTrackedStatus = () =>
+    exec("git", ["status", "--porcelain", "--untracked-files=no"], {
+      env: config.env,
+    });
+  const readHead = () =>
+    exec("git", ["rev-parse", "HEAD"], { env: config.env });
+  const status = await readTrackedStatus();
+  if (status.stdout.trim()) {
+    throw new Error(
+      "refusing to benchmark built artifacts from a dirty tracked worktree",
+    );
+  }
+  const head = await readHead();
+  await exec("bun", ["run", "build"], { env: config.env });
+  const finalStatus = await readTrackedStatus();
+  if (finalStatus.stdout.trim()) {
+    throw new Error("tracked worktree changed during artifact build");
+  }
+  const finalHead = await readHead();
+  if (finalHead.stdout.trim() !== head.stdout.trim()) {
+    throw new Error("repository revision changed during build");
+  }
+  for (const path of [config.mcpEntry, config.daemonEntry]) {
+    if (!exists(path)) throw new Error(`built entry does not exist: ${path}`);
+  }
+  return {
+    git_head: head.stdout.trim(),
+    entries: {
+      mcp: {
+        path: config.mcpEntry,
+        sha256: await hashFile(config.mcpEntry),
+      },
+      daemon: {
+        path: config.daemonEntry,
+        sha256: await hashFile(config.daemonEntry),
+      },
+    },
+  };
+}
+
 const HELP = `bench-e2e.mjs — isolated agent-side MCP vs direct cmux CLI benchmark
 
 Required environment:
@@ -1045,17 +1168,18 @@ async function main() {
       "surface and workspace are required; run inside the Nightly terminal or pass --surface/--workspace",
     );
   }
-  for (const path of [config.mcpEntry, config.daemonEntry]) {
-    if (!existsSync(path))
-      throw new Error(`built entry does not exist: ${path}`);
-  }
+  const artifactProvenance = await prepareBuiltEntries({
+    ...config,
+    env: process.env,
+  });
   const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);
   if (!nightlySocket?.isSocket()) {
     throw new Error(`nightly socket is not live: ${isolation.cmuxSocketPath}`);
   }
   await mkdir(dirname(config.out), { recursive: true });
   const logPath = daemonLogPath(config.out);
-  const socketReservation = await createSocketReservation(
+  const { rows, socketReservation } = await buildRowsAndReserve(
+    config,
     isolation.daemonSocketPath,
   );
   const env = buildIsolatedRuntimeEnv(
@@ -1063,13 +1187,6 @@ async function main() {
     socketReservation,
     isolation.cmuxSocketPath,
   );
-  const rows = buildBenchmarkRows({
-    concurrency: config.concurrency,
-    payloadSizes: config.payloadSizes,
-    samplesPerWorker: config.samplesPerWorker,
-    operations: config.operations,
-    clients: config.clients,
-  });
   const startedAt = new Date().toISOString();
   let daemon = null;
   try {
@@ -1182,9 +1299,8 @@ async function main() {
     kind: "cmuxlayer-agent-side-e2e-benchmark",
     started_at: startedAt,
     finished_at: new Date().toISOString(),
-    git_head: await readGitHead(() =>
-      execCapture("git", ["rev-parse", "HEAD"], { env }),
-    ),
+    git_head: artifactProvenance.git_head,
+    artifact_provenance: artifactProvenance,
     environment: {
       cmux_socket_path: isolation.cmuxSocketPath,
       requested_daemon_socket_path: isolation.daemonSocketPath,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -6,6 +6,7 @@ import { createWriteStream, existsSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
+  open,
   readFile,
   rm,
   stat,
@@ -600,6 +601,38 @@ export async function createSocketReservation(requestedPath) {
       if (released) return;
       released = true;
       await rm(ownerDirectory, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createOutputReservation(outputPath) {
+  const canonicalOutput = resolve(outputPath);
+  const lockPath = `${canonicalOutput}.lock`;
+  await mkdir(dirname(canonicalOutput), { recursive: true });
+  const handle = await open(lockPath, "wx", 0o600).catch((error) => {
+    if (error?.code === "EEXIST") {
+      throw new Error(
+        `benchmark output is already reserved by another run: ${canonicalOutput}`,
+      );
+    }
+    throw error;
+  });
+  try {
+    await handle.writeFile(`${process.pid}\n`, "utf8");
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await rm(lockPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+  let released = false;
+  return {
+    outputPath: canonicalOutput,
+    lockPath,
+    async release() {
+      if (released) return;
+      released = true;
+      await handle.close();
+      await rm(lockPath, { force: false });
     },
   };
 }
@@ -1335,6 +1368,15 @@ async function main() {
       "surface and workspace are required; run inside the Nightly terminal or pass --surface/--workspace",
     );
   }
+  const outputReservation = await createOutputReservation(config.out);
+  try {
+    await executeBenchmark(config, isolation);
+  } finally {
+    await outputReservation.release();
+  }
+}
+
+async function executeBenchmark(config, isolation) {
   const artifactProvenance = await prepareBuiltEntries({
     ...config,
     env: process.env,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -661,8 +661,9 @@ async function readProcessStartIdentity(pid) {
 }
 
 function parseLockOwner(text) {
+  let parsed = null;
   try {
-    const parsed = JSON.parse(text);
+    parsed = JSON.parse(text);
     if (
       isRecord(parsed) &&
       Number.isSafeInteger(parsed.pid) &&
@@ -674,10 +675,11 @@ function parseLockOwner(text) {
       };
     }
   } catch {
-    const legacyPid = Number.parseInt(text.trim(), 10);
-    if (Number.isSafeInteger(legacyPid) && legacyPid > 0) {
-      return { pid: legacyPid, process_start: null };
-    }
+    // Fall through to the legacy numeric format below.
+  }
+  const legacyPid = Number.parseInt(text.trim(), 10);
+  if (Number.isSafeInteger(legacyPid) && legacyPid > 0) {
+    return { pid: legacyPid, process_start: null };
   }
   return null;
 }
@@ -709,7 +711,11 @@ async function createPidLock(lockPath, label) {
       const owner = parseLockOwner(observedText);
       if (owner && processIsLive(owner.pid)) {
         const observedStart = await readProcessStartIdentity(owner.pid);
-        if (!owner.process_start || observedStart === owner.process_start) {
+        if (
+          !owner.process_start ||
+          observedStart === null ||
+          observedStart === owner.process_start
+        ) {
           throw new Error(`${label} is already reserved by pid ${owner.pid}`);
         }
       }
@@ -736,8 +742,8 @@ async function createPidLock(lockPath, label) {
       if (currentText !== ownerText) {
         throw new Error(`${label} ownership changed before release`);
       }
-      released = true;
       await rm(lockPath, { force: false });
+      released = true;
     },
   };
 }
@@ -1144,7 +1150,7 @@ export async function createScratchTargets(count, deps) {
     const failures = [];
     for (const surface of [...targets].reverse()) {
       try {
-        await deps.execCmux([
+        await (deps.closeCmux ?? deps.execCmux)([
           "close-surface",
           "--workspace",
           deps.workspace,
@@ -1665,6 +1671,20 @@ export function installGracefulSignalAbort(
   };
 }
 
+export async function releaseReservations(reservations) {
+  const settled = await Promise.allSettled(
+    reservations.map((reservation) =>
+      Promise.resolve().then(() => reservation.release()),
+    ),
+  );
+  const failures = settled
+    .filter((result) => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "top-level reservation release failed");
+  }
+}
+
 async function main() {
   const config = parseConfig(process.argv.slice(2), process.env);
   if (config.help) {
@@ -1689,24 +1709,35 @@ async function main() {
       isolation.cmuxSocketPath,
       stableWorkspaceId,
     );
+    let outputReservation = null;
+    const releaseTopLevel = () =>
+      releaseReservations(
+        [outputReservation, workspaceReservation].filter(Boolean),
+      );
     try {
       abortController.signal.throwIfAborted();
-      const outputReservation = await createOutputReservation(config.out);
-      try {
-        abortController.signal.throwIfAborted();
-        await executeBenchmark(config, isolation, abortController.signal);
-      } finally {
-        await outputReservation.release();
-      }
+      outputReservation = await createOutputReservation(config.out);
+      abortController.signal.throwIfAborted();
+      await executeBenchmark(
+        config,
+        isolation,
+        abortController.signal,
+        releaseTopLevel,
+      );
     } finally {
-      await workspaceReservation.release();
+      await releaseTopLevel();
     }
   } finally {
     removeSignalHandlers();
   }
 }
 
-async function executeBenchmark(config, isolation, abortSignal) {
+async function executeBenchmark(
+  config,
+  isolation,
+  abortSignal,
+  releaseTopLevel,
+) {
   const artifactProvenance = await prepareBuiltEntries({
     ...config,
     env: process.env,
@@ -1755,6 +1786,7 @@ async function executeBenchmark(config, isolation, abortSignal) {
       signal: abortSignal,
       execCmux: (args) =>
         execCapture(config.cmuxBin, args, { env, signal: abortSignal }),
+      closeCmux: (args) => execCapture(config.cmuxBin, args, { env }),
     });
     const maxMcpConcurrency = Math.max(
       0,
@@ -1862,6 +1894,11 @@ async function executeBenchmark(config, isolation, abortSignal) {
     await assertArtifactProvenance(artifactProvenance);
   } catch (error) {
     fatalError = appendFatalError(fatalError, error, "artifact revalidation");
+  }
+  try {
+    await releaseTopLevel();
+  } catch (error) {
+    fatalError = appendFatalError(fatalError, error, "top-level release");
   }
 
   const receipt = {

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -8,6 +8,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   realpath,
   rm,
   stat,
@@ -692,10 +693,15 @@ async function createPidLock(lockPath, label) {
   }
   const ownerText = `${JSON.stringify({ pid: process.pid, process_start: processStart })}\n`;
   const candidatePath = `${lockPath}.claim-${process.pid}-${randomUUID()}`;
+  const reclaimPath = `${lockPath}.reclaim`;
   await writeFile(candidatePath, ownerText, { flag: "wx", mode: 0o600 });
   let acquired = false;
   try {
-    for (let attempt = 0; attempt < 3 && !acquired; attempt += 1) {
+    for (let attempt = 0; attempt < 20 && !acquired; attempt += 1) {
+      if (existsSync(reclaimPath)) {
+        await new Promise((resolvePause) => setTimeout(resolvePause, 10));
+        continue;
+      }
       try {
         await link(candidatePath, lockPath);
         acquired = true;
@@ -719,13 +725,28 @@ async function createPidLock(lockPath, label) {
           throw new Error(`${label} is already reserved by pid ${owner.pid}`);
         }
       }
-      // Re-read before unlinking so a contender that replaced the stale owner
-      // is never removed based on an earlier observation.
-      const currentText = await readFile(lockPath, "utf8").catch(() => null);
-      if (currentText !== observedText) continue;
-      await unlink(lockPath).catch((error) => {
-        if (error?.code !== "ENOENT") throw error;
-      });
+      let ownsReclaim = false;
+      try {
+        await link(candidatePath, reclaimPath);
+        ownsReclaim = true;
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+      }
+      if (!ownsReclaim) {
+        await new Promise((resolvePause) => setTimeout(resolvePause, 10));
+        continue;
+      }
+      try {
+        const currentText = await readFile(lockPath, "utf8").catch(() => null);
+        if (currentText !== observedText) continue;
+        await unlink(lockPath).catch((error) => {
+          if (error?.code !== "ENOENT") throw error;
+        });
+        await link(candidatePath, lockPath);
+        acquired = true;
+      } finally {
+        await unlink(reclaimPath).catch(() => undefined);
+      }
     }
   } finally {
     await unlink(candidatePath).catch(() => undefined);
@@ -1564,11 +1585,38 @@ async function sha256File(path) {
     .digest("hex");
 }
 
+async function listRuntimeFiles(root) {
+  const files = [];
+  async function visit(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries.sort((left, right) =>
+      left.name.localeCompare(right.name),
+    )) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile()) files.push(path);
+    }
+  }
+  await visit(root);
+  return files;
+}
+
 export async function assertArtifactProvenance(
   provenance,
   hashFile = sha256File,
 ) {
-  for (const entry of Object.values(provenance.entries)) {
+  const attested = [
+    ...Object.values(provenance.entries),
+    ...(provenance.runtime_files ?? []),
+  ];
+  if (provenance.runtime_root && provenance.runtime_files) {
+    const expectedPaths = provenance.runtime_files.map((entry) => entry.path);
+    const observedPaths = await listRuntimeFiles(provenance.runtime_root);
+    if (JSON.stringify(observedPaths) !== JSON.stringify(expectedPaths)) {
+      throw new Error("runtime artifact file set changed after attestation");
+    }
+  }
+  for (const entry of attested) {
     const observed = await hashFile(entry.path);
     if (observed !== entry.sha256) {
       throw new Error(
@@ -1583,6 +1631,7 @@ export async function prepareBuiltEntries(config, deps = {}) {
   const exec = deps.exec ?? execCapture;
   const exists = deps.exists ?? existsSync;
   const hashFile = deps.hashFile ?? sha256File;
+  const enumerateRuntimeFiles = deps.listRuntimeFiles ?? listRuntimeFiles;
   const expectedMcpEntry = join(root, "dist", "index.js");
   const expectedDaemonEntry = join(root, "dist", "daemon.js");
   if (
@@ -1618,6 +1667,8 @@ export async function prepareBuiltEntries(config, deps = {}) {
   for (const path of [config.mcpEntry, config.daemonEntry]) {
     if (!exists(path)) throw new Error(`built entry does not exist: ${path}`);
   }
+  const runtimeRoot = join(root, "dist");
+  const runtimeFiles = await enumerateRuntimeFiles(runtimeRoot);
   return {
     git_head: head.stdout.trim(),
     entries: {
@@ -1630,6 +1681,10 @@ export async function prepareBuiltEntries(config, deps = {}) {
         sha256: await hashFile(config.daemonEntry),
       },
     },
+    runtime_root: runtimeRoot,
+    runtime_files: await Promise.all(
+      runtimeFiles.map(async (path) => ({ path, sha256: await hashFile(path) })),
+    ),
   };
 }
 

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -24,6 +24,63 @@ const DEFAULT_PAYLOAD_SIZES = Object.freeze([250, 450, 520, 900]);
 const DEFAULT_SAMPLES_PER_WORKER = 12;
 const REQUIRED_NIGHTLY_SOCKET = "/tmp/cmux-nightly.sock";
 
+function fairnessContract(operation, work, note) {
+  const frozenWork = Object.freeze([...work]);
+  return Object.freeze({
+    operation,
+    comparable: true,
+    mcp_work: frozenWork,
+    cli_work: Object.freeze([...work]),
+    note,
+  });
+}
+
+export const FAIRNESS_CONTRACTS = Object.freeze({
+  send_to: Object.freeze({
+    operation: "send_to",
+    comparable: false,
+    mcp_work: Object.freeze([
+      "topology:all-windows:sequential",
+      "dynamic-route-and-control-validation",
+      "read-screen:safety",
+      "payload-dependent-send-or-paste-with-retries",
+      "send-key:return-with-retries",
+    ]),
+    cli_work: null,
+    reason:
+      "MCP send_to performs dynamic route, control, safety, retry, and payload-dependent paste work that cannot be mirrored by direct cmux send without reimplementing the server; the CLI comparison row is explicitly absent.",
+  }),
+  read_screen: fairnessContract(
+    "read_screen",
+    ["read-screen", "topology:all-windows:sequential"],
+    "MCP reads the screen and then collects all-window topology; direct CLI performs the same external primitives in the same order.",
+  ),
+  list_surfaces: fairnessContract(
+    "list_surfaces",
+    [
+      "enumerate:all-window-workspaces",
+      "topology:target-workspace:parallel-panes",
+      "terminal-metadata:socket-empty-noop",
+    ],
+    "MCP enumerates all-window workspaces, fans target-workspace pane surface reads concurrently, then calls the socket client's in-process empty terminal-metadata method; direct CLI mirrors those external primitives and records the same no-op.",
+  ),
+});
+
+export function assertCliFairnessTrace(operation, observedWork) {
+  const contract = FAIRNESS_CONTRACTS[operation];
+  if (!contract) throw new Error(`missing fairness contract for ${operation}`);
+  if (!contract.comparable || !contract.cli_work) {
+    throw new Error(
+      `${operation} is not comparable: ${contract.reason ?? "no equivalent direct CLI arm"}`,
+    );
+  }
+  if (JSON.stringify(observedWork) !== JSON.stringify(contract.cli_work)) {
+    throw new Error(
+      `fairness contract drift for ${operation}: expected ${JSON.stringify(contract.cli_work)}, observed ${JSON.stringify(observedWork)}`,
+    );
+  }
+}
+
 function round(value, digits = 2) {
   const factor = 10 ** digits;
   return Math.round(value * factor) / factor;
@@ -117,6 +174,13 @@ export function buildBenchmarkRows({
             concurrency: workerCount,
             payload_chars: payloadChars,
             samples_per_worker: samplesPerWorker,
+            comparison_status:
+              operation === "send_to" && client === "cli"
+                ? "NOT_COMPARABLE"
+                : "MEASURED",
+            ...(operation === "send_to" && client === "cli"
+              ? { comparison_note: FAIRNESS_CONTRACTS.send_to.reason }
+              : {}),
           });
         }
       }
@@ -217,17 +281,41 @@ export async function runBenchmarkRow(row, deps) {
   const latencies = samples
     .filter((sample) => sample.ok)
     .map((sample) => sample.latency_ms);
+  const attemptCount = samples.length;
+  const successCount = latencies.length;
+  const failureCount = attemptCount - successCount;
   return {
     ...row,
     concurrency_profile: `c${row.concurrency}`,
     sample_count: samples.length,
+    attempt_count: attemptCount,
+    success_count: successCount,
+    failure_rate_pct:
+      attemptCount > 0 ? round((failureCount / attemptCount) * 100) : 0,
     p50_ms:
       latencies.length > 0 ? round(nearestRankPercentile(latencies, 50)) : null,
     p95_ms:
       latencies.length > 0 ? round(nearestRankPercentile(latencies, 95)) : null,
-    error_count: samples.filter((sample) => !sample.ok).length,
+    error_count: failureCount,
     ...summarizeTransport(samples),
     samples,
+  };
+}
+
+export function buildAbsentComparisonRow(row) {
+  return {
+    ...row,
+    comparison_status: "NOT_COMPARABLE",
+    attempt_count: 0,
+    success_count: 0,
+    failure_rate_pct: null,
+    sample_count: 0,
+    p50_ms: null,
+    p95_ms: null,
+    error_count: 0,
+    transport_counts: {},
+    transport_fallback_counts: {},
+    samples: [],
   };
 }
 
@@ -400,6 +488,17 @@ export async function terminateChild(child, graceMs = 5_000) {
     child.off("error", onError);
     child.off("close", onClose);
   }
+}
+
+export function beginObservedTermination(child, terminate = terminateChild) {
+  let promise;
+  try {
+    promise = terminate(child);
+  } catch (error) {
+    promise = Promise.reject(error);
+  }
+  promise.catch(() => undefined);
+  return promise;
 }
 
 export function waitForSocket(path, timeoutMs = 15_000) {
@@ -610,7 +709,7 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
     logError ??= error;
     rejectLogFailure(error);
     if (child) {
-      terminationPromise ??= terminateChild(child);
+      terminationPromise ??= beginObservedTermination(child);
     }
   });
   child = spawn(process.execPath, [entry], {
@@ -958,22 +1057,51 @@ function workspaceRefs(workspaces) {
     .filter((ref) => ref !== null);
 }
 
-async function runCliTopology(config, workspaces, exec = execCapture) {
-  for (const workspace of workspaces) {
+async function runCliTopology(
+  config,
+  workspaces,
+  exec = execCapture,
+  { parallelWorkspaces = false, parallelPanes = false } = {},
+) {
+  const runWorkspace = async (workspace) => {
     const panesOut = await exec(config.cmuxBin, listPanesCliArgs(workspace), {
       env: config.env,
     });
-    for (const pane of paneRefsFromListPanesStdout(panesOut.stdout)) {
-      await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
-        env: config.env,
-      });
+    const panes = paneRefsFromListPanesStdout(panesOut.stdout);
+    if (parallelPanes) {
+      await Promise.all(
+        panes.map((pane) =>
+          exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
+            env: config.env,
+          }),
+        ),
+      );
+    } else {
+      for (const pane of panes) {
+        await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
+          env: config.env,
+        });
+      }
     }
+  };
+  if (parallelWorkspaces) {
+    await Promise.all(workspaces.map(runWorkspace));
+  } else {
+    for (const workspace of workspaces) await runWorkspace(workspace);
   }
 }
 
 export async function runCliListSurfaces(config, exec = execCapture) {
+  const observedWork = [];
   await enumerateCliWorkspaces(config, exec);
-  await runCliTopology(config, [config.workspace], exec);
+  observedWork.push("enumerate:all-window-workspaces");
+  await runCliTopology(config, [config.workspace], exec, {
+    parallelWorkspaces: true,
+    parallelPanes: true,
+  });
+  observedWork.push("topology:target-workspace:parallel-panes");
+  observedWork.push("terminal-metadata:socket-empty-noop");
+  assertCliFairnessTrace("list_surfaces", observedWork);
 }
 
 export async function runCliReadScreen(
@@ -982,13 +1110,17 @@ export async function runCliReadScreen(
   sample,
   exec = execCapture,
 ) {
+  const observedWork = [];
   await exec(
     config.cmuxBin,
     cliArgs({ operation: "read_screen" }, config, worker, sample),
     { env: config.env },
   );
+  observedWork.push("read-screen");
   const workspaces = await enumerateCliWorkspaces(config, exec);
   await runCliTopology(config, workspaceRefs(workspaces), exec);
+  observedWork.push("topology:all-windows:sequential");
+  assertCliFairnessTrace("read_screen", observedWork);
 }
 
 async function runCliOperation(row, config, worker, sample) {
@@ -999,6 +1131,9 @@ async function runCliOperation(row, config, worker, sample) {
   if (row.operation === "read_screen") {
     await runCliReadScreen(config, worker, sample);
     return { ok: true, transport: "cli", transport_fallbacks: [] };
+  }
+  if (row.operation === "send_to") {
+    throw new Error(FAIRNESS_CONTRACTS.send_to.reason);
   }
   const args = cliArgs(row, config, worker, sample);
   await execCapture(config.cmuxBin, args, { env: config.env });
@@ -1014,12 +1149,12 @@ function compactCounts(counts) {
 
 export function renderMarkdownTable(rows) {
   const lines = [
-    "| operation | profile | payload | client | n | p50 ms | p95 ms | errors | transport | fallbacks |",
-    "|---|---:|---:|---|---:|---:|---:|---:|---|---|",
+    "| operation | profile | payload | client | status | attempts | successes | failure % | p50 ms | p95 ms | transport | fallbacks |",
+    "|---|---:|---:|---|---|---:|---:|---:|---:|---:|---|---|",
   ];
   for (const row of rows) {
     lines.push(
-      `| ${row.operation} | ${row.concurrency_profile} | ${row.payload_chars ?? "-"} | ${row.client} | ${row.sample_count} | ${row.p50_ms} | ${row.p95_ms} | ${row.error_count} | ${compactCounts(row.transport_counts)} | ${compactCounts(row.transport_fallback_counts)} |`,
+      `| ${row.operation} | ${row.concurrency_profile} | ${row.payload_chars ?? "-"} | ${row.client} | ${row.comparison_status ?? "MEASURED"} | ${row.attempt_count} | ${row.success_count} | ${row.failure_rate_pct ?? "-"} | ${row.p50_ms ?? "-"} | ${row.p95_ms ?? "-"} | ${compactCounts(row.transport_counts)} | ${compactCounts(row.transport_fallback_counts)} |`,
     );
   }
   return lines.join("\n");
@@ -1230,6 +1365,13 @@ async function main() {
       ),
     );
     for (const [index, row] of rows.entries()) {
+      if (row.comparison_status === "NOT_COMPARABLE") {
+        process.stderr.write(
+          `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client} NOT_COMPARABLE\n`,
+        );
+        results.push(buildAbsentComparisonRow(row));
+        continue;
+      }
       process.stderr.write(
         `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client}\n`,
       );
@@ -1333,9 +1475,18 @@ async function main() {
       load_model: "none (synthetic MCP/CLI clients; no LLM seats launched)",
       estimated_model_cost_usd: 0,
     },
+    fairness_contracts: FAIRNESS_CONTRACTS,
     row_schema: {
       identity: ["operation", "client", "concurrency_profile", "payload_chars"],
-      aggregate: ["sample_count", "p50_ms", "p95_ms", "error_count"],
+      comparison: ["comparison_status", "comparison_note?"],
+      aggregate: [
+        "attempt_count",
+        "success_count",
+        "failure_rate_pct",
+        "p50_ms",
+        "p95_ms",
+        "error_count",
+      ],
       transport: ["transport_counts", "transport_fallback_counts"],
       raw_sample: [
         "worker",

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -52,8 +52,11 @@ export const FAIRNESS_CONTRACTS = Object.freeze({
   }),
   read_screen: fairnessContract(
     "read_screen",
-    ["read-screen", "topology:all-windows:sequential"],
-    "MCP reads the screen and then collects all-window topology; direct CLI performs the same external primitives in the same order.",
+    [
+      "read-screen:raw-surface",
+      "topology:all-windows:sequential-best-effort",
+    ],
+    "MCP reads a raw surface without a workspace qualifier and then collects all-window topology best-effort; direct CLI uses the same request identity, external primitives, ordering, and churn semantics.",
   ),
   list_surfaces: fairnessContract(
     "list_surfaces",
@@ -491,12 +494,13 @@ export async function terminateChild(child, graceMs = 5_000) {
 }
 
 export function beginObservedTermination(child, terminate = terminateChild) {
-  let promise;
-  try {
-    promise = terminate(child);
-  } catch (error) {
-    promise = Promise.reject(error);
-  }
+  const promise = (() => {
+    try {
+      return terminate(child);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  })();
   promise.catch(() => undefined);
   return promise;
 }
@@ -662,6 +666,10 @@ export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
   const cleanBaseEnv = { ...baseEnv };
   delete cleanBaseEnv.CMUXLAYER_FORCE_INPROCESS;
   delete cleanBaseEnv.CMUXLAYER_DEFAULT_PALETTE;
+  delete cleanBaseEnv.CMUXLAYER_DAEMON_FD;
+  delete cleanBaseEnv.LISTEN_FDS;
+  delete cleanBaseEnv.LISTEN_PID;
+  delete cleanBaseEnv.LISTEN_FDNAMES;
   const root = reservation.ownerDirectory;
   const isolatedHome = join(root, "home");
   return stringEnv({
@@ -942,8 +950,6 @@ export function cliArgs(row, config, worker, sample) {
   if (row.operation === "read_screen") {
     return [
       "read-screen",
-      "--workspace",
-      config.workspace,
       "--surface",
       config.surface,
       "--lines",
@@ -1061,26 +1067,40 @@ async function runCliTopology(
   config,
   workspaces,
   exec = execCapture,
-  { parallelWorkspaces = false, parallelPanes = false } = {},
+  {
+    parallelWorkspaces = false,
+    parallelPanes = false,
+    bestEffort = false,
+  } = {},
 ) {
   const runWorkspace = async (workspace) => {
-    const panesOut = await exec(config.cmuxBin, listPanesCliArgs(workspace), {
-      env: config.env,
-    });
-    const panes = paneRefsFromListPanesStdout(panesOut.stdout);
+    let panes;
+    try {
+      const panesOut = await exec(config.cmuxBin, listPanesCliArgs(workspace), {
+        env: config.env,
+      });
+      panes = paneRefsFromListPanesStdout(panesOut.stdout);
+    } catch (error) {
+      if (bestEffort) return;
+      throw error;
+    }
     if (parallelPanes) {
-      await Promise.all(
-        panes.map((pane) =>
-          exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
-            env: config.env,
-          }),
-        ),
+      const work = panes.map((pane) =>
+        exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
+          env: config.env,
+        }),
       );
+      if (bestEffort) await Promise.allSettled(work);
+      else await Promise.all(work);
     } else {
       for (const pane of panes) {
-        await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
-          env: config.env,
-        });
+        try {
+          await exec(config.cmuxBin, listPaneSurfacesCliArgs(workspace, pane), {
+            env: config.env,
+          });
+        } catch (error) {
+          if (!bestEffort) throw error;
+        }
       }
     }
   };
@@ -1116,10 +1136,18 @@ export async function runCliReadScreen(
     cliArgs({ operation: "read_screen" }, config, worker, sample),
     { env: config.env },
   );
-  observedWork.push("read-screen");
-  const workspaces = await enumerateCliWorkspaces(config, exec);
-  await runCliTopology(config, workspaceRefs(workspaces), exec);
-  observedWork.push("topology:all-windows:sequential");
+  observedWork.push("read-screen:raw-surface");
+  let workspaces = [];
+  try {
+    workspaces = await enumerateCliWorkspaces(config, exec);
+  } catch {
+    // MCP collectSurfaceTopology returns null when all-window enumeration
+    // races with topology churn; the successful screen read still succeeds.
+  }
+  await runCliTopology(config, workspaceRefs(workspaces), exec, {
+    bestEffort: true,
+  });
+  observedWork.push("topology:all-windows:sequential-best-effort");
   assertCliFairnessTrace("read_screen", observedWork);
 }
 

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -465,6 +465,41 @@ export function daemonLogPath(receiptPath, pid = process.pid, now = Date.now()) 
   return `${receiptPath}.daemon-${pid}-${now}.log`;
 }
 
+export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
+  const root = reservation.ownerDirectory;
+  const isolatedHome = join(root, "home");
+  return stringEnv({
+    ...baseEnv,
+    HOME: isolatedHome,
+    CMUX_SOCKET_PATH: cmuxSocketPath,
+    CMUXLAYER_DAEMON_SOCKET: reservation.socketPath,
+    CMUXLAYER_STATE_DIR: join(root, "state"),
+    CMUXLAYER_INBOX_BASE_DIR: join(root, "inbox"),
+    CMUXLAYER_SESSION_REGISTRY: join(root, "session-registry.jsonl"),
+    CMUXLAYER_SEAT_REGISTRY_PATH: join(root, "seat-registry.json"),
+    CMUXLAYER_LAUNCHER_REGISTRY_PATH: join(root, "launcher-registry.json"),
+    CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH: join(root, "fleet-sidebar.swift"),
+    CMUXLAYER_HARNESS_HOME: join(root, "harness"),
+    CMUXLAYER_DEV: "1",
+  });
+}
+
+export function appendFatalError(current, error, phase) {
+  const detail = error instanceof Error ? error.message : String(error);
+  const entry = `${phase}: ${detail}`;
+  return current ? `${current}; ${entry}` : entry;
+}
+
+export function appendSettledFailures(current, results, phase) {
+  let combined = current;
+  for (const result of results) {
+    if (result.status === "rejected") {
+      combined = appendFatalError(combined, result.reason, phase);
+    }
+  }
+  return combined;
+}
+
 async function startIsolatedDaemon(entry, env, reservation, logPath) {
   const daemonSocketPath = reservation.socketPath;
   let child = null;
@@ -774,12 +809,11 @@ async function main() {
   const socketReservation = await createSocketReservation(
     isolation.daemonSocketPath,
   );
-  const env = stringEnv({
-    ...process.env,
-    CMUX_SOCKET_PATH: isolation.cmuxSocketPath,
-    CMUXLAYER_DAEMON_SOCKET: socketReservation.socketPath,
-    CMUXLAYER_DEV: "1",
-  });
+  const env = buildIsolatedRuntimeEnv(
+    process.env,
+    socketReservation,
+    isolation.cmuxSocketPath,
+  );
   const rows = buildBenchmarkRows({
     concurrency: config.concurrency,
     payloadSizes: config.payloadSizes,
@@ -868,20 +902,27 @@ async function main() {
       daemon.assertHealthy();
     }
   } catch (error) {
-    fatalError = error instanceof Error ? error.message : String(error);
+    fatalError = appendFatalError(fatalError, error, "benchmark");
   } finally {
-    await Promise.allSettled(mcpClients.map((client) => client.close()));
+    const clientStops = await Promise.allSettled(
+      mcpClients.map((client) => client.close()),
+    );
+    fatalError = appendSettledFailures(
+      fatalError,
+      clientStops,
+      "MCP client stop",
+    );
     if (fixture) {
       try {
         await fixture.close();
       } catch (error) {
-        fatalError ??= error instanceof Error ? error.message : String(error);
+        fatalError = appendFatalError(fatalError, error, "scratch teardown");
       }
     }
     try {
       await daemon.stop();
     } catch (error) {
-      fatalError ??= error instanceof Error ? error.message : String(error);
+      fatalError = appendFatalError(fatalError, error, "daemon stop");
     }
   }
 
@@ -897,6 +938,26 @@ async function main() {
       cmux_socket_path: isolation.cmuxSocketPath,
       requested_daemon_socket_path: isolation.daemonSocketPath,
       daemon_socket_path: socketReservation.socketPath,
+      configured_state_path: join(socketReservation.ownerDirectory, "state"),
+      daemon_state_path: join(
+        socketReservation.ownerDirectory,
+        "home",
+        ".local",
+        "state",
+        "cmux-agents",
+      ),
+      monitor_registry_path: join(
+        socketReservation.ownerDirectory,
+        "home",
+        ".golems-zikaron",
+        "monitor-registry.json",
+      ),
+      watch_registry_path: join(
+        socketReservation.ownerDirectory,
+        "home",
+        ".golems-zikaron",
+        "watch-specs.json",
+      ),
       isolated_daemon_pid: daemon.pid,
       daemon_log: logPath,
       controller_surface: config.surface,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -2,7 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { createWriteStream, existsSync } from "node:fs";
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -270,15 +270,22 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
-    const timer = setTimeout(() => {
+    let timer = null;
+    timer = setTimeout(() => {
       timedOut = true;
-      void terminateChild(child).finally(() => {
-        reject(
-          new Error(
-            `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+      const timeoutError = new Error(
+        `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
+      );
+      terminateChild(child).then(
+        () => reject(timeoutError),
+        (terminationError) =>
+          reject(
+            new AggregateError(
+              [timeoutError, terminationError],
+              "command timed out and child termination failed",
+            ),
           ),
-        );
-      });
+      );
     }, timeoutMs);
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString("utf8");
@@ -318,7 +325,7 @@ export async function terminateChild(child, graceMs = 5_000) {
     child.once("close", onExit);
   });
   child.kill("SIGTERM");
-  let timer;
+  let timer = null;
   const exitedGracefully = await Promise.race([
     exitPromise.then(() => true),
     new Promise((resolveTimeout) => {
@@ -341,8 +348,8 @@ export function waitForSocket(path, timeoutMs = 15_000) {
   let activeSocket = null;
   let retryTimer = null;
   let settled = false;
-  let resolveWait;
-  let rejectWait;
+  let resolveWait = () => undefined;
+  let rejectWait = () => undefined;
   const promise = new Promise((resolvePromise, reject) => {
     resolveWait = resolvePromise;
     rejectWait = reject;
@@ -414,16 +421,32 @@ export function openExclusiveWriteStream(path, onRuntimeError = null) {
   });
 }
 
-async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
-  if (existsSync(daemonSocketPath)) {
+export async function createSocketReservation(requestedPath) {
+  if (existsSync(requestedPath)) {
     throw new Error(
-      `isolated daemon socket already exists; refusing to reap an unowned path: ${daemonSocketPath}`,
+      `isolated daemon socket already exists; refusing to reuse an unowned path: ${requestedPath}`,
     );
   }
+  const ownerDirectory = await mkdtemp(`${requestedPath}.owner-`);
+  const socketPath = join(ownerDirectory, "daemon.sock");
+  let released = false;
+  return {
+    ownerDirectory,
+    socketPath,
+    async release() {
+      if (released) return;
+      released = true;
+      await rm(ownerDirectory, { recursive: true, force: true });
+    },
+  };
+}
+
+async function startIsolatedDaemon(entry, env, reservation, logPath) {
+  const daemonSocketPath = reservation.socketPath;
   let child = null;
   let logError = null;
   let terminationPromise = null;
-  let rejectLogFailure;
+  let rejectLogFailure = () => undefined;
   const logFailure = new Promise((_, reject) => {
     rejectLogFailure = reject;
   });
@@ -442,7 +465,7 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
   child.stdout.pipe(log, { end: false });
   child.stderr.pipe(log, { end: false });
   let earlyExit = null;
-  let rejectSpawnFailure;
+  let rejectSpawnFailure = () => undefined;
   const spawnFailure = new Promise((_, reject) => {
     rejectSpawnFailure = reject;
   });
@@ -450,6 +473,11 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
   child.once("error", onSpawnError);
   child.once("exit", (code, signal) => {
     earlyExit = { code, signal };
+    rejectSpawnFailure(
+      new Error(
+        `isolated daemon exited before readiness: ${JSON.stringify(earlyExit)}`,
+      ),
+    );
   });
   const socketWait = waitForSocket(daemonSocketPath);
   try {
@@ -468,7 +496,7 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
     terminationPromise ??= terminateChild(child);
     await terminationPromise;
     log.end();
-    await rm(daemonSocketPath, { force: true });
+    await reservation.release();
     throw error;
   }
   return {
@@ -480,7 +508,7 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
       terminationPromise ??= terminateChild(child);
       await terminationPromise;
       log.end();
-      await rm(daemonSocketPath, { force: true });
+      await reservation.release();
       if (logError) throw logError;
     },
   };
@@ -719,10 +747,13 @@ async function main() {
   }
   await mkdir(dirname(config.out), { recursive: true });
   const logPath = `${config.out}.daemon.log`;
+  const socketReservation = await createSocketReservation(
+    isolation.daemonSocketPath,
+  );
   const env = stringEnv({
     ...process.env,
     CMUX_SOCKET_PATH: isolation.cmuxSocketPath,
-    CMUXLAYER_DAEMON_SOCKET: isolation.daemonSocketPath,
+    CMUXLAYER_DAEMON_SOCKET: socketReservation.socketPath,
     CMUXLAYER_DEV: "1",
   });
   const rows = buildBenchmarkRows({
@@ -733,12 +764,18 @@ async function main() {
     clients: config.clients,
   });
   const startedAt = new Date().toISOString();
-  const daemon = await startIsolatedDaemon(
-    config.daemonEntry,
-    env,
-    isolation.daemonSocketPath,
-    logPath,
-  );
+  let daemon;
+  try {
+    daemon = await startIsolatedDaemon(
+      config.daemonEntry,
+      env,
+      socketReservation,
+      logPath,
+    );
+  } catch (error) {
+    await socketReservation.release();
+    throw error;
+  }
   const mcpClients = [];
   const results = [];
   let fixture = null;
@@ -834,7 +871,8 @@ async function main() {
     ),
     environment: {
       cmux_socket_path: isolation.cmuxSocketPath,
-      daemon_socket_path: isolation.daemonSocketPath,
+      requested_daemon_socket_path: isolation.daemonSocketPath,
+      daemon_socket_path: socketReservation.socketPath,
       isolated_daemon_pid: daemon.pid,
       daemon_log: logPath,
       controller_surface: config.surface,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -608,33 +608,84 @@ export async function createSocketReservation(requestedPath) {
 export async function createOutputReservation(outputPath) {
   const canonicalOutput = resolve(outputPath);
   const lockPath = `${canonicalOutput}.lock`;
-  await mkdir(dirname(canonicalOutput), { recursive: true });
-  const handle = await open(lockPath, "wx", 0o600).catch((error) => {
-    if (error?.code === "EEXIST") {
-      throw new Error(
-        `benchmark output is already reserved by another run: ${canonicalOutput}`,
-      );
-    }
-    throw error;
-  });
-  try {
-    await handle.writeFile(`${process.pid}\n`, "utf8");
-  } catch (error) {
-    await handle.close().catch(() => undefined);
-    await rm(lockPath, { force: true }).catch(() => undefined);
-    throw error;
-  }
-  let released = false;
-  return {
+  const reservation = await createPidLock(
+    lockPath,
+    `benchmark output ${canonicalOutput}`,
+  );
+  return Object.freeze({
     outputPath: canonicalOutput,
     lockPath,
-    async release() {
-      if (released) return;
-      released = true;
-      await handle.close();
-      await rm(lockPath, { force: false });
-    },
-  };
+    release: reservation.release,
+  });
+}
+
+function processIsLive(pid, signalPid = process.kill) {
+  try {
+    signalPid(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function createPidLock(lockPath, label, signalPid = process.kill) {
+  await mkdir(dirname(lockPath), { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const opened = await open(lockPath, "wx", 0o600).then(
+      (handle) => ({ handle, error: null }),
+      (error) => ({ handle: null, error }),
+    );
+    if (opened.error) {
+      const error = opened.error;
+      if (error?.code !== "EEXIST") throw error;
+      const ownerText = await readFile(lockPath, "utf8").catch(() => "");
+      const ownerPid = Number.parseInt(ownerText.trim(), 10);
+      if (!Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
+        throw new Error(`${label} has an unreadable owner lock: ${lockPath}`);
+      }
+      if (processIsLive(ownerPid, signalPid)) {
+        throw new Error(`${label} is already reserved by pid ${ownerPid}`);
+      }
+      await rm(lockPath, { force: true });
+      continue;
+    }
+    const handle = opened.handle;
+    try {
+      await handle.writeFile(`${process.pid}\n`, "utf8");
+    } catch (error) {
+      await handle.close().catch(() => undefined);
+      await rm(lockPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+    let released = false;
+    return {
+      lockPath,
+      async release() {
+        if (released) return;
+        released = true;
+        await handle.close();
+        await rm(lockPath, { force: false });
+      },
+    };
+  }
+  throw new Error(`${label} lock reclamation raced with another run`);
+}
+
+export async function createWorkspaceReservation(
+  cmuxSocketPath,
+  workspace,
+  lockRoot = "/tmp",
+) {
+  const key = createHash("sha256")
+    .update(`${resolve(cmuxSocketPath)}\0${workspace}`)
+    .digest("hex")
+    .slice(0, 24);
+  const lockPath = join(lockRoot, `cmuxlayer-bench-workspace-${key}.lock`);
+  return createPidLock(
+    lockPath,
+    `Nightly workspace ${workspace} on ${cmuxSocketPath}`,
+  );
 }
 
 async function endWritable(log) {
@@ -715,6 +766,7 @@ export function buildIsolatedRuntimeEnv(baseEnv, reservation, cmuxSocketPath) {
     CMUXLAYER_SESSION_REGISTRY: join(root, "session-registry.jsonl"),
     CMUXLAYER_SEAT_REGISTRY_PATH: join(root, "seat-registry.json"),
     CMUXLAYER_LAUNCHER_REGISTRY_PATH: join(root, "launcher-registry.json"),
+    CMUXLAYER_DAEMON_PID_RECEIPT: join(root, "unexpected-daemon-pids.txt"),
     CMUXLAYER_FLEET_SIDEBAR_OUTPUT_PATH: join(root, "fleet-sidebar.swift"),
     CMUXLAYER_HARNESS_HOME: join(root, "harness"),
     CMUXLAYER_DEV: "1",
@@ -750,6 +802,58 @@ export function assertOwnedDaemonHealthy(child, logError = null) {
   }
 }
 
+async function readRecordedDaemonPids(path) {
+  const text = await readFile(path, "utf8").catch((error) => {
+    if (error?.code === "ENOENT") return "";
+    throw error;
+  });
+  return [...new Set(text.split(/\s+/).filter(Boolean).map(Number))].filter(
+    (pid) => Number.isSafeInteger(pid) && pid > 0,
+  );
+}
+
+export async function assertNoUnexpectedDaemons(path, ownedPid) {
+  const unexpected = (await readRecordedDaemonPids(path)).filter(
+    (pid) => pid !== ownedPid,
+  );
+  if (unexpected.length > 0) {
+    throw new Error(
+      `MCP client autostarted unowned daemon pid(s): ${unexpected.join(",")}`,
+    );
+  }
+}
+
+export async function terminateUnexpectedDaemons(
+  path,
+  ownedPid,
+  signalPid = process.kill,
+  pause = (ms) => new Promise((resolvePause) => setTimeout(resolvePause, ms)),
+) {
+  const unexpected = (await readRecordedDaemonPids(path)).filter(
+    (pid) => pid !== ownedPid,
+  );
+  const failures = [];
+  for (const pid of unexpected) {
+    try {
+      if (!processIsLive(pid, signalPid)) continue;
+      signalPid(pid, "SIGTERM");
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (!processIsLive(pid, signalPid)) break;
+        await pause(25);
+      }
+      if (processIsLive(pid, signalPid)) signalPid(pid, "SIGKILL");
+      if (processIsLive(pid, signalPid)) {
+        throw new Error(`unowned daemon pid ${pid} survived SIGKILL`);
+      }
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "unowned daemon cleanup failed");
+  }
+}
+
 export function appendSettledFailures(current, results, phase) {
   let combined = current;
   for (const result of results) {
@@ -762,6 +866,7 @@ export function appendSettledFailures(current, results, phase) {
 
 async function startIsolatedDaemon(entry, env, reservation, logPath) {
   const daemonSocketPath = reservation.socketPath;
+  const daemonPidReceipt = env.CMUXLAYER_DAEMON_PID_RECEIPT;
   let child = null;
   let logError = null;
   let terminationPromise = null;
@@ -846,11 +951,18 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
   }
   return {
     pid: child.pid,
-    assertHealthy() {
+    async assertHealthy() {
       assertOwnedDaemonHealthy(child, logError);
+      await assertNoUnexpectedDaemons(daemonPidReceipt, child.pid);
     },
     async stop() {
       let cleanupError = null;
+      let unexpectedDaemonError = null;
+      try {
+        await terminateUnexpectedDaemons(daemonPidReceipt, child.pid);
+      } catch (error) {
+        unexpectedDaemonError = error;
+      }
       try {
         await cleanupDaemonResources({
           child,
@@ -864,7 +976,7 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
       } catch (error) {
         cleanupError = error;
       }
-      const failures = [cleanupError, logError].filter(
+      const failures = [unexpectedDaemonError, cleanupError, logError].filter(
         (failure, index, all) => failure && all.indexOf(failure) === index,
       );
       if (failures.length > 0) {
@@ -1379,6 +1491,27 @@ Options:
   --out <path>                   JSON receipt path
 `;
 
+export function installGracefulSignalAbort(
+  controller,
+  processLike = process,
+) {
+  const handlers = new Map();
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    const handler = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(new Error(`benchmark interrupted by ${signal}`));
+      }
+    };
+    handlers.set(signal, handler);
+    processLike.on(signal, handler);
+  }
+  return () => {
+    for (const [signal, handler] of handlers) {
+      processLike.off(signal, handler);
+    }
+  };
+}
+
 async function main() {
   const config = parseConfig(process.argv.slice(2), process.env);
   if (config.help) {
@@ -1391,19 +1524,36 @@ async function main() {
       "surface and workspace are required; run inside the Nightly terminal or pass --surface/--workspace",
     );
   }
-  const outputReservation = await createOutputReservation(config.out);
+  const abortController = new AbortController();
+  const removeSignalHandlers = installGracefulSignalAbort(abortController);
   try {
-    await executeBenchmark(config, isolation);
+    const workspaceReservation = await createWorkspaceReservation(
+      isolation.cmuxSocketPath,
+      config.workspace,
+    );
+    try {
+      abortController.signal.throwIfAborted();
+      const outputReservation = await createOutputReservation(config.out);
+      try {
+        abortController.signal.throwIfAborted();
+        await executeBenchmark(config, isolation, abortController.signal);
+      } finally {
+        await outputReservation.release();
+      }
+    } finally {
+      await workspaceReservation.release();
+    }
   } finally {
-    await outputReservation.release();
+    removeSignalHandlers();
   }
 }
 
-async function executeBenchmark(config, isolation) {
+async function executeBenchmark(config, isolation, abortSignal) {
   const artifactProvenance = await prepareBuiltEntries({
     ...config,
     env: process.env,
   });
+  abortSignal.throwIfAborted();
   const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);
   if (!nightlySocket?.isSocket()) {
     throw new Error(`nightly socket is not live: ${isolation.cmuxSocketPath}`);
@@ -1437,6 +1587,7 @@ async function executeBenchmark(config, isolation) {
   let fixture = null;
   let fatalError = null;
   try {
+    abortSignal.throwIfAborted();
     const maxConcurrency = Math.max(1, ...rows.map((row) => row.concurrency));
     fixture = await createScratchTargets(maxConcurrency, {
       workspace: config.workspace,
@@ -1450,11 +1601,13 @@ async function executeBenchmark(config, isolation) {
         .map((row) => row.concurrency),
     );
     for (let index = 0; index < maxMcpConcurrency; index += 1) {
-      daemon.assertHealthy();
+      abortSignal.throwIfAborted();
+      await daemon.assertHealthy();
       mcpClients.push(await connectMcpClient(config.mcpEntry, env, index));
-      daemon.assertHealthy();
+      await daemon.assertHealthy();
+      abortSignal.throwIfAborted();
     }
-    daemon.assertHealthy();
+    await daemon.assertHealthy();
     await Promise.all(
       mcpClients.map((client) =>
         client.callTool(
@@ -1464,9 +1617,11 @@ async function executeBenchmark(config, isolation) {
         ),
       ),
     );
-    daemon.assertHealthy();
+    await daemon.assertHealthy();
+    abortSignal.throwIfAborted();
     for (const [index, row] of rows.entries()) {
-      daemon.assertHealthy();
+      abortSignal.throwIfAborted();
+      await daemon.assertHealthy();
       if (row.comparison_status === "NOT_COMPARABLE") {
         process.stderr.write(
           `[bench-e2e] row ${index + 1}/${rows.length} ${row.operation} c${row.concurrency} payload=${row.payload_chars ?? "-"} ${row.client} NOT_COMPARABLE\n`,
@@ -1511,7 +1666,8 @@ async function executeBenchmark(config, isolation) {
       });
       const result = markSurfaceTransportUntrusted(measured);
       results.push(result);
-      daemon.assertHealthy();
+      await daemon.assertHealthy();
+      abortSignal.throwIfAborted();
     }
   } catch (error) {
     fatalError = appendFatalError(fatalError, error, "benchmark");

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -492,18 +492,18 @@ export async function createSocketReservation(requestedPath) {
 async function endWritable(log) {
   if (log.writableFinished || log.closed || log.destroyed) return;
   await new Promise((resolvePromise, reject) => {
-    const cleanup = () => {
+    function cleanup() {
       log.off("finish", onFinish);
       log.off("error", onError);
-    };
-    const onFinish = () => {
+    }
+    function onFinish() {
       cleanup();
       resolvePromise();
-    };
-    const onError = (error) => {
+    }
+    function onError(error) {
       cleanup();
       reject(error);
-    };
+    }
     log.once("finish", onFinish);
     log.once("error", onError);
     log.end();
@@ -1071,7 +1071,7 @@ async function main() {
     clients: config.clients,
   });
   const startedAt = new Date().toISOString();
-  let daemon;
+  let daemon = null;
   try {
     daemon = await startIsolatedDaemon(
       config.daemonEntry,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -269,9 +269,17 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(value);
+    };
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
-      reject(
+      settle(
+        reject,
         new Error(
           `${command} ${args.join(" ")} timed out after ${timeoutMs}ms`,
         ),
@@ -284,42 +292,50 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
       stderr += chunk.toString("utf8");
     });
     child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
+      settle(reject, error);
     });
     child.once("close", (code, signal) => {
-      clearTimeout(timer);
       if (code !== 0) {
-        reject(
+        settle(
+          reject,
           new Error(
             `${command} ${args.join(" ")} exited code=${code} signal=${signal}: ${stderr.trim()}`,
           ),
         );
         return;
       }
-      resolvePromise({ stdout, stderr });
+      settle(resolvePromise, { stdout, stderr });
     });
   });
 }
 
 function waitForSocket(path, timeoutMs = 15_000) {
   const deadline = Date.now() + timeoutMs;
-  return new Promise((resolvePromise, reject) => {
+  let cancelled = false;
+  let retryTimer = null;
+  const promise = new Promise((resolvePromise, reject) => {
     const attempt = () => {
+      if (cancelled) return;
       const socket = net.createConnection({ path });
       let settled = false;
       const finish = (connected) => {
-        if (settled) return;
+        if (settled || cancelled) {
+          socket.removeAllListeners();
+          // Swallow destroy-time errors from a cancelled or already-finished probe.
+          socket.on("error", ignoreFollowOnError);
+          socket.destroy();
+          return;
+        }
         settled = true;
         socket.removeAllListeners();
-        socket.on("error", () => {});
+        socket.on("error", ignoreFollowOnError);
         socket.destroy();
         if (connected) {
           resolvePromise();
         } else if (Date.now() >= deadline) {
           reject(new Error(`timed out waiting for socket ${path}`));
         } else {
-          setTimeout(attempt, 50);
+          retryTimer = setTimeout(attempt, 50);
         }
       };
       socket.setTimeout(250, () => finish(false));
@@ -328,19 +344,31 @@ function waitForSocket(path, timeoutMs = 15_000) {
     };
     attempt();
   });
+  return {
+    promise,
+    cancel() {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    },
+  };
+}
+
+function ignoreFollowOnError() {
+  // Used for destroy-time socket errors and best-effort scratch teardown after
+  // a create failure so the original error remains the thrown cause.
 }
 
 export function openExclusiveWriteStream(path) {
   return new Promise((resolvePromise, reject) => {
     const stream = createWriteStream(path, { flags: "wx" });
-    const onOpen = () => {
+    function onOpen() {
       stream.off("error", onError);
       resolvePromise(stream);
-    };
-    const onError = (error) => {
+    }
+    function onError(error) {
       stream.off("open", onOpen);
       reject(error);
-    };
+    }
     stream.once("open", onOpen);
     stream.once("error", onError);
   });
@@ -361,7 +389,7 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
   child.stdout.pipe(log, { end: false });
   child.stderr.pipe(log, { end: false });
   let earlyExit = null;
-  let rejectSpawnFailure;
+  let rejectSpawnFailure = ignoreFollowOnError;
   const spawnFailure = new Promise((_, reject) => {
     rejectSpawnFailure = reject;
   });
@@ -370,8 +398,9 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
   child.once("exit", (code, signal) => {
     earlyExit = { code, signal };
   });
+  const socketWait = waitForSocket(daemonSocketPath);
   try {
-    await Promise.race([waitForSocket(daemonSocketPath), spawnFailure]);
+    await Promise.race([socketWait.promise, spawnFailure]);
     child.off("error", onSpawnError);
     if (earlyExit) {
       throw new Error(
@@ -379,6 +408,7 @@ async function startIsolatedDaemon(entry, env, daemonSocketPath, logPath) {
       );
     }
   } catch (error) {
+    socketWait.cancel();
     child.off("error", onSpawnError);
     if (child.exitCode === null && child.signalCode === null) {
       child.kill("SIGTERM");
@@ -487,7 +517,7 @@ export async function createScratchTargets(count, deps) {
       anchor = surface;
     }
   } catch (error) {
-    await closeRecorded().catch(() => {});
+    await closeRecorded().catch(ignoreFollowOnError);
     throw error;
   }
   return { targets: Object.freeze([...targets]), close: closeRecorded };
@@ -509,30 +539,39 @@ export function operationArgs(row, surface, workspace, worker, sample) {
   return { workspace, verbose: false };
 }
 
-async function runCliOperation(row, config, worker, sample) {
-  let args;
+export function cliOperationArgs(row, surface, workspace, worker, sample) {
   if (row.operation === "send_to") {
-    args = [
+    return [
       "send",
       "--workspace",
-      config.workspace,
+      workspace,
       "--surface",
-      config.surface,
-      `${payloadText(row.payload_chars, worker, sample)}\\n`,
+      surface,
+      `${payloadText(row.payload_chars, worker, sample)}\n`,
     ];
-  } else if (row.operation === "read_screen") {
-    args = [
+  }
+  if (row.operation === "read_screen") {
+    return [
       "read-screen",
       "--workspace",
-      config.workspace,
+      workspace,
       "--surface",
-      config.surface,
+      surface,
       "--lines",
       "20",
     ];
-  } else {
-    args = ["tree", "--workspace", config.workspace];
   }
+  return ["list-workspaces"];
+}
+
+async function runCliOperation(row, config, worker, sample) {
+  const args = cliOperationArgs(
+    row,
+    config.surface,
+    config.workspace,
+    worker,
+    sample,
+  );
   await execCapture(config.cmuxBin, args, { env: config.env });
   return { ok: true, transport: "cli", transport_fallbacks: [] };
 }

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -80,7 +80,11 @@ export function buildBenchmarkRows({
       `samplesPerWorker must be at least 12, got ${samplesPerWorker}`,
     );
   }
-  const allowedOperations = new Set(["send_to", "read_screen", "list_surfaces"]);
+  const allowedOperations = new Set([
+    "send_to",
+    "read_screen",
+    "list_surfaces",
+  ]);
   const allowedClients = new Set(["mcp", "cli"]);
   for (const operation of operations) {
     if (!allowedOperations.has(operation)) {
@@ -166,7 +170,8 @@ export function markSurfaceTransportUntrusted(row) {
 }
 
 export async function runBenchmarkRow(row, deps) {
-  const nowMs = deps.nowMs ?? (() => Number(process.hrtime.bigint()) / 1_000_000);
+  const nowMs =
+    deps.nowMs ?? (() => Number(process.hrtime.bigint()) / 1_000_000);
   const workerRuns = Array.from({ length: row.concurrency }, (_, worker) =>
     (async () => {
       const samples = [];
@@ -321,25 +326,27 @@ function execCapture(command, args, { env, timeoutMs = 30_000 } = {}) {
 }
 
 export async function terminateChild(child, graceMs = 5_000) {
-  if (child.exitCode !== null || child.signalCode !== null) return;
   const isLive = () => child.exitCode === null && child.signalCode === null;
+  const streamsClosed = () =>
+    [child.stdout, child.stderr]
+      .filter(Boolean)
+      .every((stream) => stream.closed || stream.destroyed);
   let resolveFailure = () => undefined;
   const failurePromise = new Promise((resolveFailurePromise) => {
     resolveFailure = resolveFailurePromise;
   });
   const onError = (error) => resolveFailure({ kind: "error", error });
   child.on("error", onError);
-  let resolveExit = () => undefined;
-  const exitPromise = new Promise((resolveExitPromise) => {
-    resolveExit = resolveExitPromise;
+  let resolveClose = () => undefined;
+  const closePromise = new Promise((resolveClosePromise) => {
+    resolveClose = resolveClosePromise;
   });
-  const onExit = () => resolveExit({ kind: "exit" });
-  child.once("exit", onExit);
-  child.once("close", onExit);
+  const onClose = () => resolveClose({ kind: "close" });
+  child.once("close", onClose);
   const waitBounded = async () => {
     let timer = null;
     const outcome = await Promise.race([
-      exitPromise,
+      closePromise,
       failurePromise,
       new Promise((resolveTimeout) => {
         timer = setTimeout(() => resolveTimeout({ kind: "timeout" }), graceMs);
@@ -347,7 +354,7 @@ export async function terminateChild(child, graceMs = 5_000) {
     ]);
     clearTimeout(timer);
     if (outcome.kind === "error") throw outcome.error;
-    return outcome.kind === "exit";
+    return outcome.kind === "close";
   };
   const deliver = (signal) => {
     const delivered = child.kill(signal);
@@ -356,17 +363,30 @@ export async function terminateChild(child, graceMs = 5_000) {
     }
   };
   try {
+    if (!isLive()) {
+      if (streamsClosed() || (await waitBounded())) return;
+      throw new Error(
+        "child exited but stdio did not close within the bounded wait",
+      );
+    }
     deliver("SIGTERM");
     if (await waitBounded()) return;
-    if (!isLive()) return;
+    if (!isLive()) {
+      throw new Error(
+        "child exited but stdio did not close within the bounded wait",
+      );
+    }
     deliver("SIGKILL");
-    if (!(await waitBounded()) && isLive()) {
-      throw new Error("child did not exit after SIGKILL within the bounded wait");
+    if (!(await waitBounded())) {
+      throw new Error(
+        isLive()
+          ? "child did not exit after SIGKILL within the bounded wait"
+          : "child exited after SIGKILL but stdio did not close within the bounded wait",
+      );
     }
   } finally {
     child.off("error", onError);
-    child.off("exit", onExit);
-    child.off("close", onExit);
+    child.off("close", onClose);
   }
 }
 
@@ -454,6 +474,7 @@ export async function createSocketReservation(requestedPath) {
       `isolated daemon socket already exists; refusing to reuse an unowned path: ${requestedPath}`,
     );
   }
+  await mkdir(dirname(requestedPath), { recursive: true });
   const ownerDirectory = await mkdtemp(`${requestedPath}.owner-`);
   const socketPath = join(ownerDirectory, "daemon.sock");
   let released = false;
@@ -468,7 +489,61 @@ export async function createSocketReservation(requestedPath) {
   };
 }
 
-export function daemonLogPath(receiptPath, pid = process.pid, now = Date.now()) {
+async function endWritable(log) {
+  if (log.writableFinished || log.closed || log.destroyed) return;
+  await new Promise((resolvePromise, reject) => {
+    const cleanup = () => {
+      log.off("finish", onFinish);
+      log.off("error", onError);
+    };
+    const onFinish = () => {
+      cleanup();
+      resolvePromise();
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    log.once("finish", onFinish);
+    log.once("error", onError);
+    log.end();
+  });
+}
+
+export async function cleanupDaemonResources({
+  child,
+  log,
+  reservation,
+  terminate = terminateChild,
+}) {
+  const errors = [];
+  try {
+    await terminate(child);
+  } catch (error) {
+    errors.push(error);
+  }
+  child.stdout?.unpipe?.(log);
+  child.stderr?.unpipe?.(log);
+  try {
+    await endWritable(log);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await reservation.release();
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "isolated daemon cleanup failed");
+  }
+}
+
+export function daemonLogPath(
+  receiptPath,
+  pid = process.pid,
+  now = Date.now(),
+) {
   return `${receiptPath}.daemon-${pid}-${now}.log`;
 }
 
@@ -566,11 +641,30 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
     child.off("exit", onEarlyExit);
     spawnFailure.catch(() => undefined);
     logFailure.catch(() => undefined);
-    terminationPromise ??= terminateChild(child);
-    await terminationPromise;
-    log.end();
-    await reservation.release();
-    throw error;
+    let cleanupError = null;
+    try {
+      await cleanupDaemonResources({
+        child,
+        log,
+        reservation,
+        terminate: () => {
+          terminationPromise ??= terminateChild(child);
+          return terminationPromise;
+        },
+      });
+    } catch (caught) {
+      cleanupError = caught;
+    }
+    const failures = [error, cleanupError, logError].filter(
+      (failure, index, all) => failure && all.indexOf(failure) === index,
+    );
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        "isolated daemon startup and cleanup failed",
+      );
+    }
+    throw failures[0];
   }
   return {
     pid: child.pid,
@@ -578,11 +672,26 @@ async function startIsolatedDaemon(entry, env, reservation, logPath) {
       if (logError) throw logError;
     },
     async stop() {
-      terminationPromise ??= terminateChild(child);
-      await terminationPromise;
-      log.end();
-      await reservation.release();
-      if (logError) throw logError;
+      let cleanupError = null;
+      try {
+        await cleanupDaemonResources({
+          child,
+          log,
+          reservation,
+          terminate: () => {
+            terminationPromise ??= terminateChild(child);
+            return terminationPromise;
+          },
+        });
+      } catch (error) {
+        cleanupError = error;
+      }
+      const failures = [cleanupError, logError].filter(
+        (failure, index, all) => failure && all.indexOf(failure) === index,
+      );
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "isolated daemon stop failed");
+      }
     },
   };
 }
@@ -606,7 +715,10 @@ async function connectMcpClient(entry, env, label) {
     env: stringEnv(env),
     stderr: "inherit",
   });
-  const client = new Client({ name: `cmuxlayer-bench-e2e-${label}`, version: "1" });
+  const client = new Client({
+    name: `cmuxlayer-bench-e2e-${label}`,
+    version: "1",
+  });
   await client.connect(transport);
   return client;
 }
@@ -724,7 +836,15 @@ export function cliArgs(row, config, worker, sample) {
       "20",
     ];
   }
-  return [...CMUX_JSON_PREFIX, "list-workspaces"];
+  return listWindowsCliArgs();
+}
+
+export function listWindowsCliArgs() {
+  return [...CMUX_JSON_PREFIX, "list-windows"];
+}
+
+export function listWorkspacesCliArgs(window) {
+  return [...CMUX_JSON_PREFIX, "list-workspaces", "--window", window];
 }
 
 export function listPanesCliArgs(workspace) {
@@ -743,31 +863,85 @@ export function listPaneSurfacesCliArgs(workspace, pane) {
 }
 
 export function paneRefsFromListPanesStdout(stdout) {
-  let parsed;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    throw new Error(
-      `cmux list-panes returned non-JSON: ${JSON.stringify(stdout.trim())}`,
-    );
-  }
-  const panes = isRecord(parsed) && Array.isArray(parsed.panes) ? parsed.panes : [];
+  const parsed = parseCliJson(stdout, "list-panes");
+  const panes =
+    isRecord(parsed) && Array.isArray(parsed.panes) ? parsed.panes : [];
   return panes
     .map((pane) => (isRecord(pane) ? nonEmptyString(pane.ref) : null))
     .filter((ref) => ref !== null);
 }
 
-async function runCliListSurfaces(config) {
-  await execCapture(config.cmuxBin, cliArgs({ operation: "list_surfaces" }, config), {
-    env: config.env,
-  });
-  const panesOut = await execCapture(
+function parseCliJson(stdout, operation) {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `cmux ${operation} returned non-JSON: ${JSON.stringify(stdout.trim())}`,
+    );
+  }
+}
+
+async function enumerateCliWorkspaces(config, exec = execCapture) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const windowsOut = await exec(config.cmuxBin, listWindowsCliArgs(), {
+      env: config.env,
+    });
+    const parsedWindows = parseCliJson(windowsOut.stdout, "list-windows");
+    const windows = Array.isArray(parsedWindows)
+      ? parsedWindows
+      : isRecord(parsedWindows) && Array.isArray(parsedWindows.windows)
+        ? parsedWindows.windows
+        : null;
+    if (!windows) throw new Error("cmux list-windows returned malformed JSON");
+    let complete = windows.length > 0;
+    const workspaceLists = await Promise.all(
+      windows.map(async (window) => {
+        const target = isRecord(window)
+          ? (nonEmptyString(window.ref) ?? nonEmptyString(window.id))
+          : null;
+        if (!target) {
+          complete = false;
+          return [];
+        }
+        const output = await exec(
+          config.cmuxBin,
+          listWorkspacesCliArgs(target),
+          { env: config.env },
+        );
+        const parsed = parseCliJson(output.stdout, "list-workspaces");
+        if (!isRecord(parsed) || !Array.isArray(parsed.workspaces)) {
+          throw new Error(
+            `cmux list-workspaces returned malformed JSON for ${target}`,
+          );
+        }
+        const expected =
+          typeof window.workspace_count === "number"
+            ? window.workspace_count
+            : null;
+        if (
+          expected === null
+            ? parsed.workspaces.length === 0
+            : parsed.workspaces.length !== expected
+        ) {
+          complete = false;
+        }
+        return parsed.workspaces;
+      }),
+    );
+    if (complete) return workspaceLists.flat();
+  }
+  throw new Error("incomplete all-window workspace enumeration after retry");
+}
+
+export async function runCliListSurfaces(config, exec = execCapture) {
+  await enumerateCliWorkspaces(config, exec);
+  const panesOut = await exec(
     config.cmuxBin,
     listPanesCliArgs(config.workspace),
     { env: config.env },
   );
   for (const pane of paneRefsFromListPanesStdout(panesOut.stdout)) {
-    await execCapture(
+    await exec(
       config.cmuxBin,
       listPaneSurfacesCliArgs(config.workspace, pane),
       { env: config.env },
@@ -822,14 +996,20 @@ function parseConfig(argv, env) {
     help: false,
     samplesPerWorker,
     concurrency: listArg(namedArg(argv, "--concurrency"), DEFAULT_CONCURRENCY),
-    payloadSizes: listArg(namedArg(argv, "--payload-sizes"), DEFAULT_PAYLOAD_SIZES),
+    payloadSizes: listArg(
+      namedArg(argv, "--payload-sizes"),
+      DEFAULT_PAYLOAD_SIZES,
+    ),
     operations,
     clients,
     out,
     surface: namedArg(argv, "--surface") ?? nonEmptyString(env.CMUX_SURFACE_ID),
-    workspace: namedArg(argv, "--workspace") ?? nonEmptyString(env.CMUX_WORKSPACE_ID),
+    workspace:
+      namedArg(argv, "--workspace") ?? nonEmptyString(env.CMUX_WORKSPACE_ID),
     cmuxBin: namedArg(argv, "--cmux-bin") ?? "cmux",
-    mcpEntry: resolve(namedArg(argv, "--mcp-entry") ?? join(repoRoot, "dist", "index.js")),
+    mcpEntry: resolve(
+      namedArg(argv, "--mcp-entry") ?? join(repoRoot, "dist", "index.js"),
+    ),
     daemonEntry: resolve(
       namedArg(argv, "--daemon-entry") ?? join(repoRoot, "dist", "daemon.js"),
     ),
@@ -866,7 +1046,8 @@ async function main() {
     );
   }
   for (const path of [config.mcpEntry, config.daemonEntry]) {
-    if (!existsSync(path)) throw new Error(`built entry does not exist: ${path}`);
+    if (!existsSync(path))
+      throw new Error(`built entry does not exist: ${path}`);
   }
   const nightlySocket = await stat(isolation.cmuxSocketPath).catch(() => null);
   if (!nightlySocket?.isSocket()) {
@@ -915,7 +1096,9 @@ async function main() {
     });
     const maxMcpConcurrency = Math.max(
       0,
-      ...rows.filter((row) => row.client === "mcp").map((row) => row.concurrency),
+      ...rows
+        .filter((row) => row.client === "mcp")
+        .map((row) => row.concurrency),
     );
     for (let index = 0; index < maxMcpConcurrency; index += 1) {
       mcpClients.push(await connectMcpClient(config.mcpEntry, env, index));
@@ -1062,7 +1245,7 @@ async function main() {
 if (resolve(process.argv[1] ?? "") === scriptPath) {
   main().catch((error) => {
     process.stderr.write(
-      `[bench-e2e] fatal ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+      `[bench-e2e] fatal ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
     );
     process.exitCode = 1;
   });

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
@@ -8,6 +8,7 @@ import {
   buildBenchmarkRows,
   cliArgs,
   createScratchTargets,
+  createSocketReservation,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
   operationArgs,
@@ -320,4 +321,24 @@ describe("bench-e2e measurement harness", () => {
     await expect(wait.promise).rejects.toBe(reason);
   });
 
+  it("reserves an owner-only directory for the isolated daemon socket", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const requestedPath = join(directory, "run10-nightly.sock");
+    try {
+      const reservation = await createSocketReservation(requestedPath);
+
+      expect(reservation.socketPath).not.toBe(requestedPath);
+      expect(
+        reservation.socketPath.startsWith(`${requestedPath}.owner-`),
+      ).toBe(true);
+      expect(reservation.socketPath.endsWith("/daemon.sock")).toBe(true);
+
+      await reservation.release();
+      await expect(stat(reservation.ownerDirectory)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "node:events";
 import {
   assertNightlyIsolation,
   buildBenchmarkRows,
+  buildRowsAndReserve,
   buildIsolatedRuntimeEnv,
   cliArgs,
   cleanupDaemonResources,
@@ -25,6 +26,8 @@ import {
   paneRefsFromListPanesStdout,
   payloadText,
   readGitHead,
+  prepareBuiltEntries,
+  runCliReadScreen,
   runCliListSurfaces,
   runBenchmarkRow,
   summarizeTransport,
@@ -98,6 +101,62 @@ describe("bench-e2e measurement harness", () => {
     }
     expect(result.sample_count).toBe(60);
     expect(result.p95_ms).toBeGreaterThan(result.p50_ms);
+  });
+
+  it("computes latency percentiles from successful operations only", async () => {
+    let clock = 0;
+    const result = await runBenchmarkRow(
+      {
+        operation: "send_to",
+        client: "mcp",
+        concurrency: 1,
+        payload_chars: 520,
+        samples_per_worker: 12,
+      },
+      {
+        nowMs: () => clock,
+        runOperation: ({ sample }) => {
+          clock += sample < 6 ? 1 : 100;
+          return {
+            ok: sample >= 6,
+            transport: "socket",
+            transport_fallbacks: [],
+          };
+        },
+      },
+    );
+
+    expect(result.error_count).toBe(6);
+    expect(result.p50_ms).toBe(100);
+    expect(result.p95_ms).toBe(100);
+  });
+
+  it("uses null percentiles when a row has no successful operations", async () => {
+    let clock = 0;
+    const result = await runBenchmarkRow(
+      {
+        operation: "send_to",
+        client: "mcp",
+        concurrency: 1,
+        payload_chars: 900,
+        samples_per_worker: 12,
+      },
+      {
+        nowMs: () => clock,
+        runOperation: () => {
+          clock += 3;
+          return {
+            ok: false,
+            transport: "cli",
+            transport_fallbacks: ["paste_text"],
+          };
+        },
+      },
+    );
+
+    expect(result.error_count).toBe(12);
+    expect(result.p50_ms).toBeNull();
+    expect(result.p95_ms).toBeNull();
   });
 
   it("counts transport and every fallback from the raw samples", () => {
@@ -305,6 +364,70 @@ describe("bench-e2e measurement harness", () => {
     ]);
   });
 
+  it("adds the MCP topology workload to direct CLI read_screen samples", async () => {
+    const calls: string[][] = [];
+    const outputs = [
+      "screen contents",
+      JSON.stringify({
+        windows: [{ ref: "window:1", workspace_count: 2 }],
+      }),
+      JSON.stringify({
+        workspaces: [{ ref: "workspace:7" }, { ref: "workspace:8" }],
+      }),
+      JSON.stringify({
+        workspace_ref: "workspace:7",
+        panes: [{ ref: "pane:1" }],
+      }),
+      JSON.stringify({
+        workspace_ref: "workspace:7",
+        pane_ref: "pane:1",
+        surfaces: [],
+      }),
+      JSON.stringify({
+        workspace_ref: "workspace:8",
+        panes: [{ ref: "pane:2" }],
+      }),
+      JSON.stringify({
+        workspace_ref: "workspace:8",
+        pane_ref: "pane:2",
+        surfaces: [],
+      }),
+    ];
+
+    await runCliReadScreen(
+      {
+        workspace: "workspace:7",
+        surface: "surface:21",
+        cmuxBin: "/opt/cmux",
+        env: {},
+      },
+      0,
+      0,
+      (_command, args) => {
+        calls.push(args);
+        return { stdout: outputs.shift() ?? "", stderr: "" };
+      },
+    );
+
+    expect(calls).toEqual([
+      [
+        "read-screen",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:21",
+        "--lines",
+        "20",
+      ],
+      listWindowsCliArgs(),
+      listWorkspacesCliArgs("window:1"),
+      listPanesCliArgs("workspace:7"),
+      listPaneSurfacesCliArgs("workspace:7", "pane:1"),
+      listPanesCliArgs("workspace:8"),
+      listPaneSurfacesCliArgs("workspace:8", "pane:2"),
+    ]);
+  });
+
   it("retries an incomplete all-window CLI enumeration once", async () => {
     const calls: string[][] = [];
     const outputs = [
@@ -480,27 +603,25 @@ describe("bench-e2e measurement harness", () => {
   });
 
   it("rejects when an unresponsive child survives the bounded KILL wait", async () => {
-    class ImmortalChild extends EventEmitter {
-      exitCode = null;
-      signalCode = null;
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      signalCode: null,
+      kill: () => true,
+    });
 
-      kill = () => true;
-    }
-
-    await expect(terminateChild(new ImmortalChild(), 0)).rejects.toThrow(
+    await expect(terminateChild(child, 0)).rejects.toThrow(
       /did not exit after SIGKILL/,
     );
   });
 
   it("rejects when child signal delivery fails", async () => {
-    class UnsignallableChild extends EventEmitter {
-      exitCode = null;
-      signalCode = null;
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null,
+      signalCode: null,
+      kill: () => false,
+    });
 
-      kill = () => false;
-    }
-
-    await expect(terminateChild(new UnsignallableChild(), 0)).rejects.toThrow(
+    await expect(terminateChild(child, 0)).rejects.toThrow(
       /failed to deliver SIGTERM/,
     );
   });
@@ -594,6 +715,122 @@ describe("bench-e2e measurement harness", () => {
       "/tmp/run10.sock.owner-abc/",
     );
     expect(env.HOME).not.toBe("/opt/example-home");
+    expect(env).not.toHaveProperty("CMUXLAYER_FORCE_INPROCESS");
+    expect(env).not.toHaveProperty("CMUXLAYER_DEFAULT_PALETTE");
+  });
+
+  it("clears inherited MCP routing overrides from the isolated runtime", () => {
+    const env = buildIsolatedRuntimeEnv(
+      {
+        PATH: "/usr/bin",
+        CMUXLAYER_FORCE_INPROCESS: "1",
+        CMUXLAYER_DEFAULT_PALETTE: "list_surfaces",
+      },
+      {
+        ownerDirectory: "/tmp/run10.sock.owner-abc",
+        socketPath: "/tmp/run10.sock.owner-abc/daemon.sock",
+      },
+      "/tmp/cmux-nightly.sock",
+    );
+
+    expect(env.CMUXLAYER_DAEMON_SOCKET).toContain("/tmp/run10.sock.owner-abc/");
+    expect(env).not.toHaveProperty("CMUXLAYER_FORCE_INPROCESS");
+    expect(env).not.toHaveProperty("CMUXLAYER_DEFAULT_PALETTE");
+  });
+
+  it("validates rows before reserving daemon resources", async () => {
+    let reservationCalls = 0;
+
+    await expect(
+      buildRowsAndReserve(
+        {
+          concurrency: [1],
+          payloadSizes: [520],
+          samplesPerWorker: 1,
+          operations: ["send_to"],
+          clients: ["mcp"],
+        },
+        "/tmp/cmuxlayer-run10-nightly.sock",
+        async () => {
+          reservationCalls += 1;
+          throw new Error("must not reserve");
+        },
+      ),
+    ).rejects.toThrow(/at least 12/);
+    expect(reservationCalls).toBe(0);
+  });
+
+  it("builds default entries from a clean recorded revision", async () => {
+    const calls: string[] = [];
+    const result = await prepareBuiltEntries(
+      {
+        mcpEntry: "/repo/dist/index.js",
+        daemonEntry: "/repo/dist/daemon.js",
+      },
+      {
+        repoRoot: "/repo",
+        exec: (_command, args) => {
+          calls.push(args.join(" "));
+          if (args[0] === "status") return { stdout: "", stderr: "" };
+          if (args[0] === "rev-parse") {
+            return { stdout: "abc123\n", stderr: "" };
+          }
+          return { stdout: "built\n", stderr: "" };
+        },
+        exists: () => true,
+        hashFile: (path) => `sha256:${path}`,
+      },
+    );
+
+    expect(calls).toEqual([
+      "status --porcelain --untracked-files=no",
+      "rev-parse HEAD",
+      "run build",
+      "status --porcelain --untracked-files=no",
+      "rev-parse HEAD",
+    ]);
+    expect(result).toEqual({
+      git_head: "abc123",
+      entries: {
+        mcp: {
+          path: "/repo/dist/index.js",
+          sha256: "sha256:/repo/dist/index.js",
+        },
+        daemon: {
+          path: "/repo/dist/daemon.js",
+          sha256: "sha256:/repo/dist/daemon.js",
+        },
+      },
+    });
+  });
+
+  it("rejects built entry provenance when HEAD changes during the build", async () => {
+    let headReads = 0;
+
+    await expect(
+      prepareBuiltEntries(
+        {
+          mcpEntry: "/repo/dist/index.js",
+          daemonEntry: "/repo/dist/daemon.js",
+        },
+        {
+          repoRoot: "/repo",
+          exec: (_command, args) => {
+            if (args[0] === "status") return { stdout: "", stderr: "" };
+            if (args[0] === "rev-parse") {
+              headReads += 1;
+              return {
+                stdout: headReads === 1 ? "abc123\n" : "def456\n",
+                stderr: "",
+              };
+            }
+            return { stdout: "built\n", stderr: "" };
+          },
+          exists: () => true,
+          hashFile: () => "unused",
+        },
+      ),
+    ).rejects.toThrow(/revision changed during build/);
   });
 
   it("preserves primary, scratch, and daemon cleanup failures", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -14,6 +14,7 @@ import {
   cliArgs,
   cleanupDaemonResources,
   createScratchTargets,
+  createOutputReservation,
   createSocketReservation,
   daemonLogPath,
   FAIRNESS_CONTRACTS,
@@ -915,6 +916,22 @@ describe("bench-e2e measurement harness", () => {
     expect(daemonLogPath("/tmp/bench.json", 42, 1234)).toBe(
       "/tmp/bench.json.daemon-42-1234.log",
     );
+  });
+
+  it("atomically excludes overlapping runs that share an output receipt", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const output = join(directory, "receipt.json");
+    const first = await createOutputReservation(output);
+    try {
+      await expect(createOutputReservation(output)).rejects.toThrow(
+        /output is already reserved/,
+      );
+    } finally {
+      await first.release();
+    }
+    const afterRelease = await createOutputReservation(output);
+    await afterRelease.release();
+    await rm(directory, { recursive: true, force: true });
   });
 
   it("moves daemon socket, monitor, watch, and state paths under the owned run directory", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1081,12 +1081,13 @@ describe("bench-e2e measurement harness", () => {
           directory,
         ),
       ).rejects.toThrow(/already reserved/);
-      const otherWorkspace = await createWorkspaceReservation(
-        "/tmp/cmux-nightly.sock",
-        "workspace:8",
-        directory,
-      );
-      await otherWorkspace.release();
+      await expect(
+        createWorkspaceReservation(
+          "/tmp/cmux-nightly.sock",
+          "workspace:8",
+          directory,
+        ),
+      ).rejects.toThrow(/already reserved/);
     } finally {
       await first.release();
       await rm(directory, { recursive: true, force: true });
@@ -1245,6 +1246,7 @@ describe("bench-e2e measurement harness", () => {
           "/repo/dist/index.js",
           "/repo/dist/server.js",
         ],
+        resolveExecutable: () => "/opt/cmux/bin/cmux",
       },
     );
 
@@ -1282,6 +1284,11 @@ describe("bench-e2e measurement harness", () => {
           sha256: "sha256:/repo/dist/server.js",
         },
       ],
+      cli_executable: {
+        requested: "cmux",
+        path: "/opt/cmux/bin/cmux",
+        sha256: "sha256:/opt/cmux/bin/cmux",
+      },
     });
   });
 
@@ -1319,9 +1326,9 @@ describe("bench-e2e measurement harness", () => {
     };
     const hashFile = (path) =>
       path === serverPath ? serverHash : "index-before";
-    await expect(assertArtifactProvenance(provenance, hashFile)).resolves.toBe(
-      undefined,
-    );
+    await expect(
+      assertArtifactProvenance(provenance, hashFile),
+    ).resolves.toBeUndefined();
     serverHash = "server-after";
     await expect(assertArtifactProvenance(provenance, hashFile)).rejects.toThrow(
       /artifact changed after attestation.*server\.js/,
@@ -1354,6 +1361,7 @@ describe("bench-e2e measurement harness", () => {
           exists: () => true,
           hashFile: () => "unused",
           listRuntimeFiles: () => [],
+          resolveExecutable: () => "/opt/cmux/bin/cmux",
         },
       ),
     ).rejects.toThrow(/revision changed during build/);

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -35,6 +35,7 @@ import {
   readGitHead,
   prepareBuiltEntries,
   renderMarkdownTable,
+  resolveStableWorkspaceId,
   runCliReadScreen,
   installGracefulSignalAbort,
   assertNoUnexpectedDaemons,
@@ -1011,6 +1012,49 @@ describe("bench-e2e measurement harness", () => {
         directory,
       );
       await otherWorkspace.release();
+    } finally {
+      await first.release();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("canonicalizes workspace refs and ids to one reservation key", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const exec = async (_command, args) => {
+      if (args.includes("list-windows")) {
+        return {
+          stdout: JSON.stringify([
+            { ref: "window:1", id: "WINDOW-UUID", workspace_count: 1 },
+          ]),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: JSON.stringify({
+          workspaces: [{ ref: "workspace:7", id: "WORKSPACE-UUID" }],
+        }),
+        stderr: "",
+      };
+    };
+    const config = { cmuxBin: "/opt/cmux", env: {} };
+    const byRef = await resolveStableWorkspaceId("workspace:7", config, exec);
+    const byId = await resolveStableWorkspaceId("WORKSPACE-UUID", config, exec);
+    expect(byRef).toBe("WORKSPACE-UUID");
+    expect(byId).toBe("WORKSPACE-UUID");
+
+    const first = await createWorkspaceReservation(
+      "/tmp/cmux-nightly.sock",
+      byRef,
+      directory,
+    );
+    try {
+      await expect(
+        createWorkspaceReservation(
+          "/tmp/cmux-nightly.sock",
+          byId,
+          directory,
+        ),
+      ).rejects.toThrow(/already reserved/);
     } finally {
       await first.release();
       await rm(directory, { recursive: true, force: true });

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1025,6 +1025,19 @@ describe("bench-e2e measurement harness", () => {
     await rm(directory, { recursive: true, force: true });
   });
 
+  it("recovers a lock whose live PID belongs to a different process start", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const output = join(directory, "receipt.json");
+    await writeFile(
+      `${output}.lock`,
+      `${JSON.stringify({ pid: process.pid, process_start: "reused-pid-start" })}\n`,
+      "utf8",
+    );
+    const reservation = await createOutputReservation(output);
+    await reservation.release();
+    await rm(directory, { recursive: true, force: true });
+  });
+
   it("allows only one winner when contenders reclaim the same stale lock", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
     const output = join(directory, "receipt.json");

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -8,6 +8,7 @@ import {
   buildBenchmarkRows,
   buildIsolatedRuntimeEnv,
   cliArgs,
+  cleanupDaemonResources,
   createScratchTargets,
   createSocketReservation,
   daemonLogPath,
@@ -15,6 +16,8 @@ import {
   appendSettledFailures,
   listPanesCliArgs,
   listPaneSurfacesCliArgs,
+  listWindowsCliArgs,
+  listWorkspacesCliArgs,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
   operationArgs,
@@ -22,6 +25,7 @@ import {
   paneRefsFromListPanesStdout,
   payloadText,
   readGitHead,
+  runCliListSurfaces,
   runBenchmarkRow,
   summarizeTransport,
   terminateChild,
@@ -55,8 +59,12 @@ describe("bench-e2e measurement harness", () => {
       });
     }
     expect(rows.filter((row) => row.operation === "send_to")).toHaveLength(24);
-    expect(rows.filter((row) => row.operation === "read_screen")).toHaveLength(6);
-    expect(rows.filter((row) => row.operation === "list_surfaces")).toHaveLength(6);
+    expect(rows.filter((row) => row.operation === "read_screen")).toHaveLength(
+      6,
+    );
+    expect(
+      rows.filter((row) => row.operation === "list_surfaces"),
+    ).toHaveLength(6);
   });
 
   it("collects at least twelve samples from every concurrent worker", async () => {
@@ -84,7 +92,9 @@ describe("bench-e2e measurement harness", () => {
 
     expect(result.samples).toHaveLength(60);
     for (let worker = 0; worker < 5; worker += 1) {
-      expect(result.samples.filter((sample) => sample.worker === worker)).toHaveLength(12);
+      expect(
+        result.samples.filter((sample) => sample.worker === worker),
+      ).toHaveLength(12);
     }
     expect(result.sample_count).toBe(60);
     expect(result.p95_ms).toBeGreaterThan(result.p50_ms);
@@ -145,16 +155,61 @@ describe("bench-e2e measurement harness", () => {
 
     expect(fixture.targets).toEqual(["surface:21", "surface:22", "surface:23"]);
     expect(calls.slice(0, 3)).toEqual([
-      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:20", "--focus", "false"],
-      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:21", "--focus", "false"],
-      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:22", "--focus", "false"],
+      [
+        "new-split",
+        "right",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:20",
+        "--focus",
+        "false",
+      ],
+      [
+        "new-split",
+        "right",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:21",
+        "--focus",
+        "false",
+      ],
+      [
+        "new-split",
+        "right",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:22",
+        "--focus",
+        "false",
+      ],
     ]);
 
     await fixture.close();
     expect(calls.slice(3)).toEqual([
-      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:23"],
-      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:22"],
-      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:21"],
+      [
+        "close-surface",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:23",
+      ],
+      [
+        "close-surface",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:22",
+      ],
+      [
+        "close-surface",
+        "--workspace",
+        "workspace:7",
+        "--surface",
+        "surface:21",
+      ],
     ]);
   });
 
@@ -178,14 +233,28 @@ describe("bench-e2e measurement harness", () => {
     expect(args.at(-1)?.endsWith("\\n")).toBe(false);
   });
 
-  it("walks the real cmux topology verbs for CLI list_surfaces, not tree", () => {
+  it("walks the same all-window topology verbs as MCP list_surfaces", async () => {
     const config = { workspace: "workspace:7", surface: "surface:21" };
 
     expect(cliArgs({ operation: "list_surfaces" }, config, 0, 0)).toEqual([
       "--json",
       "--id-format",
       "both",
+      "list-windows",
+    ]);
+    expect(listWindowsCliArgs()).toEqual([
+      "--json",
+      "--id-format",
+      "both",
+      "list-windows",
+    ]);
+    expect(listWorkspacesCliArgs("window:1")).toEqual([
+      "--json",
+      "--id-format",
+      "both",
       "list-workspaces",
+      "--window",
+      "window:1",
     ]);
     expect(listPanesCliArgs("workspace:7")).toEqual([
       "--json",
@@ -213,6 +282,55 @@ describe("bench-e2e measurement harness", () => {
         }),
       ),
     ).toEqual(["pane:1", "pane:2"]);
+
+    const calls: string[][] = [];
+    const outputs = [
+      { windows: [{ ref: "window:1", workspace_count: 1 }] },
+      { workspaces: [{ ref: "workspace:7" }] },
+      { workspace_ref: "workspace:7", panes: [{ ref: "pane:1" }] },
+      { workspace_ref: "workspace:7", pane_ref: "pane:1", surfaces: [] },
+    ];
+    await runCliListSurfaces(
+      { ...config, cmuxBin: "/opt/cmux", env: {} },
+      async (_command, args) => {
+        calls.push(args);
+        return { stdout: JSON.stringify(outputs.shift()), stderr: "" };
+      },
+    );
+    expect(calls).toEqual([
+      listWindowsCliArgs(),
+      listWorkspacesCliArgs("window:1"),
+      listPanesCliArgs("workspace:7"),
+      listPaneSurfacesCliArgs("workspace:7", "pane:1"),
+    ]);
+  });
+
+  it("retries an incomplete all-window CLI enumeration once", async () => {
+    const calls: string[][] = [];
+    const outputs = [
+      { windows: [{ ref: "window:1", workspace_count: 2 }] },
+      { workspaces: [{ ref: "workspace:7" }] },
+      { windows: [{ ref: "window:1", workspace_count: 1 }] },
+      { workspaces: [{ ref: "workspace:7" }] },
+      { workspace_ref: "workspace:7", panes: [] },
+    ];
+
+    await runCliListSurfaces(
+      {
+        workspace: "workspace:7",
+        surface: "surface:21",
+        cmuxBin: "/opt/cmux",
+        env: {},
+      },
+      async (_command, args) => {
+        calls.push(args);
+        return { stdout: JSON.stringify(outputs.shift()), stderr: "" };
+      },
+    );
+
+    expect(calls.filter((args) => args.at(-1) === "list-windows")).toHaveLength(
+      2,
+    );
   });
 
   it("does not mix an environment workspace UUID into raw-surface calls", () => {
@@ -239,7 +357,10 @@ describe("bench-e2e measurement harness", () => {
         0,
         0,
       ),
-    ).toEqual({ workspace: "43557C0A-1F0D-4947-98A6-440ACBC0BEF8", verbose: false });
+    ).toEqual({
+      workspace: "43557C0A-1F0D-4947-98A6-440ACBC0BEF8",
+      verbose: false,
+    });
   });
 
   it("marks raw-surface send_to provenance UNTRUSTED under D180", () => {
@@ -326,7 +447,9 @@ describe("bench-e2e measurement harness", () => {
       message: "scratch target creation and teardown failed",
       errors: [
         expect.objectContaining({ message: "create failed" }),
-        expect.objectContaining({ message: expect.stringContaining("close failed") }),
+        expect.objectContaining({
+          message: expect.stringContaining("close failed"),
+        }),
       ],
     });
   });
@@ -341,7 +464,10 @@ describe("bench-e2e measurement harness", () => {
         this.signals.push(signal);
         if (signal === "SIGKILL") {
           this.signalCode = signal;
-          queueMicrotask(() => this.emit("exit", null, signal));
+          queueMicrotask(() => {
+            this.emit("exit", null, signal);
+            this.emit("close", null, signal);
+          });
         }
         return true;
       }
@@ -383,6 +509,69 @@ describe("bench-e2e measurement harness", () => {
     );
   });
 
+  it("waits for stdio close after child exit", async () => {
+    class ClosingChild extends EventEmitter {
+      exitCode = null;
+      signalCode = null;
+
+      kill() {
+        queueMicrotask(() => {
+          this.exitCode = 0;
+          this.emit("exit", 0, null);
+        });
+        return true;
+      }
+    }
+    const child = new ClosingChild();
+    let settled = false;
+    const pending = terminateChild(child, 100).then(() => {
+      settled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+    child.emit("close", 0, null);
+    await pending;
+  });
+
+  it("releases the reservation even when child termination fails", async () => {
+    const events: string[] = [];
+    const child = {
+      stdout: { unpipe: () => events.push("stdout-unpipe") },
+      stderr: { unpipe: () => events.push("stderr-unpipe") },
+    };
+    const log = Object.assign(new EventEmitter(), {
+      writableFinished: false,
+      end() {
+        events.push("log-end");
+        this.writableFinished = true;
+        queueMicrotask(() => this.emit("finish"));
+      },
+    });
+    const reservation = {
+      async release() {
+        events.push("release");
+      },
+    };
+
+    await expect(
+      cleanupDaemonResources({
+        child,
+        log,
+        reservation,
+        terminate: async () => {
+          throw new Error("terminate failed");
+        },
+      }),
+    ).rejects.toMatchObject({ name: "AggregateError" });
+    expect(events).toEqual([
+      "stdout-unpipe",
+      "stderr-unpipe",
+      "log-end",
+      "release",
+    ]);
+  });
+
   it("uses a unique daemon log beside the requested receipt", () => {
     expect(daemonLogPath("/tmp/bench.json", 42, 1234)).toBe(
       "/tmp/bench.json.daemon-42-1234.log",
@@ -413,7 +602,11 @@ describe("bench-e2e measurement harness", () => {
 
   it("preserves primary, scratch, and daemon cleanup failures", () => {
     let fatal = appendFatalError(null, new Error("row failed"), "benchmark");
-    fatal = appendFatalError(fatal, new Error("close failed"), "scratch teardown");
+    fatal = appendFatalError(
+      fatal,
+      new Error("close failed"),
+      "scratch teardown",
+    );
     fatal = appendFatalError(fatal, new Error("stop failed"), "daemon stop");
 
     expect(fatal).toContain("benchmark: row failed");
@@ -455,15 +648,29 @@ describe("bench-e2e measurement harness", () => {
       const reservation = await createSocketReservation(requestedPath);
 
       expect(reservation.socketPath).not.toBe(requestedPath);
-      expect(
-        reservation.socketPath.startsWith(`${requestedPath}.owner-`),
-      ).toBe(true);
+      expect(reservation.socketPath.startsWith(`${requestedPath}.owner-`)).toBe(
+        true,
+      );
       expect(reservation.socketPath.endsWith("/daemon.sock")).toBe(true);
 
       await reservation.release();
       await expect(stat(reservation.ownerDirectory)).rejects.toMatchObject({
         code: "ENOENT",
       });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("creates a missing parent for a nested isolated socket request", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const requestedPath = join(directory, "nested", "run10-nightly.sock");
+    try {
+      const reservation = await createSocketReservation(requestedPath);
+      expect(reservation.socketPath).toContain(
+        "/nested/run10-nightly.sock.owner-",
+      );
+      await reservation.release();
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -552,8 +552,6 @@ describe("bench-e2e measurement harness", () => {
     expect(calls).toEqual([
       [
         "read-screen",
-        "--workspace",
-        "workspace:7",
         "--surface",
         "surface:21",
         "--lines",
@@ -566,6 +564,73 @@ describe("bench-e2e measurement harness", () => {
       listPanesCliArgs("workspace:8"),
       listPaneSurfacesCliArgs("workspace:8", "pane:2"),
     ]);
+  });
+
+  it("keeps direct CLI read_screen request identity equal to the raw-surface MCP request", () => {
+    expect(
+      cliArgs(
+        { operation: "read_screen" },
+        { workspace: "workspace:7", surface: "surface:21" },
+        0,
+        0,
+      ),
+    ).toEqual(["read-screen", "--surface", "surface:21", "--lines", "20"]);
+  });
+
+  it("treats read_screen topology churn as best effort like MCP", async () => {
+    let call = 0;
+    await expect(
+      runCliReadScreen(
+        {
+          workspace: "workspace:7",
+          surface: "surface:21",
+          cmuxBin: "/opt/cmux",
+          env: {},
+        },
+        0,
+        0,
+        () => {
+          call += 1;
+          if (call === 1) return { stdout: "screen contents", stderr: "" };
+          throw new Error("workspace closed during topology collection");
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps read_screen successful when a topology pane or surface disappears", async () => {
+    for (const failingVerb of ["list-panes", "list-pane-surfaces"]) {
+      const outputs = [
+        "screen contents",
+        JSON.stringify({
+          windows: [{ ref: "window:1", workspace_count: 1 }],
+        }),
+        JSON.stringify({ workspaces: [{ ref: "workspace:7" }] }),
+        JSON.stringify({
+          workspace_ref: "workspace:7",
+          panes: [{ ref: "pane:1" }],
+        }),
+        JSON.stringify({ surfaces: [] }),
+      ];
+      await expect(
+        runCliReadScreen(
+          {
+            workspace: "workspace:7",
+            surface: "surface:21",
+            cmuxBin: "/opt/cmux",
+            env: {},
+          },
+          0,
+          0,
+          (_command, args) => {
+            if (args.includes(failingVerb)) {
+              throw new Error(`${failingVerb} raced with topology churn`);
+            }
+            return { stdout: outputs.shift() ?? "", stderr: "" };
+          },
+        ),
+      ).resolves.toBeUndefined();
+    }
   });
 
   it("retries an incomplete all-window CLI enumeration once", async () => {
@@ -882,6 +947,8 @@ describe("bench-e2e measurement harness", () => {
         PATH: "/usr/bin",
         CMUXLAYER_FORCE_INPROCESS: "1",
         CMUXLAYER_DEFAULT_PALETTE: "list_surfaces",
+        CMUXLAYER_DAEMON_FD: "7",
+        LISTEN_FDS: "1",
       },
       {
         ownerDirectory: "/tmp/run10.sock.owner-abc",
@@ -893,6 +960,8 @@ describe("bench-e2e measurement harness", () => {
     expect(env.CMUXLAYER_DAEMON_SOCKET).toContain("/tmp/run10.sock.owner-abc/");
     expect(env).not.toHaveProperty("CMUXLAYER_FORCE_INPROCESS");
     expect(env).not.toHaveProperty("CMUXLAYER_DEFAULT_PALETTE");
+    expect(env).not.toHaveProperty("CMUXLAYER_DAEMON_FD");
+    expect(env).not.toHaveProperty("LISTEN_FDS");
   });
 
   it("validates rows before reserving daemon resources", async () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1240,6 +1240,11 @@ describe("bench-e2e measurement harness", () => {
         },
         exists: () => true,
         hashFile: (path) => `sha256:${path}`,
+        listRuntimeFiles: () => [
+          "/repo/dist/daemon.js",
+          "/repo/dist/index.js",
+          "/repo/dist/server.js",
+        ],
       },
     );
 
@@ -1262,6 +1267,21 @@ describe("bench-e2e measurement harness", () => {
           sha256: "sha256:/repo/dist/daemon.js",
         },
       },
+      runtime_root: "/repo/dist",
+      runtime_files: [
+        {
+          path: "/repo/dist/daemon.js",
+          sha256: "sha256:/repo/dist/daemon.js",
+        },
+        {
+          path: "/repo/dist/index.js",
+          sha256: "sha256:/repo/dist/index.js",
+        },
+        {
+          path: "/repo/dist/server.js",
+          sha256: "sha256:/repo/dist/server.js",
+        },
+      ],
     });
   });
 
@@ -1278,6 +1298,35 @@ describe("bench-e2e measurement harness", () => {
           path.endsWith("index.js") ? "mcp-after" : "daemon-before",
       ),
     ).rejects.toThrow(/artifact changed after attestation.*index\.js/);
+  });
+
+  it("rejects drift in an imported runtime sibling", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const runtimeRoot = join(directory, "dist");
+    const indexPath = join(runtimeRoot, "index.js");
+    const serverPath = join(runtimeRoot, "server.js");
+    await mkdir(runtimeRoot);
+    await writeFile(indexPath, "index", "utf8");
+    await writeFile(serverPath, "server", "utf8");
+    let serverHash = "server-before";
+    const provenance = {
+      entries: {},
+      runtime_root: runtimeRoot,
+      runtime_files: [
+        { path: indexPath, sha256: "index-before" },
+        { path: serverPath, sha256: "server-before" },
+      ],
+    };
+    const hashFile = (path) =>
+      path === serverPath ? serverHash : "index-before";
+    await expect(assertArtifactProvenance(provenance, hashFile)).resolves.toBe(
+      undefined,
+    );
+    serverHash = "server-after";
+    await expect(assertArtifactProvenance(provenance, hashFile)).rejects.toThrow(
+      /artifact changed after attestation.*server\.js/,
+    );
+    await rm(directory, { recursive: true, force: true });
   });
 
   it("rejects built entry provenance when HEAD changes during the build", async () => {
@@ -1304,6 +1353,7 @@ describe("bench-e2e measurement harness", () => {
           },
           exists: () => true,
           hashFile: () => "unused",
+          listRuntimeFiles: () => [],
         },
       ),
     ).rejects.toThrow(/revision changed during build/);

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { EventEmitter } from "node:events";
 import {
   assertNightlyIsolation,
   buildBenchmarkRows,
+  cliArgs,
   createScratchTargets,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
@@ -14,6 +16,8 @@ import {
   readGitHead,
   runBenchmarkRow,
   summarizeTransport,
+  terminateChild,
+  waitForSocket,
 } from "../scripts/bench-e2e.mjs";
 
 describe("bench-e2e measurement harness", () => {
@@ -59,7 +63,7 @@ describe("bench-e2e measurement harness", () => {
       },
       {
         nowMs: () => clock,
-        runOperation: async ({ worker, sample }) => {
+        runOperation: ({ worker, sample }) => {
           clock += worker + sample + 1;
           return {
             ok: true,
@@ -125,7 +129,7 @@ describe("bench-e2e measurement harness", () => {
     const fixture = await createScratchTargets(3, {
       workspace: "workspace:7",
       controllerSurface: "surface:20",
-      execCmux: async (args: string[]) => {
+      execCmux: (args: string[]) => {
         calls.push(args);
         return { stdout: outputs.shift() ?? "OK\n", stderr: "" };
       },
@@ -151,6 +155,19 @@ describe("bench-e2e measurement harness", () => {
 
     expect(payload).toHaveLength(520);
     expect(payload.startsWith(": run10-e2e w4s11 ")).toBe(true);
+  });
+
+  it("submits direct CLI send rows with an actual newline", () => {
+    const args = cliArgs(
+      { operation: "send_to", payload_chars: 520 },
+      { workspace: "workspace:7", surface: "surface:21" },
+      0,
+      0,
+    );
+
+    expect(args.at(-1)).toHaveLength(521);
+    expect(args.at(-1)?.endsWith("\n")).toBe(true);
+    expect(args.at(-1)?.endsWith("\\n")).toBe(false);
   });
 
   it("does not mix an environment workspace UUID into raw-surface calls", () => {
@@ -218,15 +235,89 @@ describe("bench-e2e measurement harness", () => {
     }
   });
 
+  it("captures daemon log errors that occur after the stream opens", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const logPath = join(directory, "daemon.log");
+    let runtimeError = null;
+    try {
+      const stream = await openExclusiveWriteStream(logPath, (error) => {
+        runtimeError = error;
+      });
+      const expected = new Error("disk full");
+      stream.emit("error", expected);
+      expect(runtimeError).toBe(expected);
+      stream.end();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a benchmark receipt writable when git head lookup fails", async () => {
     await expect(
-      readGitHead(async () => {
+      readGitHead(() => {
         throw new Error("git unavailable");
       }),
     ).resolves.toBeNull();
     await expect(
-      readGitHead(async () => ({ stdout: "abc123\n", stderr: "" })),
+      readGitHead(() => ({ stdout: "abc123\n", stderr: "" })),
     ).resolves.toBe("abc123");
+  });
+
+  it("reports both scratch creation and cleanup failures", async () => {
+    let call = 0;
+    await expect(
+      createScratchTargets(2, {
+        workspace: "workspace:7",
+        controllerSurface: "surface:20",
+        execCmux: () => {
+          call += 1;
+          if (call === 1) return { stdout: "OK surface:21\n", stderr: "" };
+          if (call === 2) throw new Error("create failed");
+          throw new Error("close failed");
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "AggregateError",
+      message: "scratch target creation and teardown failed",
+      errors: [
+        expect.objectContaining({ message: "create failed" }),
+        expect.objectContaining({ message: expect.stringContaining("close failed") }),
+      ],
+    });
+  });
+
+  it("escalates an unresponsive child from TERM to KILL", async () => {
+    class FakeChild extends EventEmitter {
+      exitCode = null;
+      signalCode = null;
+      signals: string[] = [];
+
+      kill(signal: string) {
+        this.signals.push(signal);
+        if (signal === "SIGKILL") {
+          this.signalCode = signal;
+          queueMicrotask(() => this.emit("exit", null, signal));
+        }
+        return true;
+      }
+    }
+    const child = new FakeChild();
+
+    await terminateChild(child, 0);
+
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("cancels a pending socket retry without waiting for its deadline", async () => {
+    const wait = waitForSocket(
+      join(tmpdir(), `cmuxlayer-missing-${process.pid}-${Date.now()}.sock`),
+      30_000,
+    );
+    const reason = new Error("startup failed elsewhere");
+
+    wait.cancel(reason);
+
+    await expect(wait.promise).rejects.toBe(reason);
   });
 
 });

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -292,7 +292,7 @@ describe("bench-e2e measurement harness", () => {
     ];
     await runCliListSurfaces(
       { ...config, cmuxBin: "/opt/cmux", env: {} },
-      async (_command, args) => {
+      (_command, args) => {
         calls.push(args);
         return { stdout: JSON.stringify(outputs.shift()), stderr: "" };
       },
@@ -322,7 +322,7 @@ describe("bench-e2e measurement harness", () => {
         cmuxBin: "/opt/cmux",
         env: {},
       },
-      async (_command, args) => {
+      (_command, args) => {
         calls.push(args);
         return { stdout: JSON.stringify(outputs.shift()), stderr: "" };
       },
@@ -484,9 +484,7 @@ describe("bench-e2e measurement harness", () => {
       exitCode = null;
       signalCode = null;
 
-      kill() {
-        return true;
-      }
+      kill = () => true;
     }
 
     await expect(terminateChild(new ImmortalChild(), 0)).rejects.toThrow(
@@ -499,9 +497,7 @@ describe("bench-e2e measurement harness", () => {
       exitCode = null;
       signalCode = null;
 
-      kill() {
-        return false;
-      }
+      kill = () => false;
     }
 
     await expect(terminateChild(new UnsignallableChild(), 0)).rejects.toThrow(
@@ -549,7 +545,7 @@ describe("bench-e2e measurement harness", () => {
       },
     });
     const reservation = {
-      async release() {
+      release() {
         events.push("release");
       },
     };
@@ -559,7 +555,7 @@ describe("bench-e2e measurement harness", () => {
         child,
         log,
         reservation,
-        terminate: async () => {
+        terminate: () => {
           throw new Error("terminate failed");
         },
       }),

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
 import {
   assertNightlyIsolation,
+  assertArtifactProvenance,
   assertCliFairnessTrace,
   buildBenchmarkRows,
   buildAbsentComparisonRow,
@@ -831,6 +840,28 @@ describe("bench-e2e measurement harness", () => {
     });
   });
 
+  it("stops scratch creation promptly after abort and still tears down", async () => {
+    const controller = new AbortController();
+    const calls: string[][] = [];
+    await expect(
+      createScratchTargets(3, {
+        workspace: "workspace:7",
+        controllerSurface: "surface:20",
+        signal: controller.signal,
+        execCmux: (args: string[]) => {
+          calls.push(args);
+          if (args[0] === "new-split") {
+            controller.abort(new Error("stop creating"));
+            return { stdout: "OK surface:21\n", stderr: "" };
+          }
+          return { stdout: "OK\n", stderr: "" };
+        },
+      }),
+    ).rejects.toThrow(/stop creating/);
+    expect(calls.filter((args) => args[0] === "new-split")).toHaveLength(1);
+    expect(calls.filter((args) => args[0] === "close-surface")).toHaveLength(1);
+  });
+
   it("escalates an unresponsive child from TERM to KILL", async () => {
     class FakeChild extends EventEmitter {
       exitCode = null;
@@ -965,6 +996,25 @@ describe("bench-e2e measurement harness", () => {
     await rm(directory, { recursive: true, force: true });
   });
 
+  it("uses one output lock through real and symbolic-link parent paths", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const realDirectory = join(directory, "real");
+    const linkedDirectory = join(directory, "linked");
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory, "dir");
+    const first = await createOutputReservation(
+      join(realDirectory, "receipt.json"),
+    );
+    try {
+      await expect(
+        createOutputReservation(join(linkedDirectory, "receipt.json")),
+      ).rejects.toThrow(/already reserved/);
+    } finally {
+      await first.release();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("recovers an output lock whose recorded owner is gone", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
     const output = join(directory, "receipt.json");
@@ -1020,7 +1070,7 @@ describe("bench-e2e measurement harness", () => {
 
   it("canonicalizes workspace refs and ids to one reservation key", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
-    const exec = async (_command, args) => {
+    const exec = (_command, args) => {
       if (args.includes("list-windows")) {
         return {
           stdout: JSON.stringify([
@@ -1190,6 +1240,21 @@ describe("bench-e2e measurement harness", () => {
     });
   });
 
+  it("rejects mutable built entries whose hashes change after attestation", async () => {
+    await expect(
+      assertArtifactProvenance(
+        {
+          entries: {
+            mcp: { path: "/repo/dist/index.js", sha256: "mcp-before" },
+            daemon: { path: "/repo/dist/daemon.js", sha256: "daemon-before" },
+          },
+        },
+        (path) =>
+          path.endsWith("index.js") ? "mcp-after" : "daemon-before",
+      ),
+    ).rejects.toThrow(/artifact changed after attestation.*index\.js/);
+  });
+
   it("rejects built entry provenance when HEAD changes during the build", async () => {
     let headReads = 0;
 
@@ -1319,6 +1384,22 @@ describe("bench-e2e measurement harness", () => {
       verifyPid: () => Promise.resolve(true),
     });
     expect(killProbes).toBe(4);
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("does not SIGKILL a PID that loses ownership after TERM", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const receipt = join(directory, "daemon-pids.txt");
+    await writeFile(receipt, "4343\n", "utf8");
+    const signals = [];
+    let verifications = 0;
+    await terminateUnexpectedDaemons(receipt, 4242, "owner-token", {
+      signalPid: (_pid, signal) => signals.push(signal),
+      pause: () => Promise.resolve(),
+      verifyPid: () => Promise.resolve(++verifications === 1),
+    });
+    expect(signals).toContain("SIGTERM");
+    expect(signals).not.toContain("SIGKILL");
     await rm(directory, { recursive: true, force: true });
   });
 

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
@@ -174,6 +174,31 @@ describe("bench-e2e measurement harness", () => {
     expect(result.failure_rate_pct).toBe(100);
     expect(result.p50_ms).toBeNull();
     expect(result.p95_ms).toBeNull();
+  });
+
+  it("stops a row after an in-flight operation receives the abort signal", async () => {
+    const controller = new AbortController();
+    let starts = 0;
+    const pending = runBenchmarkRow(
+      { concurrency: 1, samples_per_worker: 12 },
+      {
+        signal: controller.signal,
+        runOperation: () => {
+          starts += 1;
+          return new Promise((_, reject) => {
+            controller.signal.addEventListener(
+              "abort",
+              () => reject(controller.signal.reason),
+              { once: true },
+            );
+          });
+        },
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort(new Error("stop now"));
+    await expect(pending).rejects.toThrow("stop now");
+    expect(starts).toBe(1);
   });
 
   it("counts transport and every fallback from the raw samples", () => {
@@ -942,9 +967,26 @@ describe("bench-e2e measurement harness", () => {
   it("recovers an output lock whose recorded owner is gone", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
     const output = join(directory, "receipt.json");
-    await writeFile(`${output}.lock`, "2147483647\n", "utf8");
+    await writeFile(`${output}.lock`, "99999\n", "utf8");
+    await utimes(`${output}.lock`, new Date(0), new Date(0));
     const reservation = await createOutputReservation(output);
     await reservation.release();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("allows only one winner when contenders reclaim the same stale lock", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const output = join(directory, "receipt.json");
+    await writeFile(`${output}.lock`, "99999\n", "utf8");
+    await utimes(`${output}.lock`, new Date(0), new Date(0));
+    const contenders = await Promise.allSettled([
+      createOutputReservation(output),
+      createOutputReservation(output),
+    ]);
+    expect(contenders.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(contenders.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const winner = contenders.find((result) => result.status === "fulfilled");
+    await winner.value.release();
     await rm(directory, { recursive: true, force: true });
   });
 
@@ -1188,8 +1230,51 @@ describe("bench-e2e measurement harness", () => {
       }
       if (signal === "SIGTERM") live = false;
     };
-    await terminateUnexpectedDaemons(receipt, 4242, signalPid, async () => {});
+    await terminateUnexpectedDaemons(receipt, 4242, "owner-token", {
+      signalPid,
+      pause: () => Promise.resolve(),
+      verifyPid: () => Promise.resolve(true),
+    });
     expect(signals).toContainEqual([4343, "SIGTERM"]);
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("refuses to signal a recorded PID whose ownership token does not match", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const receipt = join(directory, "daemon-pids.txt");
+    await writeFile(receipt, "4343\n", "utf8");
+    const signals = [];
+    await expect(
+      terminateUnexpectedDaemons(receipt, 4242, "owner-token", {
+        signalPid: (_pid, signal) => signals.push(signal),
+        verifyPid: () => Promise.resolve(false),
+      }),
+    ).rejects.toThrow(/unowned daemon cleanup failed/);
+    expect(signals).toEqual([0]);
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("waits after SIGKILL before declaring an unexpected daemon alive", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const receipt = join(directory, "daemon-pids.txt");
+    await writeFile(receipt, "4343\n", "utf8");
+    let killProbes = 0;
+    let killed = false;
+    const signalPid = (_pid, signal) => {
+      if (signal === "SIGKILL") killed = true;
+      if (signal === 0 && killed) {
+        killProbes += 1;
+        if (killProbes >= 3) {
+          throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        }
+      }
+    };
+    await terminateUnexpectedDaemons(receipt, 4242, "owner-token", {
+      signalPid,
+      pause: () => Promise.resolve(),
+      verifyPid: () => Promise.resolve(true),
+    });
+    expect(killProbes).toBe(4);
     await rm(directory, { recursive: true, force: true });
   });
 

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -16,6 +16,7 @@ import {
   createScratchTargets,
   createOutputReservation,
   createSocketReservation,
+  createWorkspaceReservation,
   daemonLogPath,
   FAIRNESS_CONTRACTS,
   appendFatalError,
@@ -35,6 +36,9 @@ import {
   prepareBuiltEntries,
   renderMarkdownTable,
   runCliReadScreen,
+  installGracefulSignalAbort,
+  assertNoUnexpectedDaemons,
+  terminateUnexpectedDaemons,
   runCliListSurfaces,
   runBenchmarkRow,
   summarizeTransport,
@@ -925,7 +929,7 @@ describe("bench-e2e measurement harness", () => {
     const first = await createOutputReservation(output);
     try {
       await expect(createOutputReservation(output)).rejects.toThrow(
-        /output is already reserved/,
+        /output .* is already reserved/,
       );
     } finally {
       await first.release();
@@ -933,6 +937,55 @@ describe("bench-e2e measurement harness", () => {
     const afterRelease = await createOutputReservation(output);
     await afterRelease.release();
     await rm(directory, { recursive: true, force: true });
+  });
+
+  it("recovers an output lock whose recorded owner is gone", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const output = join(directory, "receipt.json");
+    await writeFile(`${output}.lock`, "2147483647\n", "utf8");
+    const reservation = await createOutputReservation(output);
+    await reservation.release();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("serializes every run sharing one Nightly workspace", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const first = await createWorkspaceReservation(
+      "/tmp/cmux-nightly.sock",
+      "workspace:7",
+      directory,
+    );
+    try {
+      await expect(
+        createWorkspaceReservation(
+          "/tmp/cmux-nightly.sock",
+          "workspace:7",
+          directory,
+        ),
+      ).rejects.toThrow(/already reserved/);
+      const otherWorkspace = await createWorkspaceReservation(
+        "/tmp/cmux-nightly.sock",
+        "workspace:8",
+        directory,
+      );
+      await otherWorkspace.release();
+    } finally {
+      await first.release();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("turns TERM into an awaited graceful-abort signal", () => {
+    const processLike = new EventEmitter();
+    const controller = new AbortController();
+    const remove = installGracefulSignalAbort(controller, processLike);
+
+    processLike.emit("SIGTERM");
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason.message).toContain("SIGTERM");
+    remove();
+    expect(processLike.listenerCount("SIGTERM")).toBe(0);
+    expect(processLike.listenerCount("SIGINT")).toBe(0);
   });
 
   it("moves daemon socket, monitor, watch, and state paths under the owned run directory", () => {
@@ -955,6 +1008,9 @@ describe("bench-e2e measurement harness", () => {
       "/tmp/run10.sock.owner-abc/",
     );
     expect(env.HOME).not.toBe("/opt/example-home");
+    expect(env.CMUXLAYER_DAEMON_PID_RECEIPT).toContain(
+      "/tmp/run10.sock.owner-abc/",
+    );
     expect(env).not.toHaveProperty("CMUXLAYER_FORCE_INPROCESS");
     expect(env).not.toHaveProperty("CMUXLAYER_DEFAULT_PALETTE");
   });
@@ -1113,6 +1169,28 @@ describe("bench-e2e measurement harness", () => {
     expect(() => assertOwnedDaemonHealthy(child, null)).toThrow(
       /owned isolated daemon.*4242.*exitCode.*17/,
     );
+  });
+
+  it("detects and terminates any daemon autostarted by an MCP client", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const receipt = join(directory, "daemon-pids.txt");
+    await writeFile(receipt, "4242\n4343\n", "utf8");
+    await expect(assertNoUnexpectedDaemons(receipt, 4242)).rejects.toThrow(
+      /4343/,
+    );
+    let live = true;
+    const signals = [];
+    const signalPid = (pid, signal) => {
+      signals.push([pid, signal]);
+      if (signal === 0) {
+        if (!live) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        return;
+      }
+      if (signal === "SIGTERM") live = false;
+    };
+    await terminateUnexpectedDaemons(receipt, 4242, signalPid, async () => {});
+    expect(signals).toContainEqual([4343, "SIGTERM"]);
+    await rm(directory, { recursive: true, force: true });
   });
 
   it("preserves every rejected MCP client shutdown", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   assertNightlyIsolation,
   buildBenchmarkRows,
+  cliOperationArgs,
   createScratchTargets,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
@@ -59,13 +60,13 @@ describe("bench-e2e measurement harness", () => {
       },
       {
         nowMs: () => clock,
-        runOperation: async ({ worker, sample }) => {
+        runOperation: ({ worker, sample }) => {
           clock += worker + sample + 1;
-          return {
+          return Promise.resolve({
             ok: true,
             transport: "socket",
             transport_fallbacks: [],
-          };
+          });
         },
       },
     );
@@ -125,9 +126,9 @@ describe("bench-e2e measurement harness", () => {
     const fixture = await createScratchTargets(3, {
       workspace: "workspace:7",
       controllerSurface: "surface:20",
-      execCmux: async (args: string[]) => {
+      execCmux: (args: string[]) => {
         calls.push(args);
-        return { stdout: outputs.shift() ?? "OK\n", stderr: "" };
+        return Promise.resolve({ stdout: outputs.shift() ?? "OK\n", stderr: "" });
       },
     });
 
@@ -180,6 +181,29 @@ describe("bench-e2e measurement harness", () => {
     ).toEqual({ workspace: "43557C0A-1F0D-4947-98A6-440ACBC0BEF8", verbose: false });
   });
 
+  it("uses the real cmux CLI verbs and a newline submit, not a literal slash-n", () => {
+    const sendArgs = cliOperationArgs(
+      { operation: "send_to", payload_chars: 250 },
+      "surface:4",
+      "workspace:7",
+      0,
+      0,
+    );
+    expect(sendArgs[0]).toBe("send");
+    expect(sendArgs.at(-1)?.endsWith("\n")).toBe(true);
+    expect(sendArgs.at(-1)?.endsWith("\\n")).toBe(false);
+    expect(sendArgs.at(-1)).toHaveLength(251);
+    expect(
+      cliOperationArgs(
+        { operation: "list_surfaces", payload_chars: null },
+        "surface:4",
+        "workspace:7",
+        0,
+        0,
+      ),
+    ).toEqual(["list-workspaces"]);
+  });
+
   it("marks raw-surface send_to provenance UNTRUSTED under D180", () => {
     const row = markSurfaceTransportUntrusted({
       operation: "send_to",
@@ -220,12 +244,10 @@ describe("bench-e2e measurement harness", () => {
 
   it("keeps a benchmark receipt writable when git head lookup fails", async () => {
     await expect(
-      readGitHead(async () => {
-        throw new Error("git unavailable");
-      }),
+      readGitHead(() => Promise.reject(new Error("git unavailable"))),
     ).resolves.toBeNull();
     await expect(
-      readGitHead(async () => ({ stdout: "abc123\n", stderr: "" })),
+      readGitHead(() => Promise.resolve({ stdout: "abc123\n", stderr: "" })),
     ).resolves.toBe("abc123");
   });
 

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -44,6 +44,7 @@ import {
   readGitHead,
   prepareBuiltEntries,
   renderMarkdownTable,
+  releaseReservations,
   resolveStableWorkspaceId,
   runCliReadScreen,
   installGracefulSignalAbort,
@@ -850,10 +851,11 @@ describe("bench-e2e measurement harness", () => {
         signal: controller.signal,
         execCmux: (args: string[]) => {
           calls.push(args);
-          if (args[0] === "new-split") {
-            controller.abort(new Error("stop creating"));
-            return { stdout: "OK surface:21\n", stderr: "" };
-          }
+          controller.abort(new Error("stop creating"));
+          return { stdout: "OK surface:21\n", stderr: "" };
+        },
+        closeCmux: (args: string[]) => {
+          calls.push(args);
           return { stdout: "OK\n", stderr: "" };
         },
       }),
@@ -1035,6 +1037,16 @@ describe("bench-e2e measurement harness", () => {
     );
     const reservation = await createOutputReservation(output);
     await reservation.release();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it("preserves a legacy numeric lock while its PID is live", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const output = join(directory, "receipt.json");
+    await writeFile(`${output}.lock`, `${process.pid}\n`, "utf8");
+    await expect(createOutputReservation(output)).rejects.toThrow(
+      /already reserved/,
+    );
     await rm(directory, { recursive: true, force: true });
   });
 
@@ -1429,6 +1441,33 @@ describe("bench-e2e measurement harness", () => {
 
     expect(fatal).toContain("MCP client stop: client 1 failed");
     expect(fatal).toContain("MCP client stop: client 2 failed");
+  });
+
+  it("aggregates every top-level reservation release failure", async () => {
+    const calls = [];
+    await expect(
+      releaseReservations([
+        {
+          release: () => {
+            calls.push("output");
+            throw new Error("output release failed");
+          },
+        },
+        {
+          release: () => {
+            calls.push("workspace");
+            throw new Error("workspace release failed");
+          },
+        },
+      ]),
+    ).rejects.toMatchObject({
+      name: "AggregateError",
+      errors: [
+        expect.objectContaining({ message: "output release failed" }),
+        expect.objectContaining({ message: "workspace release failed" }),
+      ],
+    });
+    expect(calls).toEqual(["output", "workspace"]);
   });
 
   it("cancels a pending socket retry without waiting for its deadline", async () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -20,6 +20,7 @@ import {
   FAIRNESS_CONTRACTS,
   appendFatalError,
   appendSettledFailures,
+  assertOwnedDaemonHealthy,
   listPanesCliArgs,
   listPaneSurfacesCliArgs,
   listWindowsCliArgs,
@@ -1088,6 +1089,30 @@ describe("bench-e2e measurement harness", () => {
     expect(fatal).toContain("benchmark: row failed");
     expect(fatal).toContain("scratch teardown: close failed");
     expect(fatal).toContain("daemon stop: stop failed");
+  });
+
+  it("preserves nested aggregate cleanup evidence in fatal_error", () => {
+    const cleanup = new AggregateError(
+      [new Error("SIGKILL failed"), new Error("reservation release failed")],
+      "isolated daemon cleanup failed",
+    );
+    const stop = new AggregateError([cleanup], "isolated daemon stop failed");
+
+    const fatal = appendFatalError(null, stop, "daemon stop");
+
+    expect(fatal).toContain("isolated daemon stop failed");
+    expect(fatal).toContain("isolated daemon cleanup failed");
+    expect(fatal).toContain("SIGKILL failed");
+    expect(fatal).toContain("reservation release failed");
+  });
+
+  it("fails health checks when the owned daemon exits after readiness", () => {
+    const child = { exitCode: null, signalCode: null, pid: 4242 };
+    expect(() => assertOwnedDaemonHealthy(child, null)).not.toThrow();
+    child.exitCode = 17;
+    expect(() => assertOwnedDaemonHealthy(child, null)).toThrow(
+      /owned isolated daemon.*4242.*exitCode.*17/,
+    );
   });
 
   it("preserves every rejected MCP client shutdown", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -5,14 +5,18 @@ import { join } from "node:path";
 import { EventEmitter } from "node:events";
 import {
   assertNightlyIsolation,
+  assertCliFairnessTrace,
   buildBenchmarkRows,
+  buildAbsentComparisonRow,
   buildRowsAndReserve,
   buildIsolatedRuntimeEnv,
+  beginObservedTermination,
   cliArgs,
   cleanupDaemonResources,
   createScratchTargets,
   createSocketReservation,
   daemonLogPath,
+  FAIRNESS_CONTRACTS,
   appendFatalError,
   appendSettledFailures,
   listPanesCliArgs,
@@ -27,6 +31,7 @@ import {
   payloadText,
   readGitHead,
   prepareBuiltEntries,
+  renderMarkdownTable,
   runCliReadScreen,
   runCliListSurfaces,
   runBenchmarkRow,
@@ -127,6 +132,9 @@ describe("bench-e2e measurement harness", () => {
     );
 
     expect(result.error_count).toBe(6);
+    expect(result.attempt_count).toBe(12);
+    expect(result.success_count).toBe(6);
+    expect(result.failure_rate_pct).toBe(50);
     expect(result.p50_ms).toBe(100);
     expect(result.p95_ms).toBe(100);
   });
@@ -155,6 +163,9 @@ describe("bench-e2e measurement harness", () => {
     );
 
     expect(result.error_count).toBe(12);
+    expect(result.attempt_count).toBe(12);
+    expect(result.success_count).toBe(0);
+    expect(result.failure_rate_pct).toBe(100);
     expect(result.p50_ms).toBeNull();
     expect(result.p95_ms).toBeNull();
   });
@@ -170,6 +181,27 @@ describe("bench-e2e measurement harness", () => {
       transport_counts: { socket: 1, cli: 2 },
       transport_fallback_counts: { paste_text: 2, send: 1 },
     });
+  });
+
+  it("renders attempts, successes, and failure rate beside percentiles", () => {
+    const table = renderMarkdownTable([
+      {
+        operation: "send_to",
+        concurrency_profile: "c5",
+        payload_chars: 520,
+        client: "mcp",
+        attempt_count: 60,
+        success_count: 47,
+        failure_rate_pct: 21.67,
+        p50_ms: 100,
+        p95_ms: 200,
+        transport_counts: { UNTRUSTED: 60 },
+        transport_fallback_counts: { UNTRUSTED_D180: 60 },
+      },
+    ]);
+
+    expect(table).toContain("| attempts | successes | failure % | p50 ms |");
+    expect(table).toContain("| 60 | 47 | 21.67 | 100 | 200 |");
   });
 
   it("refuses production or ambiguous socket configuration", () => {
@@ -279,7 +311,7 @@ describe("bench-e2e measurement harness", () => {
     expect(payload.startsWith(": run10-e2e w4s11 ")).toBe(true);
   });
 
-  it("submits direct CLI send rows with an actual newline", () => {
+  it("keeps the legacy direct CLI send shape available but not comparable", () => {
     const args = cliArgs(
       { operation: "send_to", payload_chars: 520 },
       { workspace: "workspace:7", surface: "surface:21" },
@@ -289,7 +321,6 @@ describe("bench-e2e measurement harness", () => {
 
     expect(args.at(-1)).toHaveLength(521);
     expect(args.at(-1)?.endsWith("\n")).toBe(true);
-    expect(args.at(-1)?.endsWith("\\n")).toBe(false);
   });
 
   it("walks the same all-window topology verbs as MCP list_surfaces", async () => {
@@ -362,6 +393,115 @@ describe("bench-e2e measurement harness", () => {
       listPanesCliArgs("workspace:7"),
       listPaneSurfacesCliArgs("workspace:7", "pane:1"),
     ]);
+  });
+
+  it("defines and enforces one fairness contract for every operation", () => {
+    expect(Object.keys(FAIRNESS_CONTRACTS)).toEqual([
+      "send_to",
+      "read_screen",
+      "list_surfaces",
+    ]);
+    expect(FAIRNESS_CONTRACTS.send_to).toMatchObject({
+      comparable: false,
+      cli_work: null,
+    });
+    expect(FAIRNESS_CONTRACTS.send_to.reason).toMatch(
+      /dynamic.*cannot be mirrored/i,
+    );
+    expect(() => assertCliFairnessTrace("send_to", [])).toThrow(
+      /not comparable/,
+    );
+    for (const contract of [
+      FAIRNESS_CONTRACTS.read_screen,
+      FAIRNESS_CONTRACTS.list_surfaces,
+    ]) {
+      expect(contract.comparable).toBe(true);
+      expect(contract.cli_work).toEqual(contract.mcp_work);
+      expect(() =>
+        assertCliFairnessTrace(contract.operation, contract.cli_work),
+      ).not.toThrow();
+      expect(() =>
+        assertCliFairnessTrace(contract.operation, ["drifted-work"]),
+      ).toThrow(/fairness contract drift/);
+    }
+  });
+
+  it("emits an explicit absent row instead of an unfair send_to comparison", () => {
+    const [mcpRow, cliRow] = buildBenchmarkRows({
+      concurrency: [5],
+      payloadSizes: [520],
+      samplesPerWorker: 12,
+      operations: ["send_to"],
+      clients: ["mcp", "cli"],
+    });
+
+    expect(mcpRow.comparison_status).toBe("MEASURED");
+    expect(cliRow).toMatchObject({
+      client: "cli",
+      comparison_status: "NOT_COMPARABLE",
+    });
+    expect(buildAbsentComparisonRow(cliRow)).toMatchObject({
+      attempt_count: 0,
+      success_count: 0,
+      failure_rate_pct: null,
+      p50_ms: null,
+      p95_ms: null,
+      comparison_status: "NOT_COMPARABLE",
+    });
+  });
+
+  it("fans out multi-pane list_surfaces work concurrently like MCP", async () => {
+    const calls: string[][] = [];
+    const releases: Array<() => void> = [];
+    const pending = runCliListSurfaces(
+      {
+        workspace: "workspace:7",
+        surface: "surface:21",
+        cmuxBin: "/opt/cmux",
+        env: {},
+      },
+      (_command, args) => {
+        calls.push(args);
+        if (args.includes("list-windows")) {
+          return {
+            stdout: JSON.stringify({
+              windows: [{ ref: "window:1", workspace_count: 1 }],
+            }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-workspaces")) {
+          return {
+            stdout: JSON.stringify({ workspaces: [{ ref: "workspace:7" }] }),
+            stderr: "",
+          };
+        }
+        if (args.includes("list-panes")) {
+          return {
+            stdout: JSON.stringify({
+              workspace_ref: "workspace:7",
+              panes: [{ ref: "pane:1" }, { ref: "pane:2" }],
+            }),
+            stderr: "",
+          };
+        }
+        return new Promise((resolve) => {
+          releases.push(() =>
+            resolve({
+              stdout: JSON.stringify({ surfaces: [] }),
+              stderr: "",
+            }),
+          );
+        });
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      calls.filter((args) => args.includes("list-pane-surfaces")),
+    ).toHaveLength(2);
+    for (const release of releases) release();
+    await pending;
   });
 
   it("adds the MCP topology workload to direct CLI read_screen samples", async () => {
@@ -539,6 +679,23 @@ describe("bench-e2e measurement harness", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("observes a log-triggered termination rejection immediately", async () => {
+    const expected = new Error("termination failed");
+    const rejection = Promise.reject(expected);
+    const originalCatch = rejection.catch.bind(rejection);
+    let catchCalls = 0;
+    rejection.catch = (...args) => {
+      catchCalls += 1;
+      return originalCatch(...args);
+    };
+
+    const observed = beginObservedTermination({}, () => rejection);
+
+    expect(observed).toBe(rejection);
+    expect(catchCalls).toBe(1);
+    await expect(observed).rejects.toBe(expected);
   });
 
   it("keeps a benchmark receipt writable when git head lookup fails", async () => {
@@ -751,7 +908,7 @@ describe("bench-e2e measurement harness", () => {
           clients: ["mcp"],
         },
         "/tmp/cmuxlayer-run10-nightly.sock",
-        async () => {
+        () => {
           reservationCalls += 1;
           throw new Error("must not reserve");
         },

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -10,10 +10,13 @@ import {
   createScratchTargets,
   createSocketReservation,
   daemonLogPath,
+  listPanesCliArgs,
+  listPaneSurfacesCliArgs,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
   operationArgs,
   openExclusiveWriteStream,
+  paneRefsFromListPanesStdout,
   payloadText,
   readGitHead,
   runBenchmarkRow,
@@ -170,6 +173,43 @@ describe("bench-e2e measurement harness", () => {
     expect(args.at(-1)).toHaveLength(521);
     expect(args.at(-1)?.endsWith("\n")).toBe(true);
     expect(args.at(-1)?.endsWith("\\n")).toBe(false);
+  });
+
+  it("walks the real cmux topology verbs for CLI list_surfaces, not tree", () => {
+    const config = { workspace: "workspace:7", surface: "surface:21" };
+
+    expect(cliArgs({ operation: "list_surfaces" }, config, 0, 0)).toEqual([
+      "--json",
+      "--id-format",
+      "both",
+      "list-workspaces",
+    ]);
+    expect(listPanesCliArgs("workspace:7")).toEqual([
+      "--json",
+      "--id-format",
+      "both",
+      "list-panes",
+      "--workspace",
+      "workspace:7",
+    ]);
+    expect(listPaneSurfacesCliArgs("workspace:7", "pane:3")).toEqual([
+      "--json",
+      "--id-format",
+      "both",
+      "list-pane-surfaces",
+      "--workspace",
+      "workspace:7",
+      "--pane",
+      "pane:3",
+    ]);
+    expect(
+      paneRefsFromListPanesStdout(
+        JSON.stringify({
+          workspace_ref: "workspace:7",
+          panes: [{ ref: "pane:1" }, { ref: "pane:2" }],
+        }),
+      ),
+    ).toEqual(["pane:1", "pane:2"]);
   });
 
   it("does not mix an environment workspace UUID into raw-surface calls", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -9,6 +9,7 @@ import {
   cliArgs,
   createScratchTargets,
   createSocketReservation,
+  daemonLogPath,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
   operationArgs,
@@ -307,6 +308,42 @@ describe("bench-e2e measurement harness", () => {
     await terminateChild(child, 0);
 
     expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("rejects when an unresponsive child survives the bounded KILL wait", async () => {
+    class ImmortalChild extends EventEmitter {
+      exitCode = null;
+      signalCode = null;
+
+      kill() {
+        return true;
+      }
+    }
+
+    await expect(terminateChild(new ImmortalChild(), 0)).rejects.toThrow(
+      /did not exit after SIGKILL/,
+    );
+  });
+
+  it("rejects when child signal delivery fails", async () => {
+    class UnsignallableChild extends EventEmitter {
+      exitCode = null;
+      signalCode = null;
+
+      kill() {
+        return false;
+      }
+    }
+
+    await expect(terminateChild(new UnsignallableChild(), 0)).rejects.toThrow(
+      /failed to deliver SIGTERM/,
+    );
+  });
+
+  it("uses a unique daemon log beside the requested receipt", () => {
+    expect(daemonLogPath("/tmp/bench.json", 42, 1234)).toBe(
+      "/tmp/bench.json.daemon-42-1234.log",
+    );
   });
 
   it("cancels a pending socket retry without waiting for its deadline", async () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertNightlyIsolation,
+  buildBenchmarkRows,
+  createScratchTargets,
+  markSurfaceTransportUntrusted,
+  nearestRankPercentile,
+  operationArgs,
+  openExclusiveWriteStream,
+  payloadText,
+  readGitHead,
+  runBenchmarkRow,
+  summarizeTransport,
+} from "../scripts/bench-e2e.mjs";
+
+describe("bench-e2e measurement harness", () => {
+  it("uses nearest-rank percentiles instead of copying p50 into p95", () => {
+    const samples = Array.from({ length: 20 }, (_, index) => index + 1);
+
+    expect(nearestRankPercentile(samples, 50)).toBe(10);
+    expect(nearestRankPercentile(samples, 95)).toBe(19);
+  });
+
+  it("builds adjacent MCP/CLI pairs for every required matrix row", () => {
+    const rows = buildBenchmarkRows({
+      concurrency: [1, 5, 10],
+      payloadSizes: [250, 450, 520, 900],
+      samplesPerWorker: 12,
+    });
+
+    expect(rows).toHaveLength(36);
+    for (let index = 0; index < rows.length; index += 2) {
+      expect(rows[index].client).toBe("mcp");
+      expect(rows[index + 1].client).toBe("cli");
+      expect(rows[index + 1]).toMatchObject({
+        operation: rows[index].operation,
+        concurrency: rows[index].concurrency,
+        payload_chars: rows[index].payload_chars,
+        samples_per_worker: 12,
+      });
+    }
+    expect(rows.filter((row) => row.operation === "send_to")).toHaveLength(24);
+    expect(rows.filter((row) => row.operation === "read_screen")).toHaveLength(6);
+    expect(rows.filter((row) => row.operation === "list_surfaces")).toHaveLength(6);
+  });
+
+  it("collects at least twelve samples from every concurrent worker", async () => {
+    let clock = 0;
+    const result = await runBenchmarkRow(
+      {
+        operation: "read_screen",
+        client: "mcp",
+        concurrency: 5,
+        payload_chars: null,
+        samples_per_worker: 12,
+      },
+      {
+        nowMs: () => clock,
+        runOperation: async ({ worker, sample }) => {
+          clock += worker + sample + 1;
+          return {
+            ok: true,
+            transport: "socket",
+            transport_fallbacks: [],
+          };
+        },
+      },
+    );
+
+    expect(result.samples).toHaveLength(60);
+    for (let worker = 0; worker < 5; worker += 1) {
+      expect(result.samples.filter((sample) => sample.worker === worker)).toHaveLength(12);
+    }
+    expect(result.sample_count).toBe(60);
+    expect(result.p95_ms).toBeGreaterThan(result.p50_ms);
+  });
+
+  it("counts transport and every fallback from the raw samples", () => {
+    expect(
+      summarizeTransport([
+        { transport: "socket", transport_fallbacks: [] },
+        { transport: "cli", transport_fallbacks: ["paste_text"] },
+        { transport: "cli", transport_fallbacks: ["paste_text", "send"] },
+      ]),
+    ).toEqual({
+      transport_counts: { socket: 1, cli: 2 },
+      transport_fallback_counts: { paste_text: 2, send: 1 },
+    });
+  });
+
+  it("refuses production or ambiguous socket configuration", () => {
+    expect(() =>
+      assertNightlyIsolation({
+        CMUX_SOCKET_PATH: "/tmp/cmux-production.sock",
+        CMUXLAYER_DAEMON_SOCKET: "/tmp/cmuxlayer-nightly.sock",
+      }),
+    ).toThrow(/nightly/i);
+    expect(() =>
+      assertNightlyIsolation({
+        CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+        CMUXLAYER_DAEMON_SOCKET: "/tmp/cmuxlayer-stated.sock",
+      }),
+    ).toThrow(/isolated daemon/i);
+    expect(
+      assertNightlyIsolation({
+        CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+        CMUXLAYER_DAEMON_SOCKET: "/tmp/cmuxlayer-run10-nightly.sock",
+      }),
+    ).toEqual({
+      cmuxSocketPath: "/tmp/cmux-nightly.sock",
+      daemonSocketPath: "/tmp/cmuxlayer-run10-nightly.sock",
+    });
+  });
+
+  it("creates one right-hand scratch surface per worker and tears down exact refs", async () => {
+    const calls: string[][] = [];
+    const outputs = [
+      "OK surface:21 workspace:7\n",
+      "OK surface:22 workspace:7\n",
+      "OK surface:23 workspace:7\n",
+    ];
+    const fixture = await createScratchTargets(3, {
+      workspace: "workspace:7",
+      controllerSurface: "surface:20",
+      execCmux: async (args: string[]) => {
+        calls.push(args);
+        return { stdout: outputs.shift() ?? "OK\n", stderr: "" };
+      },
+    });
+
+    expect(fixture.targets).toEqual(["surface:21", "surface:22", "surface:23"]);
+    expect(calls.slice(0, 3)).toEqual([
+      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:20", "--focus", "false"],
+      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:21", "--focus", "false"],
+      ["new-split", "right", "--workspace", "workspace:7", "--surface", "surface:22", "--focus", "false"],
+    ]);
+
+    await fixture.close();
+    expect(calls.slice(3)).toEqual([
+      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:23"],
+      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:22"],
+      ["close-surface", "--workspace", "workspace:7", "--surface", "surface:21"],
+    ]);
+  });
+
+  it("uses an inert shell builtin payload of the exact requested size", () => {
+    const payload = payloadText(520, 4, 11);
+
+    expect(payload).toHaveLength(520);
+    expect(payload.startsWith(": run10-e2e w4s11 ")).toBe(true);
+  });
+
+  it("does not mix an environment workspace UUID into raw-surface calls", () => {
+    expect(
+      operationArgs(
+        {
+          operation: "read_screen",
+          payload_chars: null,
+        },
+        "surface:4",
+        "43557C0A-1F0D-4947-98A6-440ACBC0BEF8",
+        0,
+        0,
+      ),
+    ).toEqual({ surface: "surface:4", lines: 20, parsed_only: true });
+    expect(
+      operationArgs(
+        {
+          operation: "list_surfaces",
+          payload_chars: null,
+        },
+        "surface:4",
+        "43557C0A-1F0D-4947-98A6-440ACBC0BEF8",
+        0,
+        0,
+      ),
+    ).toEqual({ workspace: "43557C0A-1F0D-4947-98A6-440ACBC0BEF8", verbose: false });
+  });
+
+  it("marks raw-surface send_to provenance UNTRUSTED under D180", () => {
+    const row = markSurfaceTransportUntrusted({
+      operation: "send_to",
+      client: "mcp",
+      payload_chars: 520,
+      transport_counts: { socket: 2 },
+      transport_fallback_counts: {},
+      samples: [
+        { transport: "socket", transport_fallbacks: [], ok: true },
+        { transport: "socket", transport_fallbacks: [], ok: true },
+      ],
+    });
+
+    expect(row.transport_counts).toEqual({ UNTRUSTED: 2 });
+    expect(row.reported_transport_counts).toEqual({ socket: 2 });
+    expect(row.inferred_transport).toBe("cli");
+    expect(row.transport_note).toContain("D180");
+    expect(row.samples[0]).toMatchObject({
+      transport: "UNTRUSTED",
+      reported_transport: "socket",
+      inferred_transport: "cli",
+      transport_trust: "untrusted",
+    });
+  });
+
+  it("rejects an existing daemon log before startup can continue", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cmuxlayer-bench-e2e-"));
+    const logPath = join(directory, "daemon.log");
+    await writeFile(logPath, "existing\n", "utf8");
+    try {
+      await expect(openExclusiveWriteStream(logPath)).rejects.toMatchObject({
+        code: "EEXIST",
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a benchmark receipt writable when git head lookup fails", async () => {
+    await expect(
+      readGitHead(async () => {
+        throw new Error("git unavailable");
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readGitHead(async () => ({ stdout: "abc123\n", stderr: "" })),
+    ).resolves.toBe("abc123");
+  });
+
+});

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -6,10 +6,13 @@ import { EventEmitter } from "node:events";
 import {
   assertNightlyIsolation,
   buildBenchmarkRows,
+  buildIsolatedRuntimeEnv,
   cliArgs,
   createScratchTargets,
   createSocketReservation,
   daemonLogPath,
+  appendFatalError,
+  appendSettledFailures,
   markSurfaceTransportUntrusted,
   nearestRankPercentile,
   operationArgs,
@@ -344,6 +347,53 @@ describe("bench-e2e measurement harness", () => {
     expect(daemonLogPath("/tmp/bench.json", 42, 1234)).toBe(
       "/tmp/bench.json.daemon-42-1234.log",
     );
+  });
+
+  it("moves daemon socket, monitor, watch, and state paths under the owned run directory", () => {
+    const env = buildIsolatedRuntimeEnv(
+      { PATH: "/usr/bin", HOME: "/opt/example-home" },
+      {
+        ownerDirectory: "/tmp/run10.sock.owner-abc",
+        socketPath: "/tmp/run10.sock.owner-abc/daemon.sock",
+      },
+      "/tmp/cmux-nightly.sock",
+    );
+
+    expect(env).toMatchObject({
+      CMUX_SOCKET_PATH: "/tmp/cmux-nightly.sock",
+      CMUXLAYER_DAEMON_SOCKET: "/tmp/run10.sock.owner-abc/daemon.sock",
+      HOME: "/tmp/run10.sock.owner-abc/home",
+      CMUXLAYER_STATE_DIR: "/tmp/run10.sock.owner-abc/state",
+    });
+    expect(env.CMUXLAYER_SESSION_REGISTRY).toContain(
+      "/tmp/run10.sock.owner-abc/",
+    );
+    expect(env.HOME).not.toBe("/opt/example-home");
+  });
+
+  it("preserves primary, scratch, and daemon cleanup failures", () => {
+    let fatal = appendFatalError(null, new Error("row failed"), "benchmark");
+    fatal = appendFatalError(fatal, new Error("close failed"), "scratch teardown");
+    fatal = appendFatalError(fatal, new Error("stop failed"), "daemon stop");
+
+    expect(fatal).toContain("benchmark: row failed");
+    expect(fatal).toContain("scratch teardown: close failed");
+    expect(fatal).toContain("daemon stop: stop failed");
+  });
+
+  it("preserves every rejected MCP client shutdown", () => {
+    const fatal = appendSettledFailures(
+      null,
+      [
+        { status: "fulfilled", value: undefined },
+        { status: "rejected", reason: new Error("client 1 failed") },
+        { status: "rejected", reason: new Error("client 2 failed") },
+      ],
+      "MCP client stop",
+    );
+
+    expect(fatal).toContain("MCP client stop: client 1 failed");
+    expect(fatal).toContain("MCP client stop: client 2 failed");
   });
 
   it("cancels a pending socket retry without waiting for its deadline", async () => {


### PR DESCRIPTION
## Summary

- add a Nightly-only agent-side benchmark pairing MCP with equivalent direct cmux CLI work for `send_to`, `read_screen`, and `list_surfaces`
- measure c1/c5/c10, 250/450/520/900-character send payloads, at least 12 samples per worker, raw samples, and nearest-rank p50/p95
- isolate socket plus every persistent registry beneath one owned temporary directory; await stdio close and continue teardown through log completion and reservation release
- mark all surface-mode MCP `send_to` transport `UNTRUSTED` under D180, retaining overwritten server metadata only as reported, non-attested data

## BEFORE findings

- D180: surface-mode `send_to` overwrites inner CLI provenance. The table never presents the known-false reported `socket` label as attested truth.
- D181: `report_to_parent` returned `report_caller_unmanaged`; the engine contract report file remains the escalation path.
- D183: the original unique-socket harness inherited real monitor/watch/state paths, explaining D175's phantom benchmark rows. Current isolation moves HOME, daemon socket, monitor/watch registries, state, inbox, session/seat/launcher registries, and sidebar output beneath the run-owned directory.
- D182 confirmed after D183 isolation: c5/520 **13/60**, c5/900 **13/60**, c10/520 **31/120**, c10/900 **25/120** failed with `Buffer not found` (**82/360 total**). This is not a harness artifact.
- Threshold evidence remains valid: MCP 250 chars p50 **75.51 ms** versus 520 chars p50 **464.73 ms** / p95 **797.27 ms**, a **6.2x** p50 increase with 12 successful samples per row.

## Measurement validity

- Pre-fairness `list_surfaces` rows in `full4.json` are real executions but **invalid for MCP-vs-CLI conclusions** and are excluded: the old CLI row did less topology work.
- Post-fix receipt `list-fairness-postfix.json` mirrors MCP's all-window enumeration and retry before pane/surface enumeration. All rows had zero errors:

| concurrency | MCP p50/p95 ms | direct CLI p50/p95 ms | samples each | transport |
|---|---:|---:|---:|---|
| c1 | 39.71 / 89.54 | 479.27 / 609.16 | 12 | MCP socket / CLI cli |
| c5 | 152.63 / 991.75 | 542.55 / 562.33 | 60 | MCP socket / CLI cli |
| c10 | 263.23 / 368.33 | 565.94 / 612.95 | 120 | MCP socket / CLI cli |

- The isolated D182 receipt is `d183-rerun.json`; it supersedes the unisolated failure counts. Pre-fix send/read latency rows remain real samples, subject to D180's `UNTRUSTED` surface-send provenance label.

## Verification

- focused harness + D138: **29/29 passed**
- typecheck: passed
- full suite, inherited socket environment: **155 files, 3,611 passed, 1 skipped**
- full suite, socket authority removed: **155 files, 3,611 passed, 1 skipped**
- independent local CodeRabbit: one minor suggestion rejected because silently treating missing stdio close as success would hide log truncation; no unresolved correctness finding
- phase-0-owned files: no diff
- Nightly pressure only; synthetic clients, no LLM seats, estimated model cost **$0**

— cmuxlayerCodex-e17bf592 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-e17bf592","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a0530a","ts":"2026-08-30T17:02:21Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds benchmark and test tooling only; no production MCP/server path changes, though the script spawns daemons and signals processes when run locally against Nightly.
> 
> **Overview**
> Adds **`scripts/bench-e2e.mjs`**, a Nightly-only executable that benchmarks MCP tool calls against direct **`cmux`** CLI work for `send_to`, `read_screen`, and `list_surfaces` at configurable concurrency (default 1/5/10), send payload sizes, and ≥12 samples per worker. It emits a JSON receipt plus a Markdown summary with nearest-rank **p50/p95**, failure rates, and transport metadata.
> 
> The harness enforces **fairness contracts** so CLI arms mirror MCP topology work where comparable; **`send_to` CLI rows are `NOT_COMPARABLE`** and recorded as absent rather than measured. MCP surface **`send_to`** transport is relabeled **`UNTRUSTED`** (D180) while preserving reported values for audit.
> 
> Runs are isolated: nightly socket checks, per-run daemon socket/state under an owned temp tree, PID locks for output and workspace, clean **`dist`** builds with SHA-256 provenance re-checked during the run, scratch pane splits per worker, and guarded daemon/MCP client lifecycle (including unexpected autostart cleanup). **`tests/bench-e2e.test.ts`** covers matrix building, stats, fairness traces, locks, and teardown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede1f0a6913e1e7cd82995708913af4627c775d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nightly MCP-vs-CLI benchmark harness in `bench-e2e.mjs`
> - Adds a standalone Node.js ESM script that benchmarks MCP client tool invocations against the direct cmux CLI across `send_to`, `read_screen`, and `list_surfaces`, varying concurrency and payload size, then writes a JSON receipt and Markdown summary.
> - Uses fairness contracts to mark `send_to`+CLI as non-comparable; CLI `read_screen`/`list_surfaces` work traces are validated against expected fair pathways.
> - Runs under an isolated per-run daemon with PID-lock reservations, artifact provenance attestation (SHA-256 hashes for built entries, runtime files, and the CLI executable), and strict Nightly isolation checks (`CMUX_SOCKET_PATH` and `CMUXLAYER_DAEMON_SOCKET`).
> - Detects and terminates unexpected daemons auto-started by clients, verifies ownership via environment token, and reports runtime health.
> - Adds a Vitest suite in [bench-e2e.test.ts](https://github.com/EtanHey/cmuxlayer/pull/575/files#diff-c218fd13d6ed51d6eaf0c7815bb973b87dbc915c3405a7e699ab8253e87c6e8c) covering percentile math, row construction, transport summarization, reservation locking, provenance enforcement, daemon lifecycle, and topology traversal.
> - Risk: exits non-zero on any fatal error or provenance drift; requires a clean git worktree and stable HEAD during build via `prepareBuiltEntries`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ede1f0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end benchmarking tool comparing MCP and direct CLI latency.
  - Supports multiple operations, concurrency levels, payload sizes, and client types.
  - Reports p50/p95 latency, transport usage, errors, and comparison results.
  - Produces JSON receipts and Markdown benchmark tables.
  - Runs benchmarks in isolated environments with cleanup, validation, and failure handling.

- **Tests**
  - Added comprehensive coverage for benchmark execution, fairness validation, isolation, reporting, concurrency, cancellation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->