### PR TITLE
chore: release v0.4.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.68",
+  "version": "0.4.69",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Automated version-bump PR for cmuxlayer v0.4.69. The release tag is created only after required checks pass and this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or behavioral changes.
> 
> **Overview**
> Automated release PR that **bumps `package.json` version** from `0.4.68` to **`0.4.69`**. No source, dependency, or script changes—only the published package version is updated ahead of tagging after merge and checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264ff96617d15294f39dd78e4feeff81c39f765d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version to 0.4.69
> Updates the version field in [package.json](https://github.com/EtanHey/cmuxlayer/pull/582/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 0.4.68 to 0.4.69. This is a routine release tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 264ff96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->