### PR TITLE
fix(#442): acknowledge-and-retry for the draft guard, and split the stale case

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -724,6 +724,12 @@ const SendToArgsSchema = z.object({
   press_enter: z.boolean().optional().default(true),
   allow_busy: z.boolean().optional().default(false),
   allow_long_inline: z.boolean().optional().default(false),
+  override_foreign_draft: z
+    .string()
+    .optional()
+    .describe(
+      'Acknowledge a prior blocked_by_foreign_draft refusal: pass the EXACT composer text that error reported. Delivery proceeds only if the composer still holds exactly that text; if it changed, the send is refused as blocked_by_draft_override_stale rather than typed over. Use when the "draft" is UI ghost text (an autocomplete suggestion over an empty composer), which this guard cannot distinguish from a real draft on a flattened frame.',
+    ),
   targeting: z
     .object({
       role: z.enum(["implementor", "reviewer", "gatherer"]).optional(),
@@ -1571,15 +1577,18 @@ class DeliverySafetyGateError extends Error {
     readonly error_code:
       | "blocked_by_interactive_prompt"
       | "blocked_by_permission_prompt"
-      | "blocked_by_foreign_draft",
+      | "blocked_by_foreign_draft"
+      | "blocked_by_draft_override_stale",
     readonly screen: ParsedScreenResult,
     readonly draftText?: string,
   ) {
     super(
       error_code === "blocked_by_permission_prompt"
         ? "delivery blocked by active permission prompt"
+        : error_code === "blocked_by_draft_override_stale"
+          ? `override_foreign_draft did not match the composer: it now holds ${JSON.stringify(draftText ?? "unknown")}; refused before typing because the text changed after you observed it`
         : error_code === "blocked_by_foreign_draft"
-          ? `target composer already holds text this delivery did not write: ${JSON.stringify(draftText ?? "unknown")}; refused before typing`
+          ? `target composer already holds text this delivery did not write: ${JSON.stringify(draftText ?? "unknown")}; refused before typing. If this is UI ghost text over an empty composer, re-send with override_foreign_draft set to exactly that string.`
         : "target surface has an open picker/menu; refused to type (would be consumed as menu keystrokes)",
     );
     this.name = "DeliverySafetyGateError";
@@ -5819,6 +5828,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     cli?: CliType;
     /** When set, also refuse a composer already holding someone else's text. */
     draftGuardText?: string;
+    /** Caller's acknowledgement of a prior refusal; see the draft guard below. */
+    draftOverrideText?: string;
   }): Promise<{ text: string; parsed: ParsedScreenResult } | null> => {
     const { surface, workspace, cli } = opts;
     const snapshot = await readParsedSurface(surface, workspace, {
@@ -5858,11 +5869,42 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       opts.draftGuardText !== undefined &&
       composerHoldsForeignDraft(snapshot.text, opts.draftGuardText)
     ) {
-      throw new DeliverySafetyGateError(
-        "blocked_by_foreign_draft",
-        snapshot.parsed,
-        extractComposerInputRegion(snapshot.text)?.trim() || undefined,
-      );
+      const observed =
+        extractComposerInputRegion(snapshot.text)?.trim() || undefined;
+
+      // AIDEV-NOTE (#442/#504): the frame this guard reads is FLATTENED, so a
+      // human's real draft and UI ghost text (an autocomplete suggestion drawn
+      // over an EMPTY composer) are byte-identical here. There is no attribute
+      // to test until #504 wires render_grid styling into this path, so the
+      // guard cannot classify -- and it must not pretend to.
+      //
+      // `override_foreign_draft` is therefore an ACKNOWLEDGEMENT, not a bypass:
+      // the caller echoes back the exact text the refusal reported, and the
+      // send proceeds only if the composer STILL holds exactly that. That keeps
+      // the property #442 exists to protect. A human mid-draft is TYPING, so
+      // their text moves between the refusal and the retry and the echo stops
+      // matching; static ghost text does not move. A blanket boolean would have
+      // traded this guard away, which is why this is a compare-and-swap.
+      const ack = opts.draftOverrideText?.trim();
+      if (ack === undefined || ack.length === 0) {
+        throw new DeliverySafetyGateError(
+          "blocked_by_foreign_draft",
+          snapshot.parsed,
+          observed,
+        );
+      }
+      if (observed === undefined || observed !== ack) {
+        // The composer moved after the caller looked. That is the dangerous
+        // case, and it gets its OWN code: conflating it with the refusal above
+        // is what made a stale acknowledgement indistinguishable from a fresh
+        // one.
+        throw new DeliverySafetyGateError(
+          "blocked_by_draft_override_stale",
+          snapshot.parsed,
+          observed,
+        );
+      }
+      // Acknowledged and still current: fall through and deliver.
     }
 
     return snapshot;
@@ -6454,6 +6496,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     delivery_id?: string;
     verify_submit?: boolean;
     allow_recovery_enter_retry?: boolean;
+    /** Caller acknowledgement forwarded to the draft guard. */
+    draftOverrideText?: string;
     require_observed_payload_before_enter?: boolean;
     submit_verify_timeout_ms?: number;
     stableSurfaceIdentity?: string | null;
@@ -6559,6 +6603,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       workspace: opts.workspace,
       ...(draftGuardedEvent && draftGuardText.trim().length > 0
         ? { draftGuardText }
+        : {}),
+      ...(opts.draftOverrideText !== undefined
+        ? { draftOverrideText: opts.draftOverrideText }
         : {}),
     });
     // Boot delivery is always attributable. Established relay paths retain
@@ -10395,6 +10442,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         .describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
         ),
+      override_foreign_draft: z
+        .string()
+        .optional()
+        .describe(
+          "Acknowledge a prior blocked_by_foreign_draft refusal: pass the EXACT composer text that error reported. Delivery proceeds only if the composer still holds exactly that text; if it changed, the send is refused as blocked_by_draft_override_stale rather than typed over.",
+        ),
     },
     ANNOTATIONS.mutating,
     async (args) => {
@@ -10558,6 +10611,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
               press_enter: args.press_enter,
               rename_to_task: args.rename_to_task,
+              draftOverrideText: args.override_foreign_draft,
               stableSurfaceIdentity: route.stableSurfaceIdentity,
               source_event: sourceEvent,
               delivery_id: deliveryId,
@@ -13374,6 +13428,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       allow_busy?: boolean;
       source_event: DeliveryEventType;
       delivery_id?: string;
+      /** Forwarded to the draft guard; see assertDeliveryTargetIsSafe. */
+      draft_override_text?: string;
       timings?: DeliveryPhaseTimings;
     }) => {
       const routeStartedAt = Date.now();
@@ -13626,6 +13682,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             chunk_delay_ms: SEND_INPUT_CHUNK_DELAY_MS,
             press_enter: args.press_enter,
             stableSurfaceIdentity: deliveryRoute.surface_uuid,
+            draftOverrideText: args.draft_override_text,
             source_event: args.source_event,
             source_agent: args.agent_id,
             delivery_id: args.delivery_id,
@@ -17510,6 +17567,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                     press_enter: args.press_enter,
                     rename_to_task: args.rename_to_task,
                     allow_long_inline: args.allow_long_inline,
+                    override_foreign_draft: args.override_foreign_draft,
                     _cmuxlayer_source_event: "send_to",
                     _cmuxlayer_delivery_id: deliveryId,
                     _cmuxlayer_timings: timings,
@@ -17781,6 +17839,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
                   agent_id: agent.agent_id,
                   text: args.text,
                   press_enter: args.press_enter,
+                  draft_override_text: args.override_foreign_draft,
                   allow_busy: args.allow_busy,
                   source_event: "send_to",
                   delivery_id: deliveryId,
@@ -18075,6 +18134,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               agent_id: agentId,
               text: args.text,
               press_enter: args.press_enter,
+              draft_override_text: args.override_foreign_draft,
               allow_busy: args.allow_busy,
               source_event: "send_to",
               delivery_id: deliveryId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1481,6 +1481,16 @@ export interface DeliveryRecord {
   surfaceObserverIdentity?: string | null;
   beforeMutation?: () => Promise<void>;
   lockKey?: string;
+  /**
+   * The caller's foreign-draft acknowledgement, carried onto the BACKGROUND path.
+   * Without it, `override_foreign_draft` was accepted and then silently dropped
+   * whenever `background: true`: the delivery still threw `blocked_by_foreign_draft`
+   * after the caller had done exactly what the tool description asks. The
+   * synchronous path forwarded it; `DeliveryRecord` had no field to carry it, so the
+   * background path could not. `send_to({ mode: 'surface', background: true })`
+   * inherited the same gap by delegation. Found in review by CodeRabbit on #585.
+   */
+  draftOverrideText?: string;
 }
 
 class DeliveryError extends Error {
@@ -8404,6 +8414,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           delivery_id: lifecycle ? record.delivery_id : undefined,
           verify_submit: record.verify_submit,
           beforeMutation: record.beforeMutation,
+          draftOverrideText: record.draftOverrideText,
           onChunkDelivered: (sentChunks) => {
             record.sent_chunks = sentChunks;
           },
@@ -10539,6 +10550,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             rename_to_task: args.rename_to_task,
             started_at: new Date().toISOString(),
             stableSurfaceIdentity: route.stableSurfaceIdentity,
+            draftOverrideText: args.override_foreign_draft,
             beforeMutation: route.assertCurrent,
           };
           const receiptEngine = context.lifecycleSweepEngine;

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -35,6 +35,30 @@ function parseToolResult(result: any) {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
+/**
+ * Typed accessor for the MCP server's registered-tool table.
+ *
+ * The surrounding tests reach `_registeredTools` through an untyped cast; that is
+ * grandfathered, but new code cannot introduce untyped values (DeepSource blocks
+ * them), so these cases go through one narrow cast kept in a single place.
+ */
+type ToolResult = {
+  isError?: boolean;
+  structuredContent?: unknown;
+  content?: Array<{ text: string }>;
+};
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+  extra: Record<string, unknown>,
+) => Promise<ToolResult>;
+
+function sendToHandler(server: unknown): ToolHandler {
+  return (
+    server as { _registeredTools: Record<string, { handler: ToolHandler }> }
+  )._registeredTools["send_to"].handler;
+}
+
 async function spawnReadyAgent(
   server: any,
   cli: "claude" | "codex" = "claude",
@@ -249,7 +273,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     screenText = "Claude Code\n> merge #208 when green and send me the commit\n";
     mockExec.mockClear();
 
-    const result = await (server as any)._registeredTools["send_to"].handler(
+    const result = await sendToHandler(server)(
       {
         mode: "agent",
         agent_id: agentId,
@@ -258,7 +282,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
         override_foreign_draft:
           "merge #208 when green and send me the commit",
       },
-      {} as any,
+      {},
     );
 
     expect(parseToolResult(result).ok).toBe(true);
@@ -284,7 +308,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     screenText = "Claude Code\n> so about the release, I think we should\n";
     mockExec.mockClear();
 
-    const result = await (server as any)._registeredTools["send_to"].handler(
+    const result = await sendToHandler(server)(
       {
         mode: "agent",
         agent_id: agentId,
@@ -292,7 +316,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
         press_enter: true,
         override_foreign_draft: "merge #208 when green and send me the commit",
       },
-      {} as any,
+      {},
     );
 
     const parsed = parseToolResult(result);
@@ -326,9 +350,9 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     screenText = "Claude Code\n> merge #208 when green and send me the commit\n";
     mockExec.mockClear();
 
-    const result = await (server as any)._registeredTools["send_to"].handler(
+    const result = await sendToHandler(server)(
       { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
-      {} as any,
+      {},
     );
 
     const parsed = parseToolResult(result);

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -225,6 +225,120 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     context.dispose();
   });
 
+  // AIDEV-NOTE (#442/#504): `override_foreign_draft` is an ACKNOWLEDGEMENT, not a
+  // bypass. The frame the guard reads is flattened, so UI ghost text over an empty
+  // composer is byte-identical to a human draft; the caller echoes the exact text the
+  // refusal reported and the send proceeds only if the composer STILL holds it. The
+  // three cases below are one property from three sides -- the last two are the ones
+  // that keep it from becoming a blanket bypass.
+  it("send_to delivers over ghost text when the caller echoes it back exactly", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n\u276f ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+
+    // A cmux autocomplete SUGGESTION rendered over an empty composer. Indistinguishable
+    // from a draft on this frame -- which is the whole reason the override exists.
+    screenText = "Claude Code\n> merge #208 when green and send me the commit\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools["send_to"].handler(
+      {
+        mode: "agent",
+        agent_id: agentId,
+        text: "fleet message",
+        press_enter: true,
+        override_foreign_draft:
+          "merge #208 when green and send me the commit",
+      },
+      {} as any,
+    );
+
+    expect(parseToolResult(result).ok).toBe(true);
+    expect(mutatedPane(mockExec)).toBe(true);
+    context.dispose();
+  }, 20_000);
+
+  it("send_to refuses a STALE acknowledgement with its own error code, and types nothing", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n\u276f ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+
+    // The composer MOVED after the caller looked -- a human is mid-keystroke. This is
+    // the case a boolean override would have typed straight over.
+    screenText = "Claude Code\n> so about the release, I think we should\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools["send_to"].handler(
+      {
+        mode: "agent",
+        agent_id: agentId,
+        text: "fleet message",
+        press_enter: true,
+        override_foreign_draft: "merge #208 when green and send me the commit",
+      },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      delivered: false,
+      terminal: true,
+      error_code: "blocked_by_draft_override_stale",
+    });
+    // The two refusals must not be conflated: a caller retrying on a stale ack is
+    // exactly the caller who must NOT be told "ghost text, go ahead".
+    expect(parsed.error_code).not.toBe("blocked_by_foreign_draft");
+    expect(parsed.error).toMatch(/did not match the composer/i);
+    expect(mutatedPane(mockExec)).toBe(false);
+    context.dispose();
+  }, 20_000);
+
+  it("send_to without an acknowledgement still refuses, and points at the override", async () => {
+    const { createServer, createServerContext } = await loadServerModule();
+    let screenText = "Claude Code\n\u276f ";
+    const mockExec = makeLifecycleExec(() => screenText);
+    const context = createServerContext({
+      exec: mockExec,
+      stateDir: testDir,
+      disableSpawnPreflight: true,
+      sessionIdentityResolver: () => null,
+    });
+    const server = createServer({ context });
+    const agentId = await spawnReadyAgent(server);
+
+    screenText = "Claude Code\n> merge #208 when green and send me the commit\n";
+    mockExec.mockClear();
+
+    const result = await (server as any)._registeredTools["send_to"].handler(
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
+      {} as any,
+    );
+
+    const parsed = parseToolResult(result);
+    expect(result.isError).toBe(true);
+    expect(parsed.error_code).toBe("blocked_by_foreign_draft");
+    expect(parsed.error).toMatch(/override_foreign_draft/);
+    expect(mutatedPane(mockExec)).toBe(false);
+    context.dispose();
+  }, 20_000);
+
   it("interact skill refuses a non-empty composer and names its contents", async () => {
     const { createServer, createServerContext } = await loadServerModule();
     let screenText = "Claude Code\n❯ ";


### PR DESCRIPTION
Follows up my comment on #504. That issue's ask #4 already names this case — *"this same styling would let the draft guard tell a human's real draft from any other dim/ghost UI text"* — so this is deliberately **not** the styling work. It is the interim half, and it is written so #504 makes it unnecessary rather than conflicting with it.

## The problem

`send_to` returns terminal `blocked_by_foreign_draft` quoting text the pane's visible composer does not hold: a cmux autocomplete **suggestion** drawn over an empty composer. Because `composerHoldsForeignDraft` receives only the flattened frame, ghost text and a real draft are byte-identical to it.

The caller has no way forward. Escape and ctrl+u dispatch to the terminal; the suggestion is drawn above it, so the next `surface.read_text` still shows it. The pane becomes undeliverable and the only remedy is tearing down and re-attaching the session — which loses its context. Observed ~9 times in ~18h across 4 panes on 0.4.68.

## What this does

Adds `override_foreign_draft` — an **acknowledgement, not a bypass**.

The caller echoes back the exact text the refusal reported, and delivery proceeds **only if the composer still holds exactly that**. It is a compare-and-swap, and that is the whole design:

> A human mid-draft is *typing*, so their text moves between the refusal and the retry and the echo stops matching. Static ghost text does not move.

A blanket `allow_*: true` boolean — which would have matched the existing `allow_busy` / `allow_long_inline` convention — would have traded #442 away entirely, so I deliberately did not follow that convention here. If you'd rather it were a boolean, that's your call and I'll change it, but I think the CAS is what keeps the guard meaningful while it cannot classify.

A stale acknowledgement gets its **own** error code, `blocked_by_draft_override_stale`, rather than being folded back into the original refusal. That case — the composer moved after the caller looked — is the dangerous one, and it is precisely the one a caller most needs to distinguish. The unacknowledged refusal message now also points at the new parameter.

## Test plan

3 tests added to `tests/delivery-truth-t2.test.ts`, in the existing `#442` block:

1. ghost text + exact echo → **delivers**
2. composer moved + stale echo → refused `blocked_by_draft_override_stale`, **pane not mutated**
3. no acknowledgement → still `blocked_by_foreign_draft`, now naming the override

Verified in **both directions**, because a test that has only ever seen the fixed code hasn't been tested:

```
src reverted, tests kept  ->  3 failed | 13 passed   (all three fail)
src restored              ->  16 passed
full suite                ->  156 files | 3762 tests | 0 failures
```

The 13 pre-existing tests in that block pass either way, so the new arms are the only thing these changes move.

`tsc --noEmit` clean.

## Notes

- Wired through both delivery entry points: the `send_input` handler (covers `send_to mode=surface` and `send_input`) and `deliverAgentInput` (covers `mode=agent`). I deliberately did **not** wire it into the broadcast path, which has its own args type and where a per-pane acknowledgement doesn't make sense.
- Default behaviour is unchanged when the parameter is absent.
- **I'm a first-time contributor and I don't have a voucher.** CONTRIBUTING says to name one and I'd rather say so than leave it blank — happy for this to wait on that, or to be told the vouching model applies differently to a bug I reported on #504 myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `override_foreign_draft` acknowledgement to delivery safety guard and split stale case
> - Introduces an optional `override_foreign_draft` string on `send_to` and `send_input`; when its trimmed value matches the currently observed foreign composer text, the guarded delivery proceeds instead of being blocked.
> - Adds the `blocked_by_draft_override_stale` error code to `DeliverySafetyGateError` for acknowledgements that no longer match the composer, while the existing `blocked_by_foreign_draft` error now names `override_foreign_draft` as the retry mechanism.
> - Fixes background delivery so `draftOverrideText` is retained on the `DeliveryRecord` and forwarded into `executeDeliveryEngine` / `assertDeliveryTargetIsSafe`, instead of being dropped on the async path.
> - Routes the acknowledgement through surface delegation, single-agent, and multi-agent `send_to` paths via `deliverAgentInput`.
> - Risk: the guard in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/585/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) compares trimmed text only; leading/trailing whitespace differences between the acknowledgement and the observed composer frame are ignored, so reviewers should confirm that is the intended compare-and-swap semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 863f8a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional draft acknowledgement support when sending text to a composer with an existing draft.
  * Available through the `send_to` and `send_input` tools, including background delivery.
  * Delivery proceeds only when the acknowledgement exactly matches the current draft.
  * Added a distinct error when an acknowledgement is outdated.

* **Bug Fixes**
  * Prevented text from being sent when a draft changes after acknowledgement.
  * Improved safeguards to ensure refused deliveries do not modify the composer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->