### PR TITLE
Run 10 Phase 1: publish BEFORE fallback gate

### DIFF
--- a/docs/plans/2026-08-31-run10-phase1-publish.md
+++ b/docs/plans/2026-08-31-run10-phase1-publish.md
@@ -40,7 +40,7 @@
 ### Task 3: Verify and open the worker PR
 
 **Files:**
-- Modify in place after handoff: `/Users/etanheyman/.cmux/agents/cmuxlayerCodex-2c968dd2/report.md`
+- Modify in place after handoff: `<agent-report-path>`
 
 1. Run focused tests and inspect the full output.
 2. Run typecheck with socket variables present and with both socket variables unset.

--- a/docs/plans/2026-08-31-run10-phase1-publish.md
+++ b/docs/plans/2026-08-31-run10-phase1-publish.md
@@ -1,0 +1,53 @@
+# Run 10 Phase 1 Publish Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Publish the accepted Run 10 Phase 1 BEFORE matrix without remeasurement and make every MCP-side CLI fallback fail the benchmark process, with its classifier exercised by CI.
+
+**Architecture:** Keep the accepted local receipt immutable and derive the signed PR comment from its 36 rows. Add a pure fallback classifier to `scripts/bench-e2e.mjs`, use it in the process exit gate, and exercise direct-CLI-arm versus MCP-fallback semantics in the Vitest suite that CI runs. GitHub CI cannot execute the live matrix without isolated cmux; it proves the classifier, while an invoked benchmark proves the process exit. The PR comment is the publication artifact: its default section shows non-PASS rows plus an unchanged count, its collapsed section carries all rows, every row has a measurement tag, and the D201 evidence sits beside the data.
+
+**Tech Stack:** Node.js ESM, Vitest, GitHub PR comments, JSON benchmark receipts.
+
+---
+
+### Task 1: Specify the CLI fallback process gate and CI regression
+
+**Files:**
+- Modify: `tests/bench-e2e.test.ts`
+- Modify: `scripts/bench-e2e.mjs`
+
+1. Add a failing test for a pure `benchmarkGateFailures(rows, fatalError)` helper.
+2. Assert that an MCP row with reported `transport_counts.cli`, reported fallback counts, or D180 `inferred_transport: "cli"` produces a `cli fallback active` failure.
+3. Assert that a direct CLI comparison row does not produce a fallback failure.
+4. Run `bunx vitest run tests/bench-e2e.test.ts -t "fails the benchmark gate on every MCP CLI fallback"` and observe the missing export failure.
+5. Implement the minimal helper and replace the current inline exit predicate with it.
+6. Re-run the focused test and the complete harness test file.
+
+### Task 2: Publish the accepted BEFORE matrix
+
+**Files:**
+- Read: `docs.local/scratch/run10-phase1/isolation-test-20260831.json`
+- Create locally, not in Git: `docs.local/scratch/run10-phase1/phase1-before-comment.md`
+
+1. Read the accepted receipt; do not execute `bench-e2e.mjs` again.
+2. Render the 36 rows into the Run 10 PR-comment shape.
+3. Tag the 24 measured rows `sampled` and the 12 absent CLI-send rows `single_shot`; leave every numeric cell blank for `single_shot` rows.
+4. Show only FAIL/NOT_COMPARABLE rows in the default section and state the exact unchanged PASS-row count.
+5. Put all 36 rows in a collapsed `<details>` block.
+6. Mark all surface-mode transport `UNTRUSTED` under D180.
+7. Add D201 evidence with exact measured values: 250/450 are 0% at c1/c5/c10; c1 is 0% at 520/900; c10 failure rates are lower than c5 while latency rises substantially. State that this is evidence against simple capacity exhaustion and for a bounded race window, not a verdict about the racing party.
+
+### Task 3: Verify and open the worker PR
+
+**Files:**
+- Modify in place after handoff: `/Users/etanheyman/.cmux/agents/cmuxlayerCodex-2c968dd2/report.md`
+
+1. Run focused tests and inspect the full output.
+2. Run typecheck with socket variables present and with both socket variables unset.
+3. Run the D138 forbidden-path grep gate and verify no changes to `src/server.ts` or `src/agent-engine.ts`.
+4. Run the full suite in both required environment modes; treat `tests/server.test.ts:4536` only as the known D153 flake if it is the exact failure.
+5. Run bots first on the exact diff; report any real bot defect to the lead before fixing it.
+6. Commit with the verified Codex identity trailer, push, and open a ready-for-review PR.
+7. Post the signed BEFORE publication comment and request bot reviews.
+8. Wait for CI, inspect every bot comment, disposition blocking findings, and run the standalone unresolved-thread query immediately before handoff.
+9. Update the existing report in place with the PR URL, publication table/link, fallback gate proof, tag list, and suite tails. Do not unlink the report.

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -2095,9 +2095,11 @@ function d201Evidence(rows) {
   const observed = [
     "## D201 mechanism evidence",
     "",
-    `- Boundary: 250/450 = 0% at c1, c5, and c10 (${profiles.map((profile) => `${profile} ${row(profile, 250).failure_rate_pct}%/${row(profile, 450).failure_rate_pct}%`).join("; ")}).`,
-    `- Concurrency: c1 = 0% at both 520 and 900 characters (${row("c1", 520).failure_rate_pct}%/${row("c1", 900).failure_rate_pct}%).`,
-    `- Non-monotonic curve: c5 520/900 = ${row("c5", 520).failure_rate_pct}%/${row("c5", 900).failure_rate_pct}% at p50 ${row("c5", 520).p50_ms}/${row("c5", 900).p50_ms} ms; c10 520/900 = ${row("c10", 520).failure_rate_pct}%/${row("c10", 900).failure_rate_pct}% at p50 ${row("c10", 520).p50_ms}/${row("c10", 900).p50_ms} ms. c10 fails less than c5 while latency rises substantially.`,
+    `${boundaryZero ? "- Boundary: 250/450 = 0% at c1, c5, and c10" : "- Observed boundary rates (250/450)"} (${profiles.map((profile) => `${profile} ${row(profile, 250).failure_rate_pct}%/${row(profile, 450).failure_rate_pct}%`).join("; ")}).`,
+    `${c1Zero ? "- Concurrency: c1 = 0% at both 520 and 900 characters" : "- Observed c1 rates (520/900)"} (${row("c1", 520).failure_rate_pct}%/${row("c1", 900).failure_rate_pct}%).`,
+    c10FailsLess && c10LatencyRises
+      ? `- Non-monotonic curve: c5 520/900 = ${row("c5", 520).failure_rate_pct}%/${row("c5", 900).failure_rate_pct}% at p50 ${row("c5", 520).p50_ms}/${row("c5", 900).p50_ms} ms; c10 520/900 = ${row("c10", 520).failure_rate_pct}%/${row("c10", 900).failure_rate_pct}% at p50 ${row("c10", 520).p50_ms}/${row("c10", 900).p50_ms} ms. c10 fails less than c5 while latency rises substantially.`
+      : `- Observed high-payload rates and latency: c5 520/900 = ${row("c5", 520).failure_rate_pct}%/${row("c5", 900).failure_rate_pct}% at p50 ${row("c5", 520).p50_ms}/${row("c5", 900).p50_ms} ms; c10 520/900 = ${row("c10", 520).failure_rate_pct}%/${row("c10", 900).failure_rate_pct}% at p50 ${row("c10", 520).p50_ms}/${row("c10", 900).p50_ms} ms.`,
   ];
   if (boundaryZero && c1Zero && c10FailsLess && c10LatencyRises) {
     observed.push(

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -2051,8 +2051,31 @@ function requiredD201Row(rows, profile, payload) {
 }
 
 function d201Evidence(rows) {
-  const row = (profile, payload) => requiredD201Row(rows, profile, payload);
   const profiles = ["c1", "c5", "c10"];
+  const payloads = [250, 450, 520, 900];
+  const missingRows = profiles.flatMap((profile) =>
+    payloads
+      .filter((payload) => {
+        const candidate = rows.find(
+          (entry) =>
+            entry.operation === "send_to" &&
+            entry.client === "mcp" &&
+            entry.concurrency_profile === profile &&
+            entry.payload_chars === payload,
+        );
+        return !candidate || publicationMeasurementKind(candidate) !== "sampled";
+      })
+      .map((payload) => `${profile} payload=${payload}`),
+  );
+  if (missingRows.length > 0) {
+    return [
+      "## D201 mechanism evidence",
+      "",
+      `- D201: INCONCLUSIVE — required sampled rows are incomplete: ${missingRows.join(", ")}.`,
+    ].join("\n");
+  }
+
+  const row = (profile, payload) => requiredD201Row(rows, profile, payload);
   const boundaryZero = profiles.every(
     (profile) =>
       row(profile, 250).failure_rate_pct === 0 &&

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -2106,12 +2106,16 @@ export function renderPhase1BeforePublication(receipt) {
   );
   const unchangedCount = rows.length - visibleRows.length;
   const gateFailures = benchmarkGateFailures(rows, receipt.fatal_error);
+  const fatalFailure = receipt.fatal_error
+    ? `Fatal gate failure: ${String(receipt.fatal_error).replace(/\s+/g, " ").trim()}`
+    : null;
   return [
     "<!-- cmuxlayer-run10-phase1-before -->",
     `## Run 10 Phase 1 BEFORE: ${gateFailures.length === 0 ? "GREEN" : "RED"}`,
     "",
     `Source: ${receipt.git_head ?? "unknown"} at ${receipt.started_at ?? "unknown"}. Surface-mode transport is **UNTRUSTED** under D180; reported socket provenance is not treated as attested transport.`,
     "",
+    ...(fatalFailure ? [fatalFailure, ""] : []),
     renderPublicationRows(visibleRows),
     "",
     `${unchangedCount} rows unchanged.`,

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1942,14 +1942,15 @@ export function benchmarkGateFailures(rows, fatalError) {
     if (row.inferred_transport === "cli") {
       evidence.push("inferred_transport=cli");
     }
-    let hasAttestedTransport = ["cli", "socket"].includes(
-      row.inferred_transport,
-    );
+    let hasAttestedTransport = false;
     for (const field of ["transport_counts", "reported_transport_counts"]) {
       for (const [transport, count] of positiveCountEntries(row[field])) {
         if (/unknown/i.test(transport)) {
           unattested.push(`${field}.${transport}=${count}`);
-        } else if (transport !== "UNTRUSTED") {
+        } else if (
+          field === "transport_counts" &&
+          ["cli", "socket"].includes(transport)
+        ) {
           hasAttestedTransport = true;
         }
         if (/cli/i.test(transport)) {
@@ -1969,7 +1970,14 @@ export function benchmarkGateFailures(rows, fatalError) {
     if (evidence.length > 0) {
       failures.push(`${identity} cli fallback active: ${evidence.join(", ")}`);
     }
-    if (unattested.length > 0 || !hasAttestedTransport) {
+    const isD180UntrustedSurface =
+      row.operation === "send_to" &&
+      row.transport_trust === "untrusted" &&
+      Number(row.transport_fallback_counts?.UNTRUSTED_D180) > 0;
+    if (
+      unattested.length > 0 ||
+      (!hasAttestedTransport && !isD180UntrustedSurface)
+    ) {
       failures.push(
         `${identity} unattested transport: ${unattested.join(", ") || "no attested transport"}`,
       );

--- a/scripts/bench-e2e.mjs
+++ b/scripts/bench-e2e.mjs
@@ -1918,6 +1918,208 @@ function compactCounts(counts) {
     : entries.map(([name, count]) => `${name}:${count}`).join(",");
 }
 
+function benchmarkRowIdentity(row) {
+  return `${row.operation} ${row.client} ${row.concurrency_profile ?? `c${row.concurrency}`} payload=${row.payload_chars ?? "-"}`;
+}
+
+function positiveCountEntries(counts) {
+  return Object.entries(counts ?? {}).filter(
+    ([, count]) => Number.isFinite(count) && count > 0,
+  );
+}
+
+export function benchmarkGateFailures(rows, fatalError) {
+  const failures = [];
+  if (fatalError) failures.push(`fatal: ${fatalError}`);
+  for (const row of rows) {
+    const identity = benchmarkRowIdentity(row);
+    if (Number(row.error_count) > 0) {
+      failures.push(`${identity} operation errors: ${row.error_count}`);
+    }
+    if (row.client !== "mcp") continue;
+    const evidence = [];
+    const unattested = [];
+    if (row.inferred_transport === "cli") {
+      evidence.push("inferred_transport=cli");
+    }
+    let hasAttestedTransport = ["cli", "socket"].includes(
+      row.inferred_transport,
+    );
+    for (const field of ["transport_counts", "reported_transport_counts"]) {
+      for (const [transport, count] of positiveCountEntries(row[field])) {
+        if (/unknown/i.test(transport)) {
+          unattested.push(`${field}.${transport}=${count}`);
+        } else if (transport !== "UNTRUSTED") {
+          hasAttestedTransport = true;
+        }
+        if (/cli/i.test(transport)) {
+          evidence.push(`${field}.${transport}=${count}`);
+        }
+      }
+    }
+    for (const field of [
+      "transport_fallback_counts",
+      "reported_transport_fallback_counts",
+    ]) {
+      for (const [fallback, count] of positiveCountEntries(row[field])) {
+        if (fallback === "UNTRUSTED_D180") continue;
+        evidence.push(`${field}.${fallback}=${count}`);
+      }
+    }
+    if (evidence.length > 0) {
+      failures.push(`${identity} cli fallback active: ${evidence.join(", ")}`);
+    }
+    if (unattested.length > 0 || !hasAttestedTransport) {
+      failures.push(
+        `${identity} unattested transport: ${unattested.join(", ") || "no attested transport"}`,
+      );
+    }
+  }
+  return failures;
+}
+
+function publicationMeasurementKind(row) {
+  return Number(row.sample_count) > 1 && Number(row.attempt_count) > 1
+    ? "sampled"
+    : "single_shot";
+}
+
+function publicationStatus(row) {
+  if (row.comparison_status === "NOT_COMPARABLE") return "NOT_COMPARABLE";
+  return benchmarkGateFailures([row], null).length === 0 ? "PASS" : "FAIL";
+}
+
+function publicationGateReason(row) {
+  if (row.comparison_status === "NOT_COMPARABLE") return "FAIRNESS_CONTRACT";
+  const failures = benchmarkGateFailures([row], null);
+  const reasons = [];
+  if (failures.some((failure) => failure.includes("cli fallback active"))) {
+    reasons.push("CLI_FALLBACK");
+  }
+  if (Number(row.error_count) > 0) reasons.push("OPERATION_ERROR");
+  if (failures.some((failure) => failure.includes("unattested transport"))) {
+    reasons.push("UNATTESTED_TRANSPORT");
+  }
+  return reasons.join(", ") || "—";
+}
+
+function publicationValue(row, value) {
+  if (publicationMeasurementKind(row) !== "sampled") return "—";
+  return value ?? "—";
+}
+
+function publicationTransport(row) {
+  if (row.operation === "send_to" && row.client === "mcp") {
+    return "UNTRUSTED (D180)";
+  }
+  return compactCounts(row.transport_counts ?? {});
+}
+
+function renderPublicationRows(rows) {
+  const lines = [
+    "| operation | profile | payload | client | measurement | status | reason | attempts | successes | failure % | p50 ms | p95 ms | transport |",
+    "|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---|",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.operation} | ${row.concurrency_profile} | ${row.payload_chars ?? "-"} | ${row.client} | ${publicationMeasurementKind(row)} | ${publicationStatus(row)} | ${publicationGateReason(row)} | ${publicationValue(row, row.attempt_count)} | ${publicationValue(row, row.success_count)} | ${publicationValue(row, row.failure_rate_pct)} | ${publicationValue(row, row.p50_ms)} | ${publicationValue(row, row.p95_ms)} | ${publicationTransport(row)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function requiredD201Row(rows, profile, payload) {
+  const row = rows.find(
+    (candidate) =>
+      candidate.operation === "send_to" &&
+      candidate.client === "mcp" &&
+      candidate.concurrency_profile === profile &&
+      candidate.payload_chars === payload,
+  );
+  if (!row || publicationMeasurementKind(row) !== "sampled") {
+    throw new Error(`missing sampled D201 row ${profile} payload=${payload}`);
+  }
+  return row;
+}
+
+function d201Evidence(rows) {
+  const row = (profile, payload) => requiredD201Row(rows, profile, payload);
+  const profiles = ["c1", "c5", "c10"];
+  const boundaryZero = profiles.every(
+    (profile) =>
+      row(profile, 250).failure_rate_pct === 0 &&
+      row(profile, 450).failure_rate_pct === 0,
+  );
+  const c1Zero = [520, 900].every(
+    (payload) => row("c1", payload).failure_rate_pct === 0,
+  );
+  const c10FailsLess = [520, 900].every(
+    (payload) =>
+      row("c10", payload).failure_rate_pct <
+      row("c5", payload).failure_rate_pct,
+  );
+  const c10LatencyRises = [520, 900].every(
+    (payload) => row("c10", payload).p50_ms > row("c5", payload).p50_ms,
+  );
+  const observed = [
+    "## D201 mechanism evidence",
+    "",
+    `- Boundary: 250/450 = 0% at c1, c5, and c10 (${profiles.map((profile) => `${profile} ${row(profile, 250).failure_rate_pct}%/${row(profile, 450).failure_rate_pct}%`).join("; ")}).`,
+    `- Concurrency: c1 = 0% at both 520 and 900 characters (${row("c1", 520).failure_rate_pct}%/${row("c1", 900).failure_rate_pct}%).`,
+    `- Non-monotonic curve: c5 520/900 = ${row("c5", 520).failure_rate_pct}%/${row("c5", 900).failure_rate_pct}% at p50 ${row("c5", 520).p50_ms}/${row("c5", 900).p50_ms} ms; c10 520/900 = ${row("c10", 520).failure_rate_pct}%/${row("c10", 900).failure_rate_pct}% at p50 ${row("c10", 520).p50_ms}/${row("c10", 900).p50_ms} ms. c10 fails less than c5 while latency rises substantially.`,
+  ];
+  if (boundaryZero && c1Zero && c10FailsLess && c10LatencyRises) {
+    observed.push(
+      "- Interpretation: this is evidence against simple capacity exhaustion and for a bounded race window. It narrows candidates; it does not identify the racing party. Read the buffer store capacity and eviction policy before proposing a paste-path fix.",
+    );
+  } else {
+    const failedPredicates = [
+      [boundaryZero, "250/450 zero-rate boundary"],
+      [c1Zero, "c1 520/900 zero-rate condition"],
+      [c10FailsLess, "c10-below-c5 failure-rate condition"],
+      [c10LatencyRises, "c10-above-c5 latency condition"],
+    ]
+      .filter(([holds]) => !holds)
+      .map(([, label]) => label);
+    observed.push(
+      `- D201: INCONCLUSIVE — ${failedPredicates.join(", ")} did not hold. The observed rates remain recorded above, but no capacity/race interpretation is published.`,
+    );
+  }
+  return observed.join("\n");
+}
+
+export function renderPhase1BeforePublication(receipt) {
+  if (!Array.isArray(receipt?.rows) || receipt.rows.length === 0) {
+    throw new Error("phase-1 publication requires benchmark rows");
+  }
+  const rows = receipt.rows;
+  const visibleRows = rows.filter(
+    (row) => publicationStatus(row) !== "PASS" || row.moved === true,
+  );
+  const unchangedCount = rows.length - visibleRows.length;
+  const gateFailures = benchmarkGateFailures(rows, receipt.fatal_error);
+  return [
+    "<!-- cmuxlayer-run10-phase1-before -->",
+    `## Run 10 Phase 1 BEFORE: ${gateFailures.length === 0 ? "GREEN" : "RED"}`,
+    "",
+    `Source: ${receipt.git_head ?? "unknown"} at ${receipt.started_at ?? "unknown"}. Surface-mode transport is **UNTRUSTED** under D180; reported socket provenance is not treated as attested transport.`,
+    "",
+    renderPublicationRows(visibleRows),
+    "",
+    `${unchangedCount} rows unchanged.`,
+    "",
+    "<details>",
+    `<summary>Full ${rows.length}-row BEFORE table</summary>`,
+    "",
+    renderPublicationRows(rows),
+    "",
+    "</details>",
+    "",
+    d201Evidence(rows),
+    "",
+  ].join("\n");
+}
+
 export function renderMarkdownTable(rows) {
   const lines = [
     "| operation | profile | payload | client | status | attempts | successes | failure % | p50 ms | p95 ms | transport | fallbacks |",
@@ -2859,6 +3061,7 @@ async function executeBenchmark(
     fatalError = appendFatalError(fatalError, error, "workspace release");
   }
 
+  const gateFailures = benchmarkGateFailures(results, fatalError);
   const receipt = {
     schema_version: 1,
     kind: "cmuxlayer-agent-side-e2e-benchmark",
@@ -2923,6 +3126,10 @@ async function executeBenchmark(
     },
     rows: results,
     fatal_error: fatalError,
+    ci_gate: {
+      verdict: gateFailures.length === 0 ? "GREEN" : "RED",
+      failures: gateFailures,
+    },
   };
   await publishBenchmarkReceipt(
     config.out,
@@ -2933,7 +3140,7 @@ async function executeBenchmark(
   );
   process.stdout.write(`${renderMarkdownTable(results)}\n`);
   process.stdout.write(`[bench-e2e] receipt ${config.out}\n`);
-  if (fatalError || results.some((row) => row.error_count > 0)) {
+  if (gateFailures.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -568,6 +568,33 @@ describe("bench-e2e measurement harness", () => {
         "evidence against simple capacity exhaustion",
       );
     }
+
+    const contradictory = renderPhase1BeforePublication({
+      ...receipt,
+      rows: receipt.rows.map((row) => {
+        const replacement = [
+          ["c5", 450, 1],
+          ["c1", 900, 1],
+          ["c10", 520, 30],
+        ].find(
+          ([profile, payload]) =>
+            row.operation === "send_to" &&
+            row.client === "mcp" &&
+            row.concurrency_profile === profile &&
+            row.payload_chars === payload,
+        );
+        return replacement ? { ...row, failure_rate_pct: replacement[2] } : row;
+      }),
+    });
+    expect(contradictory).not.toContain("250/450 = 0% at c1, c5, and c10");
+    expect(contradictory).not.toContain(
+      "c1 = 0% at both 520 and 900 characters",
+    );
+    expect(contradictory).not.toContain(
+      "c10 fails less than c5 while latency rises substantially",
+    );
+    expect(contradictory).toContain("Observed boundary rates");
+    expect(contradictory).toContain("Observed high-payload rates and latency");
   });
 
   it("refuses production or ambiguous socket configuration", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -352,6 +352,7 @@ describe("bench-e2e measurement harness", () => {
       reported_transport_counts: { socket: 12 },
       reported_transport_fallback_counts: {},
       inferred_transport: "socket",
+      transport_trust: "untrusted",
     };
 
     expect(benchmarkGateFailures([directCliArm, socketMcpArm], null)).toEqual(
@@ -374,6 +375,7 @@ describe("bench-e2e measurement harness", () => {
         {
           ...socketMcpArm,
           operation: "list_surfaces",
+          transport_counts: { socket: 12 },
           reported_transport_fallback_counts: { cli_fallback_active: 1 },
         },
         {
@@ -383,16 +385,24 @@ describe("bench-e2e measurement harness", () => {
           reported_transport_counts: {},
           inferred_transport: undefined,
         },
+        {
+          ...socketMcpArm,
+          operation: "list_surfaces",
+          transport_counts: {},
+          reported_transport_counts: { socket: 12 },
+          inferred_transport: "socket",
+        },
       ],
       null,
     );
 
-    expect(failures).toHaveLength(4);
+    expect(failures).toHaveLength(5);
     expect(failures.slice(0, 3).every((failure) =>
       failure.includes("cli fallback active"),
     )).toBe(true);
     expect(failures[0]).toContain("send_to mcp c5 payload=520");
     expect(failures[3]).toContain("unattested transport: transport_counts.unknown=12");
+    expect(failures[4]).toContain("unattested transport: no attested transport");
   });
 
   it("renders the phase-1 BEFORE publication with tags, collapsed rows, and D201 evidence", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -526,6 +526,15 @@ describe("bench-e2e measurement harness", () => {
     expect(fatalMarkdown.split("<details>")[0]).toContain(
       "Fatal gate failure: workspace release failed after measurement",
     );
+
+    const partialFatalMarkdown = renderPhase1BeforePublication({
+      ...receipt,
+      fatal_error: "daemon stopped before matrix completion",
+      rows: receipt.rows.filter((row) => row.operation === "read_screen"),
+    });
+    expect(partialFatalMarkdown).toContain(
+      "D201: INCONCLUSIVE — required sampled rows are incomplete:",
+    );
     expect(markdown).toContain("250/450 = 0% at c1, c5, and c10");
     expect(markdown).toContain("c1 = 0% at both 520 and 900 characters");
     expect(markdown).toContain(

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -21,6 +21,7 @@ import {
   assertOutputOutsideGitMetadata,
   assertNightlyIsolation,
   assertArtifactProvenance,
+  benchmarkGateFailures,
   assertLockPathIdentity,
   assertLockFileAuthority,
   assertCliFairnessTrace,
@@ -57,6 +58,7 @@ import {
   provenanceStatusArgs,
   publishWithLockHolder,
   publishBenchmarkReceipt,
+  renderPhase1BeforePublication,
   renderMarkdownTable,
   releaseReservations,
   resolveGitMetadataPaths,
@@ -328,6 +330,217 @@ describe("bench-e2e measurement harness", () => {
 
     expect(table).toContain("| attempts | successes | failure % | p50 ms |");
     expect(table).toContain("| 60 | 47 | 21.67 | 100 | 200 |");
+  });
+
+  it("fails the benchmark gate on every MCP CLI fallback", () => {
+    const directCliArm = {
+      operation: "read_screen",
+      client: "cli",
+      concurrency_profile: "c1",
+      error_count: 0,
+      transport_counts: { cli: 12 },
+      transport_fallback_counts: {},
+    };
+    const socketMcpArm = {
+      operation: "send_to",
+      client: "mcp",
+      concurrency_profile: "c1",
+      payload_chars: 450,
+      error_count: 0,
+      transport_counts: { UNTRUSTED: 12 },
+      transport_fallback_counts: { UNTRUSTED_D180: 12 },
+      reported_transport_counts: { socket: 12 },
+      reported_transport_fallback_counts: {},
+      inferred_transport: "socket",
+    };
+
+    expect(benchmarkGateFailures([directCliArm, socketMcpArm], null)).toEqual(
+      [],
+    );
+
+    const failures = benchmarkGateFailures(
+      [
+        {
+          ...socketMcpArm,
+          concurrency_profile: "c5",
+          payload_chars: 520,
+          inferred_transport: "cli",
+        },
+        {
+          ...socketMcpArm,
+          operation: "read_screen",
+          transport_counts: { cli: 1, socket: 11 },
+        },
+        {
+          ...socketMcpArm,
+          operation: "list_surfaces",
+          reported_transport_fallback_counts: { cli_fallback_active: 1 },
+        },
+        {
+          ...socketMcpArm,
+          operation: "read_screen",
+          transport_counts: { unknown: 12 },
+          reported_transport_counts: {},
+          inferred_transport: undefined,
+        },
+      ],
+      null,
+    );
+
+    expect(failures).toHaveLength(4);
+    expect(failures.slice(0, 3).every((failure) =>
+      failure.includes("cli fallback active"),
+    )).toBe(true);
+    expect(failures[0]).toContain("send_to mcp c5 payload=520");
+    expect(failures[3]).toContain("unattested transport: transport_counts.unknown=12");
+  });
+
+  it("renders the phase-1 BEFORE publication with tags, collapsed rows, and D201 evidence", () => {
+    const d201 = {
+      c1: {
+        250: [0, 100],
+        450: [0, 110],
+        520: [0, 120],
+        900: [0, 130],
+      },
+      c5: {
+        250: [0, 700],
+        450: [0, 710],
+        520: [25, 819.45],
+        900: [23.33, 1234.46],
+      },
+      c10: {
+        250: [0, 1400],
+        450: [0, 1500],
+        520: [8.33, 1753.81],
+        900: [6.67, 2198.73],
+      },
+    };
+    const sendRows = Object.entries(d201).flatMap(([profile, payloads]) =>
+      Object.entries(payloads).map(([payload, [failureRate, p50]]) => ({
+        operation: "send_to",
+        client: "mcp",
+        concurrency_profile: profile,
+        payload_chars: Number(payload),
+        comparison_status: "MEASURED",
+        sample_count: Number(profile.slice(1)) * 12,
+        attempt_count: Number(profile.slice(1)) * 12,
+        success_count:
+          (Number(profile.slice(1)) * 12 * (100 - failureRate)) / 100,
+        failure_rate_pct: failureRate,
+        p50_ms: p50,
+        p95_ms: p50 + 100,
+        error_count: failureRate === 0 ? 0 : 1,
+        transport_counts: { UNTRUSTED: Number(profile.slice(1)) * 12 },
+        transport_fallback_counts: {
+          UNTRUSTED_D180: Number(profile.slice(1)) * 12,
+        },
+        transport_trust: "untrusted",
+        inferred_transport: Number(payload) > 500 ? "cli" : "socket",
+      })),
+    );
+    const receipt = {
+      git_head: "a".repeat(40),
+      started_at: "2026-08-31T12:25:31.400Z",
+      fatal_error: null,
+      rows: [
+        ...sendRows,
+        {
+          operation: "read_screen",
+          client: "mcp",
+          concurrency_profile: "c1",
+          payload_chars: null,
+          comparison_status: "MEASURED",
+          sample_count: 12,
+          attempt_count: 12,
+          success_count: 12,
+          failure_rate_pct: 0,
+          p50_ms: 40,
+          p95_ms: 50,
+          error_count: 0,
+          transport_counts: { socket: 12 },
+          transport_fallback_counts: {},
+        },
+        {
+          operation: "list_surfaces",
+          client: "cli",
+          concurrency_profile: "c10",
+          payload_chars: null,
+          comparison_status: "MEASURED",
+          sample_count: 120,
+          attempt_count: 120,
+          success_count: 106,
+          failure_rate_pct: 11.67,
+          p50_ms: 655.48,
+          p95_ms: 859.84,
+          error_count: 14,
+          transport_counts: { cli: 106, unknown: 14 },
+          transport_fallback_counts: {},
+        },
+        {
+          operation: "send_to",
+          client: "cli",
+          concurrency_profile: "c1",
+          payload_chars: 250,
+          comparison_status: "NOT_COMPARABLE",
+          sample_count: 0,
+          attempt_count: 0,
+          success_count: 0,
+          failure_rate_pct: null,
+          p50_ms: null,
+          p95_ms: null,
+          error_count: 0,
+          transport_counts: {},
+          transport_fallback_counts: {},
+        },
+      ],
+    };
+    const markdown = renderPhase1BeforePublication(receipt);
+
+    const summary = markdown.split("<details>")[0];
+    expect(summary).toContain("7 rows unchanged");
+    expect(summary).not.toContain("| read_screen | c1 | - | mcp |");
+    expect(summary).toContain(
+      "| send_to | c5 | 520 | mcp | sampled | FAIL | CLI_FALLBACK, OPERATION_ERROR |",
+    );
+    expect(summary).toContain(
+      "| send_to | c1 | 250 | cli | single_shot | NOT_COMPARABLE | FAIRNESS_CONTRACT | — | — | — | — | — |",
+    );
+    expect(markdown).toContain("<summary>Full 15-row BEFORE table</summary>");
+    expect(markdown).toContain("| read_screen | c1 | - | mcp | sampled | PASS |");
+    expect(markdown).toContain("250/450 = 0% at c1, c5, and c10");
+    expect(markdown).toContain("c1 = 0% at both 520 and 900 characters");
+    expect(markdown).toContain(
+      "c5 520/900 = 25%/23.33% at p50 819.45/1234.46 ms",
+    );
+    expect(markdown).toContain(
+      "c10 520/900 = 8.33%/6.67% at p50 1753.81/2198.73 ms",
+    );
+    expect(markdown).toContain("evidence against simple capacity exhaustion");
+    expect(markdown).toContain("does not identify the racing party");
+
+    const predicateBreaks = [
+      ["c5", 450, 1],
+      ["c1", 900, 1],
+      ["c10", 520, 30],
+    ];
+    for (const [profile, payload, failureRate] of predicateBreaks) {
+      const inconclusive = renderPhase1BeforePublication({
+        ...receipt,
+        rows: receipt.rows.map((row) =>
+          row.operation === "send_to" &&
+          row.client === "mcp" &&
+          row.concurrency_profile === profile &&
+          row.payload_chars === payload
+            ? { ...row, failure_rate_pct: failureRate }
+            : row,
+        ),
+      });
+      expect(inconclusive).toContain("D201: INCONCLUSIVE");
+      expect(inconclusive).not.toContain(
+        "evidence against simple capacity exhaustion",
+      );
+    }
   });
 
   it("refuses production or ambiguous socket configuration", () => {

--- a/tests/bench-e2e.test.ts
+++ b/tests/bench-e2e.test.ts
@@ -518,6 +518,14 @@ describe("bench-e2e measurement harness", () => {
     );
     expect(markdown).toContain("<summary>Full 15-row BEFORE table</summary>");
     expect(markdown).toContain("| read_screen | c1 | - | mcp | sampled | PASS |");
+
+    const fatalMarkdown = renderPhase1BeforePublication({
+      ...receipt,
+      fatal_error: "workspace release failed after measurement",
+    });
+    expect(fatalMarkdown.split("<details>")[0]).toContain(
+      "Fatal gate failure: workspace release failed after measurement",
+    );
     expect(markdown).toContain("250/450 = 0% at c1, c5, and c10");
     expect(markdown).toContain("c1 = 0% at both 520 and 900 characters");
     expect(markdown).toContain(


### PR DESCRIPTION
## Summary

- publish the accepted Run 10 Phase 1 BEFORE receipt without remeasurement
- make every observed MCP-side CLI fallback fail the benchmark process and emit `ci_gate` receipt evidence
- render compact non-PASS/moved rows, a collapsed full table, measurement tags, explicit gate reasons, D180 transport trust, and conditional D201 mechanism evidence

## Scope

- no `src/server.ts`, `src/agent-engine.ts`, socket-routing, or paste-path changes
- accepted receipt remains immutable
- no new P0/P1 found versus main

## Verification

- `bun test tests/bench-e2e.test.ts`: 113 passed
- `bun run test`: 155 files, 3,696 passed, 1 skipped, exit 0
- unset `CMUX_SOCKET_PATH` / `CMUX_DAEMON_SOCKET` full suite: same 155 / 3,696 / 1, exit 0
- `bun run typecheck` in both environment modes: exit 0
- D138 `tests/no-machine-home-literals.test.ts`: 1 passed
- protected push hook: 155 files, 3,696 passed, 1 skipped, exit 0
- local CodeRabbit repair review: zero findings
- Claude pair-review: actionable findings repaired and re-reviewed

CI note: GitHub CI exercises the fallback classifier through Vitest. The live benchmark itself requires isolated cmux and is not run by GitHub Actions; when invoked, the benchmark process exits nonzero on any MCP CLI fallback and records the reasons in `ci_gate`.

— cmuxlayerCodex-2c968dd2 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-2c968dd2","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a057c1","ts":"2026-08-31T13:28:54Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: benchmark runs that previously exited 0 can now fail on MCP transport gating; impact is limited to the bench harness and publication tooling, not production MCP routing.
> 
> **Overview**
> Adds a **benchmark CI gate** in `scripts/bench-e2e.mjs`: exported `benchmarkGateFailures` flags fatal errors, row operation errors, MCP **CLI fallback** evidence (inferred transport, transport counts, fallback counts), and **unattested transport** on MCP rows, with an exception for D180 untrusted `send_to` surface rows. The harness **exit code** now follows any gate failure instead of only `fatal_error` / `error_count`, and JSON receipts gain **`ci_gate`** (`verdict` + `failures`).
> 
> Also adds **`renderPhase1BeforePublication`** to turn an immutable receipt into Run 10 Phase 1 BEFORE PR-comment markdown: non-PASS summary table, collapsed full matrix, `sampled` / `single_shot` tags, gate reason codes, D180 **UNTRUSTED** transport labeling, and conditional **D201** mechanism evidence (or INCONCLUSIVE when predicates or rows are incomplete).
> 
> **Vitest** in `tests/bench-e2e.test.ts` locks in five fallback/unattested scenarios and publication/D201 edge cases. A **implementation plan** doc is added under `docs/plans/`; no server or agent-engine changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d758552686944a86fa2d749187b220096add0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add benchmark gate and Phase 1 BEFORE publication renderer to `scripts/bench-e2e.mjs`
> - Adds `benchmarkGateFailures` which classifies benchmark rows as failures for fatal errors, per-row operation errors, MCP CLI fallback evidence, and unattested transports
> - Adds `renderPhase1BeforePublication` which produces a markdown publication artifact with visible/collapsed tables, gate verdicts, and D201 evidence predicates for profiles c1/c5/c10 and payloads 250/450/520/900
> - Modifies `executeBenchmark` to embed a `ci_gate` block in the receipt and set a non-zero exit code whenever the gate produces any failure
> - Behavioral Change: `executeBenchmark` now exits non-zero on MCP CLI fallback or unattested transports, not only on fatal errors or `error_count > 0`; consumers reading the receipt must handle the new `ci_gate` field
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d75855.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark validation for CLI fallbacks, unsupported transport evidence, and other gating failures.
  * Added publication output for the Phase 1 BEFORE benchmark matrix, including measurement tags and D201 evidence.
  * Benchmark receipts now include a clear CI gate verdict.

* **Bug Fixes**
  * Benchmark runs now exit with a failure status whenever any configured gate fails, not only on fatal errors.

* **Tests**
  * Added coverage for gate detection, publication formatting, collapsed results, evidence details, and inconclusive outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->