### PR TITLE
docs(public): truth pass on README, CONTRIBUTING, and live site copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ bun install
 
 1. Branch from `main`
 2. Write tests for your changes
-3. Run tests: `bun test`
+3. Run tests: `bun run test` (vitest)
 4. Open a PR against `main`
 
 ## PR Process

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ cmuxLayer exposes a 10-tool public MCP surface for controlling cmux terminal wor
   <img src="./assets/cmuxlayer-logo-split-pane-grid.svg" alt="cmuxLayer" width="96" height="96" />
 </p>
 
-[![install](https://img.shields.io/badge/install-npm%20install%20--g%20cmuxlayer-22c55e)](https://github.com/EtanHey/cmuxlayer#quick-start)
+[![install](https://img.shields.io/badge/install-brew%20install%20etanhey%2Flayers%2Fcmuxlayer-22c55e)](#quick-start)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![MCP Tools](https://img.shields.io/badge/MCP-10%20tools-green.svg)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-3023%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-3759%20passing-brightgreen.svg)](#testing)
 
 ## Quick start
 
@@ -113,7 +113,7 @@ Tell your AI agent things like:
 - *"Wait for all agents to finish, then read their output"*
 - *"Set the sidebar status to show our deploy progress"*
 
-cmuxLayer retains 45 internal tool definitions; only 10 are registered and callable through MCP. The other 35 are not exposed through ToolSearch or any other MCP path. `reorder_surface` is the single approved deletion. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
+cmuxLayer retains 45 internal tool definitions; only 10 are registered and callable through MCP. The other 35 are not exposed through ToolSearch or any other MCP path. `read_screen` parses agent metadata (status, model, tokens, context %) for Claude Code, Codex, Gemini, and Cursor.
 
 ## Agent routing workflow
 
@@ -171,7 +171,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 | `send_command` | Deprecated one-release alias for `send_to(mode:"command")` |
 | `send_key` | Deprecated one-release alias for `send_to(mode:"key")` |
 | `rename_tab` | Rename a surface tab |
-| `update_surface` | Update a surface title or metadata |
+| `update_surface` | Move or rename one terminal surface |
 | `notify` | Show a cmux notification banner |
 | `set_status` | Set sidebar status key-value pair |
 | `set_progress` | Set progress indicator (0.0-1.0) |
@@ -186,7 +186,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 | `wait_for_all` | Deprecated one-release alias for `wait_for(ids:[...])` |
 | `interact` | Send interactive input (confirm, cancel, resume) |
 | `broadcast` | Fan out a guarded message to agents by role |
-| `report_to_parent` | Report structured completion to a parent agent |
+| `report_to_parent` | Raise a short blocker to the managed agent's registry parent |
 | `supersede_agent_goal` | Replace a managed agent's active file-backed goal |
 | `register_monitor` | Register or re-arm a monitor deadman record |
 | `signal_monitor` | Refresh a monitor heartbeat |
@@ -197,7 +197,7 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 
 | Tool | What it does |
 |------|-------------|
-| `close_surface` | Close a terminal or browser pane |
+| `close_surface` | Close one surface, managed agent, or workspace, with live-agent guards |
 | `stop_agent` | Gracefully stop an agent |
 | `kill` | Force-kill agent processes |
 
@@ -219,19 +219,14 @@ The other 35 internal definitions, including `interact`, are not callable. The d
 ```text
 AI Agent  ─── MCP ───>  cmuxLayer  ─── Unix socket ───>  cmux
                          ├── Agent engine (spawn → monitor → teardown)
-                         ├── Screen parser (5 agent formats)
+                         ├── Screen parser (Claude Code, Codex, Gemini, Cursor)
                          ├── Mode policy (autonomous vs manual)
                          ├── State manager + event log
                          ├── Metacomm READ  — harness JSONL (real tokens/context/model)
                          └── Metacomm WRITE — per-agent inbox file + Monitor dispatch
 ```
 
-The socket client connects to cmux through a Unix socket. It reconnects after a disconnect and falls back to a CLI subprocess when the socket is unavailable.
-
-| Connection | Latency | Speedup |
-|------------|---------|---------|
-| CLI subprocess | ~142ms | baseline |
-| Unix socket | ~0.1ms | **1,423x** |
+The socket client connects to cmux through a persistent Unix socket instead of starting a `cmux` CLI subprocess per call. It reconnects after a disconnect and falls back to the CLI subprocess when the socket is unavailable.
 
 ## Troubleshooting
 
@@ -255,7 +250,7 @@ repositories. The error lists every path it searched.
 ## Testing
 
 ```bash
-bun run test        # 3023 tests via vitest
+bun run test        # 3759 tests via vitest
 npm run typecheck   # Type checking
 ```
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "cmuxLayer — Terminal MCP for AI Agents",
     description:
-      "10 public MCP tools. 0.2ms socket latency. Spawn agents, send input, and read screens through one Unix socket.",
+      "10 public MCP tools. Spawn agents, send input, and read screens through one Unix socket.",
     url: "https://cmuxlayer.etanheyman.com",
     siteName: "cmuxLayer",
     type: "website",
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "cmuxLayer — Terminal MCP for AI Agents",
     description:
-      "10 public MCP tools. 0.2ms socket latency. Spawn agents, send input, and read screens.",
+      "10 public MCP tools. Spawn agents, send input, and read screens.",
     images: ["/og.png"],
   },
   icons: {

--- a/site/components/animated-demo.tsx
+++ b/site/components/animated-demo.tsx
@@ -634,7 +634,7 @@ export function AnimatedDemo() {
   }
 
   useEffect(() => {
-    if (startedRef.current) return;
+    if (startedRef.current) return undefined;
     startedRef.current = true;
 
     // Start on scroll

--- a/site/components/animated-demo.tsx
+++ b/site/components/animated-demo.tsx
@@ -53,7 +53,6 @@ export function AnimatedDemo() {
   const tabsRef = useRef<HTMLDivElement>(null);
   const surfacesRef = useRef<HTMLSpanElement>(null);
   const agentsRef = useRef<HTMLSpanElement>(null);
-  const latencyRef = useRef<HTMLSpanElement>(null);
   const statusRef = useRef<HTMLSpanElement>(null);
   const statusBarRef = useRef<HTMLDivElement>(null);
   const layoutRef = useRef<HTMLDivElement>(null);
@@ -638,14 +637,6 @@ export function AnimatedDemo() {
     if (startedRef.current) return;
     startedRef.current = true;
 
-    // Latency flicker
-    const latencyId = setInterval(() => {
-      if (latencyRef.current) {
-        latencyRef.current.textContent =
-          (0.1 + Math.random() * 0.2).toFixed(1) + "ms";
-      }
-    }, 1800);
-
     // Start on scroll
     const obs = new IntersectionObserver(
       (entries) => {
@@ -681,7 +672,6 @@ export function AnimatedDemo() {
 
     return () => {
       unmountedRef.current = true;
-      clearInterval(latencyId);
       if (cronInterval.current) clearInterval(cronInterval.current);
       obs.disconnect();
     };
@@ -770,7 +760,6 @@ export function AnimatedDemo() {
             </span>
             <span ref={surfacesRef}>2 surfaces</span>
             <span ref={agentsRef}>0 agents</span>
-            <span ref={latencyRef}>0.2ms</span>
             <span className="ml-auto" ref={statusRef}>
               ready
             </span>

--- a/site/components/comparison.tsx
+++ b/site/components/comparison.tsx
@@ -3,7 +3,7 @@ const withoutItems = [
   "Copy-paste output from one agent to another",
   "Manually check if each agent finished",
   "One agent at a time, sequential work",
-  "~142ms per CLI subprocess call",
+  "A new CLI subprocess for every call",
 ];
 
 const withItems = [
@@ -11,7 +11,7 @@ const withItems = [
   "One agent reads another's screen directly",
   "Auto-monitor with parsed status and done signals",
   "Parallel multi-agent orchestration",
-  "0.1ms persistent socket (1,423x faster)",
+  "One persistent Unix socket, CLI fallback",
 ];
 
 function XIcon() {

--- a/site/components/cta.tsx
+++ b/site/components/cta.tsx
@@ -18,7 +18,7 @@ export function Cta() {
           Stop being the clipboard.
         </h2>
         <p className="text-text-secondary text-[15px] mb-9 font-light">
-          npm install. Add to MCP config. Start orchestrating.
+          brew install. Add to MCP config. Start orchestrating.
         </p>
         <div className="flex items-center justify-center gap-3 max-[480px]:flex-col">
           <a

--- a/site/components/hero.tsx
+++ b/site/components/hero.tsx
@@ -6,7 +6,7 @@ export function Hero() {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText("npm install -g cmuxlayer").then(() => {
+    navigator.clipboard.writeText("brew install etanhey/layers/cmuxlayer").then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -95,7 +95,7 @@ export function Hero() {
             onClick={handleCopy}
           >
             <code className="text-text flex-1">
-              <span className="text-text-dim">$</span> npm install -g cmuxlayer
+              <span className="text-text-dim">$</span> brew install etanhey/layers/cmuxlayer
             </code>
             <button
               className="bg-transparent border-none text-text-dim cursor-pointer p-0 transition-colors duration-200 flex items-center justify-center w-6 h-6 shrink-0 hover:text-accent"

--- a/site/components/integrations.tsx
+++ b/site/components/integrations.tsx
@@ -27,9 +27,9 @@ interface SetupStep {
 const setupSteps: SetupStep[] = [
   {
     num: "01",
-    text: "Install from npm",
-    code: "npm install -g cmuxlayer",
-    copyText: "npm install -g cmuxlayer",
+    text: "Install with Homebrew",
+    code: "brew install etanhey/layers/cmuxlayer",
+    copyText: "brew install etanhey/layers/cmuxlayer",
   },
   {
     num: "02",

--- a/site/components/shared/footer.tsx
+++ b/site/components/shared/footer.tsx
@@ -73,7 +73,7 @@ const PRODUCT_LINKS: Record<
       external: true,
     },
     {
-      label: "npm",
+      label: "Install",
       href: "https://github.com/EtanHey/cmuxlayer#quick-start",
       external: true,
     },

--- a/site/components/stat-strip.tsx
+++ b/site/components/stat-strip.tsx
@@ -1,8 +1,8 @@
 const stats = [
-  { value: "0.2ms", label: "socket latency" },
+  { value: "Apache 2.0", label: "license" },
   { value: "10", label: "public MCP tools" },
   { value: "5", label: "agent CLIs" },
-  { value: "326", label: "tests passing" },
+  { value: "3,759", label: "tests passing" },
 ];
 
 export function StatStrip() {


### PR DESCRIPTION
## Summary
- Truth pass on the public copy: README, CONTRIBUTING, and the site source that actually serves `cmuxlayer.etanheyman.com`. Every kept number was produced by a command run in this lane; every unverifiable number was removed.
- Install path corrected from npm to Homebrew everywhere. `cmuxlayer` is not on the npm registry (`npm view cmuxlayer` returns E404) and every `publish.yml` tag run has failed (v0.4.67, v0.4.68, v0.4.69). `brew info etanhey/layers/cmuxlayer` resolves to stable 0.4.69.
- Size: S (10 files, +23/-39, all hand-written copy).

## Which site source serves the subdomain
`site/` (Next.js on Vercel) is live. `landing/` is dead copy.
- DNS: `dig +short CNAME cmuxlayer.etanheyman.com` → `b815a13a5e6b21f7.vercel-dns-017.com.`
- HTTP: `curl -sI https://cmuxlayer.etanheyman.com/` → `server: Vercel`, `x-nextjs-prerender: 1`, and the exact security headers declared in `site/vercel.json`.
- `site/README.md` states "Deployed to Vercel with root directory set to `site/`".
- `landing/` deploys via `.github/workflows/pages.yml` to GitHub Pages (`https://etanhey.github.io/cmuxlayer/`); `gh api repos/EtanHey/cmuxlayer/pages` shows `cname: null`, so its `landing/CNAME` file never took effect on the subdomain.
- **Proposal (not done in this PR):** delete `landing/` and `pages.yml` in a follow-up. `landing/index.html` still carries the stale `0.2ms`, `326 tests`, and npm-install claims this PR removes from the live site.

## Verified claims
| Claim | Proof | Result | Action |
|---|---|---|---|
| 10 public MCP tools (README, badge, site, repo description) | `PUBLIC_TOOL_NAMES` in `src/server.ts`; live `tools/list` from a running cmuxlayer 0.4.69 MCP session; drift test | 10, names match exactly | kept |
| 45 internal tool definitions / 35 not callable | `CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1 vitest run tests/tool-count-drift.test.ts` | 5 passed | kept |
| README badge + Testing section: 3023 tests | `bun run test` (vitest, 156 files) | 3759 passed, 1 skipped | changed → 3759 |
| Site stat strip: 326 tests passing | same run | 3759 | changed → 3,759 |
| `npm install -g cmuxlayer` (README badge, hero, setup step 01, CTA) | `npm view cmuxlayer` → E404; `gh run list --workflow publish.yml` → 3/3 failure | not installable from npm | changed → `brew install etanhey/layers/cmuxlayer` |
| CLI ~142ms vs socket ~0.1ms, 1,423x (README table, site comparison) | `git log -S'1,423'` → introduced in PR #4; `benchmarks/daemon-baseline.json` measures daemon path only (`list_surfaces` p50 9.47ms on a GitHub runner, 2026-08-31); no current end-to-end CLI-vs-socket measurement exists | unverifiable | removed; replaced with a mechanism statement (persistent socket, CLI fallback) |
| Site: "0.2ms socket latency" (stat strip, OG/Twitter description) and the demo's randomized 0.1–0.3ms counter | no measurement backs 0.2ms; the demo value was `Math.random()` | fabricated-looking metric | removed; stat replaced with license |
| "Screen parser (5 agent formats)" | `ParsedScreenAgentType` in `src/types.ts` = claude, codex, gemini, cursor (+unknown); README's own table says Kiro has no parser | 4 | changed → named list |
| `report_to_parent` / `update_surface` / `close_surface` README rows | live tool descriptions from `tools/list` | README rows described older behaviour | changed to match live descriptions |
| "`reorder_surface` is the single approved deletion" | grep src: only a CLI-fallback method name, never a tool; no test guards the sentence | insider history, meaningless to an outsider | removed |
| CONTRIBUTING: run tests with `bun test` | `package.json` `test` script is `vitest run --maxWorkers=1` | `bun test` invokes Bun's runner, not the project runner | changed → `bun run test` (vitest) |
| CONTRIBUTING: "All PRs are reviewed by CodeRabbit" | `gh api` comments on #584/#582/#569 → `coderabbitai[bot]` present | true | kept |
| Supported-agents table, Kiro command `kiro-cli` | `src/agent-command.ts` builds `kiro-cli chat …` | true | kept |
| Doc links (4 docs, LICENSE, hooks, logo asset) | `test -e` each path | all exist | kept |
| Banned words (seamless, blazing, revolutionary, effortless, powerful, …) | grep over README, CONTRIBUTING, site/app, site/components | none | n/a |
| Private paths / hostnames | grep for `/Users/`, `~/Gits`, tailnet hosts | none in README/CONTRIBUTING; the animated demo's fictional `~/Gits/…` repo lines left as narrative | n/a |

## Removed words and numbers
`3023`, `326`, `~142ms`, `~0.1ms`, `1,423x`, `0.2ms`, `5 agent formats`, `npm install -g cmuxlayer`, the `reorder_surface` sentence.

## Repo one-line description
Current: "10 public MCP tools for controlling cmux workspaces and managing Claude, Codex, Gemini, Kiro, and Cursor agents." This is accurate against source and the live server. No change proposed. The Homebrew formula description ("Terminal multiplexer MCP server for AI agent workspace orchestration") is the one that is loose, but it lives in `EtanHey/homebrew-layers`.

## Out of scope, flagged for follow-up
- `docs/fresh-install.md:20` still offers `npm install -g cmuxlayer`.
- `.github/PULL_REQUEST_TEMPLATE.md` says `bun test`.
- `publish.yml` fails on every tag; either fix the npm publish or delete the workflow.
- The animated demo's narrative (`Claude Code v1.0.23`, `claude-opus-4-6`, "326 tests passing" for a fictional voicelayer run) is untouched; it is clearly staged, but a reader may not know that.

## Test plan
- [x] `bun run test` → 3759 passed, 1 skipped, 156 files, exit 0
- [x] `CMUXLAYER_RUN_TOOL_COUNT_DRIFT=1 vitest run tests/tool-count-drift.test.ts tests/naming-convention.test.ts tests/t1-registry-truth.test.ts tests/vercel-config.test.ts tests/memory-watchdog-package.test.ts` → 24 passed
- [x] `site/`: `tsc --noEmit -p .` → exit 0
- [ ] Vercel preview build (Vercel runs on PR open)

## Bot policy
Read `AGENTS.md` and `CLAUDE.md`: no bot clause. **Panel = CodeRabbit + lead read** (Etan rule via lead, in force until Mon 2026-09-07 04:00: reviewer summons are CodeRabbit only; `@codex` is forbidden on any PR while the shared pool sits at ~2%). Bugbot not summoned per canon #9 non-core tiering. One `@codex review` comment was posted at PR open, before this rule reached the lane; Codex answered with a usage-limit message and will not be re-summoned. Bugbot auto-ran from the repo install (not summoned) and also reported a usage limit.

## Review round 1
- CodeRabbit: pass, no actionable comments (docstring-coverage warning is informational and covers pre-existing site functions).
- DeepSource JavaScript: one minor consistent-return finding on the demo effect's early exit, fixed in the follow-up commit; green on `5471bb7`.
- All checks green on `5471bb7` (test, build-site, perf-budget, DeepSource JS + Shell, CodeRabbit, Macroscope, launchd-units, launcher-parity x2, docs.local guard). CodeRabbit's incremental re-review of the one-line fix is rate-limited (~41 min from 15:54 UTC); its check is green and the lead read covers the fix.

— W20-fable (worker) · claude-code/claude-fable-5-1
<!-- golem-id v1 {"seat":"W20-fable","role":"worker","harness":"claude-code","model":"claude-fable-5-1","model_source":"session-jsonl","session":"f493a564","ts":"2026-09-05T15:31:59Z"} -->
