### PR TITLE
fix: fingerprint prompt delivery receipts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, mkdtempSync, rmSync } from "node:fs";
 import { access, appendFile, mkdir, readFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
@@ -677,7 +677,8 @@ const DeliveryReceiptOutputSchema = z
   .object({
     ...DeliveryOutputShape,
     bytes: z.number().int().nonnegative().optional(),
-    prompt_text: z.string().nullable().optional(),
+    prompt_bytes: z.number().int().nonnegative().optional(),
+    prompt_sha256: z.string().optional(),
     prompt_warning: z.string().nullable().optional(),
   })
   .passthrough();
@@ -7256,6 +7257,14 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     );
   };
 
+  const fingerprintPromptReceipt = <T extends object>(receipt: T, prompt: string) =>
+    Object.defineProperty(Object.assign(receipt, {
+      prompt_bytes: Buffer.byteLength(prompt, "utf8"),
+      prompt_sha256: createHash("sha256").update(prompt).digest("hex"),
+    }), "prompt_text", { value: hasInlinePrompt(prompt) ? prompt : null }) as unknown as T & {
+      prompt_text: string | null;
+    };
+
   const deliverBootPrompt = async (opts: {
     surface: string;
     stableSurfaceIdentity?: string | null;
@@ -7281,7 +7290,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       !bootPromptPath &&
       !hasInlinePrompt(opts.injected_prompt)
     ) {
-      return {
+      return fingerprintPromptReceipt({
         ...buildPublicDeliveryReceipt({
           typed: false,
           submit_attempted: false,
@@ -7289,9 +7298,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           retry_count: 0,
         }),
         bytes: 0,
-        prompt_text: null,
         prompt_warning: null,
-      };
+      }, "");
     }
 
     const rawPrompt = bootPromptPath
@@ -7368,7 +7376,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         }
       : undefined;
     if (readiness.delivery_state === "queued") {
-      return {
+      return fingerprintPromptReceipt({
         ...buildPublicDeliveryReceipt({
           delivery_state: "queued",
           typed: false,
@@ -7383,9 +7391,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             "the live pane remains available for inspection or retry.",
         }),
         bytes: 0,
-        prompt_text: hasInlinePrompt(rawPrompt) ? rawPrompt : null,
         prompt_warning: promptWarning,
-      };
+      }, rawPrompt);
     }
     let sentChunks = 0;
 
@@ -7421,11 +7428,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           stableSurfaceIdentity: opts.stableSurfaceIdentity,
         },
       );
-      return {
+      return fingerprintPromptReceipt({
         ...delivery,
-        prompt_text: hasInlinePrompt(rawPrompt) ? rawPrompt : null,
         prompt_warning: promptWarning,
-      };
+      }, rawPrompt);
     } catch (error) {
       if (error instanceof SurfaceGoneError) {
         throw error;
@@ -7467,7 +7473,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               error,
             );
           }
-          return {
+          return fingerprintPromptReceipt({
             ...buildPublicDeliveryReceipt({
               delivery_state: "submitted",
               typed: true,
@@ -7477,9 +7483,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               retry_count: error.retry_count,
             }),
             bytes: Buffer.byteLength(sanitizedText, "utf8"),
-            prompt_text: rawPrompt,
             prompt_warning: promptWarning,
-          };
+          }, rawPrompt);
         }
       }
 

--- a/tests/pointer-discipline.test.ts
+++ b/tests/pointer-discipline.test.ts
@@ -875,6 +875,23 @@ describe("pane input pointer discipline", () => {
     context.dispose();
   });
 
+  it("fingerprints inline and file-backed prompt receipts without echoing them", async () => {
+    const promptPath = join(testDir, "receipt-prompt.md"), prompts = ["inline receipt secret", "file-backed receipt secret\nsecond line"];
+    writeFileSync(promptPath, prompts[1]!, "utf8");
+    const { createServer, createServerContext } = await loadServerModule();
+    for (const [index, prompt] of prompts.entries()) {
+      const context = createServerContext({ exec: makeLifecycleExec(), stateDir: join(testDir, `receipt-${index}`),
+        disableSpawnPreflight: true, sessionIdentityResolver: () => null });
+      const result = await (createServer({ context }) as any)._registeredTools.spawn_agent.handler(
+        { repo: "brainlayer", model: "codex", cli: "codex", workspace: "workspace:1",
+          ...(index === 0 ? { prompt } : { boot_prompt_path: promptPath }) }, {} as any);
+      const receipt = parseToolResult(result).boot_prompt_receipt;
+      expect(receipt).toMatchObject({ prompt_bytes: Buffer.byteLength(prompt), prompt_sha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+      expect(JSON.stringify(receipt)).not.toContain(prompt);
+      context.dispose();
+    }
+  });
+
   it.each([
     {
       toolName: "new_worktree_split",


### PR DESCRIPTION
## Summary
- replace receipt `prompt_text` echoes with `prompt_bytes` and `prompt_sha256`
- preserve the full prompt as non-enumerable internal state for registry persistence
- cover inline and `boot_prompt_path` receipts with one regression test

## Verification
- focused regression: 1 passed, 36 skipped
- pointer discipline file: 37 passed
- typecheck: passed with socket environment inherited and unset
- full suite, socket inherited: 155 files passed; 3,705 tests passed; 1 skipped
- full suite, socket unset: 155 files passed; 3,705 tests passed; 1 skipped
- pre-push suite: 155 files passed; 3,705 tests passed; 1 skipped
- D138 forbidden `/Users/` grep: zero matches outside docs
- changed-line count: 50 (36 insertions, 14 deletions)
- local CodeRabbit pre-commit attempt: timed out at the mandated 180-second cap without emitting findings

— cmuxlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a05971","ts":"2026-08-31T20:37:28Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to boot-prompt receipt serialization with a deliberate public API break (`prompt_text` → fingerprints); delivery behavior is unchanged aside from what clients see in receipts.
> 
> **Overview**
> **Boot prompt delivery receipts** no longer expose full prompt content in the public tool output. They now return **`prompt_bytes`** and **`prompt_sha256`** so callers can verify what was delivered without leaking secrets in logs or MCP responses.
> 
> All **`deliverBootPrompt`** return paths go through a new **`fingerprintPromptReceipt`** helper that attaches the fingerprint fields and, when needed for registry persistence, keeps the full text on a **non-enumerable `prompt_text`** property so **`JSON.stringify`** on the receipt (as in tests) does not include the prompt.
> 
> The **`DeliveryReceiptOutputSchema`** is updated accordingly (`prompt_text` removed from the public schema). A regression test covers inline prompts and **`boot_prompt_path`** and asserts the serialized receipt never contains the prompt body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2e1cd360ffea41df67413edb834296e0c3de7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `prompt_text` in delivery receipts with `prompt_bytes` and `prompt_sha256` fingerprint
> - Boot prompt delivery receipts now include `prompt_bytes` (UTF-8 byte length) and `prompt_sha256` (hex SHA-256) instead of the raw `prompt_text` field, so prompt contents are no longer echoed in serialized receipts.
> - A new `fingerprintPromptReceipt` helper inside `createServer` augments each receipt and sets `prompt_text` as a non-enumerable property (null when no inline prompt).
> - Updates `DeliveryReceiptOutputSchema` to declare `prompt_bytes` and `prompt_sha256` and drop `prompt_text`.
> - Risk: `prompt_text` is removed from the declared schema in `DeliveryReceiptOutputSchema`; any external consumer expecting `prompt_text` in JSON output will no longer receive it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b2e1cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->