### PR TITLE
ci: scope the daemon perf budget to diffs that can move a timing (#452)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,90 @@ jobs:
         with:
           persist-credentials: false
 
+      # The benchmark measures a live daemon on a shared runner, so its p95 rows
+      # carry real variance. On a pull request that cannot alter runtime
+      # behaviour, a red row is noise that costs a re-run and teaches people to
+      # ignore the check. Scope it to diffs that could actually move the numbers
+      # and warn-and-skip otherwise.
+      #
+      # This is a step rather than an `on.pull_request.paths` filter because a
+      # paths filter is workflow-level: ci.yml carries seven jobs, and gating the
+      # file would silently gate test, build-site, launcher-parity and the rest
+      # along with this one. GitHub has no per-job paths filter.
+      - name: Decide whether the benchmark must run
+        id: scope
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // Anything that can move a daemon timing. Deliberately wider than
+            // src/: skipping a baseline or harness edit would let a budget
+            // change land unmeasured, which is the one failure this guard must
+            // not introduce.
+            const PERF_RELEVANT = [
+              'src/',
+              'benchmarks/',
+              'scripts/bench-daemon',
+              'scripts/check-daemon-benchmark',
+              'package.json',
+              'bun.lock',
+              'package-lock.json',
+              '.github/workflows/ci.yml',
+            ];
+
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('run', 'true');
+              core.setOutput(
+                'reason',
+                `Event \`${context.eventName}\` always runs the budget, so main keeps a complete green-main history.`,
+              );
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const touched = files
+              .map((file) => file.filename)
+              .filter((name) => PERF_RELEVANT.some((prefix) => name.startsWith(prefix)));
+
+            if (touched.length > 0) {
+              const shown = touched.slice(0, 10);
+              const more = touched.length - shown.length;
+              core.setOutput('run', 'true');
+              core.setOutput(
+                'reason',
+                `Diff touches ${touched.length} performance-relevant path(s), so the budget is enforced strictly:\n`
+                  + shown.map((name) => `- \`${name}\``).join('\n')
+                  + (more > 0 ? `\n- ...and ${more} more` : ''),
+              );
+              return;
+            }
+
+            core.warning(
+              `Skipping the daemon performance budget: none of the ${files.length} changed file(s) `
+                + `can affect daemon runtime (matched none of: ${PERF_RELEVANT.join(', ')}).`,
+            );
+            core.setOutput('run', 'false');
+            core.setOutput(
+              'reason',
+              `None of the ${files.length} changed file(s) can affect daemon runtime, so the benchmark was not run.\n\n`
+                + `The budget stays strict on any diff touching: ${PERF_RELEVANT.map((p) => `\`${p}\``).join(', ')}.`,
+            );
+
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        if: steps.scope.outputs.run == 'true'
 
       - run: rm -f package-lock.json
+        if: steps.scope.outputs.run == 'true'
       - run: bun install
+        if: steps.scope.outputs.run == 'true'
 
       - name: Restore bounded green-main benchmark history
+        if: steps.scope.outputs.run == 'true'
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: docs.local/scratch/perf-budget/history.json
@@ -59,10 +137,27 @@ jobs:
           restore-keys: daemon-perf-history-main-${{ hashFiles('benchmarks/daemon-baseline.json') }}-
 
       - name: Run daemon performance budget
+        if: steps.scope.outputs.run == 'true'
         run: bun run bench:daemon:check
 
+      # Write the skip into the same report the comment step already publishes,
+      # so a skipped run reads as SKIPPED rather than as the step's
+      # "did not produce a report" ERROR fallback.
+      - name: Report skipped performance budget
+        if: steps.scope.outputs.run != 'true'
+        env:
+          REASON: ${{ steps.scope.outputs.reason }}
+        run: |
+          set -euo pipefail
+          mkdir -p docs.local/scratch/perf-budget
+          {
+            printf '%s\n' '<!-- cmuxlayer-perf-budget -->'
+            printf '%s\n\n' '## Daemon performance budget: SKIPPED'
+            printf '%s\n' "$REASON"
+          } > docs.local/scratch/perf-budget/comment.md
+
       - name: Save bounded green-main benchmark history
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: success() && steps.scope.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: docs.local/scratch/perf-budget/history.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,16 @@ jobs:
               'package.json',
               'bun.lock',
               'package-lock.json',
+              // `bench:daemon:check` runs `bun run build` (tsc -p tsconfig.json)
+              // and benchmarks dist/daemon.js, so compiler settings decide what
+              // is actually measured. Prefix, to cover tsconfig.*.json too.
+              'tsconfig',
               '.github/workflows/ci.yml',
             ];
+
+            // pulls.listFiles caps its response at 3000 entries, so on a larger
+            // diff a src/ change can sit past the cap and read as absent.
+            const LIST_FILES_CAP = 3000;
 
             if (context.eventName !== 'pull_request') {
               core.setOutput('run', 'true');
@@ -92,9 +100,28 @@ jobs:
               per_page: 100,
             });
 
+            // Renames expose the pre-rename path as `previous_filename`. Moving
+            // src/daemon.ts out of src/ changes daemon code while the new name
+            // matches nothing, so both sides of a rename have to be checked.
             const touched = files
-              .map((file) => file.filename)
-              .filter((name) => PERF_RELEVANT.some((prefix) => name.startsWith(prefix)));
+              .filter((file) =>
+                [file.filename, file.previous_filename].some(
+                  (name) =>
+                    name && PERF_RELEVANT.some((prefix) => name.startsWith(prefix)),
+                ),
+              )
+              .map((file) => file.filename);
+
+            if (files.length >= LIST_FILES_CAP) {
+              core.setOutput('run', 'true');
+              core.setOutput(
+                'reason',
+                `Diff reports ${files.length} changed file(s), at or past the ${LIST_FILES_CAP}-entry `
+                  + `listFiles cap, so a performance-relevant path may be hidden past the cap. `
+                  + `Running the budget rather than guessing.`,
+              );
+              return;
+            }
 
             if (touched.length > 0) {
               const shown = touched.slice(0, 10);

--- a/tests/perf-budget-scope.test.ts
+++ b/tests/perf-budget-scope.test.ts
@@ -71,7 +71,9 @@ async function decide(
     },
   };
   const github = {
-    paginate: async () => files,
+    // Promise-returning rather than `async`: the workflow script awaits this,
+    // but an `async` function with no `await` inside trips DeepSource JS-0116.
+    paginate: () => Promise.resolve(files),
     rest: { pulls: { listFiles: null } },
   };
   const context = {

--- a/tests/perf-budget-scope.test.ts
+++ b/tests/perf-budget-scope.test.ts
@@ -11,6 +11,11 @@ import { describe, expect, it } from "vitest";
  *
  * This guards the scoping fix: strict where the diff could move a timing,
  * warn-and-skip where it provably cannot.
+ *
+ * The behavioural cases below run the workflow's OWN `github-script` body,
+ * extracted from ci.yml, rather than a copy of its logic. JS embedded in YAML
+ * is invisible to `tsc`, so executing the real thing is the only way these
+ * assertions cannot drift from what CI actually does.
  */
 
 const workflow = readFileSync(
@@ -23,26 +28,70 @@ const perfBudgetJob = workflow.slice(
   workflow.indexOf("  test:"),
 );
 
-/**
- * The prefix list is read out of the workflow rather than duplicated here, so
- * editing the workflow's list re-points these cases instead of silently
- * drifting from them.
- */
-function performanceRelevantPrefixes(): string[] {
-  const block = perfBudgetJob.match(
-    /const PERF_RELEVANT = \[([\s\S]*?)\];/,
-  )?.[1];
-  if (!block) throw new Error("PERF_RELEVANT list not found in ci.yml");
-  return [...block.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+/** Pull the `script: |` body of the scope step out of the YAML, de-indented. */
+function scopeScriptSource(): string {
+  const afterStep = perfBudgetJob.split(
+    "- name: Decide whether the benchmark must run",
+  )[1];
+  if (afterStep === undefined)
+    throw new Error("scope step not found in ci.yml");
+
+  const body = afterStep.split("script: |")[1];
+  if (body === undefined) throw new Error("scope step has no script block");
+
+  const indent = " ".repeat(12);
+  const lines: string[] = [];
+  for (const line of body.split("\n")) {
+    if (line.trim() === "") {
+      lines.push("");
+      continue;
+    }
+    if (!line.startsWith(indent)) break;
+    lines.push(line.slice(indent.length));
+  }
+  return lines.join("\n");
 }
 
-/** The workflow's own predicate, kept to one line so it cannot drift in spirit. */
-function wouldRunBudget(changedFiles: string[]): boolean {
-  const prefixes = performanceRelevantPrefixes();
-  return changedFiles.some((name) =>
-    prefixes.some((prefix) => name.startsWith(prefix)),
+type Decision = { run?: string; reason?: string; warned?: string };
+type ChangedFile = { filename: string; previous_filename?: string };
+
+/** Run the real script against a synthetic event and capture its outputs. */
+async function decide(
+  eventName: string,
+  files: ChangedFile[],
+): Promise<Decision> {
+  const decision: Decision = {};
+  const core = {
+    setOutput(name: string, value: string) {
+      if (name === "run") decision.run = value;
+      if (name === "reason") decision.reason = value;
+    },
+    warning(message: string) {
+      decision.warned = message;
+    },
+  };
+  const github = {
+    paginate: async () => files,
+    rest: { pulls: { listFiles: null } },
+  };
+  const context = {
+    eventName,
+    repo: { owner: "EtanHey", repo: "cmuxlayer" },
+    issue: { number: 596 },
+  };
+
+  const run = new Function(
+    "context",
+    "github",
+    "core",
+    `return (async () => {\n${scopeScriptSource()}\n})();`,
   );
+  await run(context, github, core);
+  return decision;
 }
+
+const named = (...names: string[]): ChangedFile[] =>
+  names.map((filename) => ({ filename }));
 
 describe("perf-budget scoping (backlog #452)", () => {
   it("gates the benchmark on the scope step rather than always running it", () => {
@@ -72,13 +121,23 @@ describe("perf-budget scoping (backlog #452)", () => {
     expect(triggers).not.toMatch(/^\s+paths(-ignore)?:/m);
   });
 
-  it("skips a diff that cannot move a daemon timing", () => {
+  it("skips a diff that cannot move a daemon timing", async () => {
     // The literal cmuxlayer#595 file list that failed twice on jitter.
-    expect(wouldRunBudget(["tests/no-new-as-any.test.ts"])).toBe(false);
-    expect(wouldRunBudget(["README.md", "docs/design/foo.md"])).toBe(false);
+    const jitterPr = await decide(
+      "pull_request",
+      named("tests/no-new-as-any.test.ts"),
+    );
+    expect(jitterPr.run).toBe("false");
+    expect(jitterPr.warned).toBeDefined();
+
+    const docsPr = await decide(
+      "pull_request",
+      named("README.md", "docs/design/foo.md"),
+    );
+    expect(docsPr.run).toBe("false");
   });
 
-  it("stays strict on anything that can move a daemon timing", () => {
+  it("stays strict on anything that can move a daemon timing", async () => {
     for (const changed of [
       ["src/daemon.ts"],
       ["src/server.ts", "tests/agent-engine.test.ts"],
@@ -88,20 +147,45 @@ describe("perf-budget scoping (backlog #452)", () => {
       ["package.json"],
       ["bun.lock"],
       [".github/workflows/ci.yml"],
+      // bench:daemon:check runs `bun run build` (tsc -p tsconfig.json) and
+      // benchmarks dist/daemon.js, so compiler settings decide what is measured.
+      ["tsconfig.json"],
+      ["tsconfig.build.json"],
     ]) {
-      expect(
-        wouldRunBudget(changed),
-        `should run for ${changed.join(", ")}`,
-      ).toBe(true);
+      const decision = await decide("pull_request", named(...changed));
+      expect(decision.run, `should run for ${changed.join(", ")}`).toBe("true");
     }
   });
 
-  it("covers the baseline and harness, not just src/", () => {
-    // Skipping a baseline edit would let a budget change land unmeasured —
-    // the one regression this guard must not introduce.
-    const prefixes = performanceRelevantPrefixes();
-    expect(prefixes).toContain("src/");
-    expect(prefixes).toContain("benchmarks/");
-    expect(prefixes.some((prefix) => prefix.startsWith("scripts/"))).toBe(true);
+  it("runs on a non-PR event so main keeps a complete green-main history", async () => {
+    const decision = await decide("push", []);
+    expect(decision.run).toBe("true");
+  });
+
+  it("catches a rename that moves daemon code out of a scoped path", async () => {
+    // The new name matches nothing, but daemon code still changed. GitHub
+    // exposes the pre-rename path as previous_filename.
+    const decision = await decide("pull_request", [
+      { filename: "lib/daemon.ts", previous_filename: "src/daemon.ts" },
+    ]);
+    expect(decision.run).toBe("true");
+  });
+
+  it("runs rather than guesses when the diff hits the listFiles cap", async () => {
+    // pulls.listFiles caps at 3000 entries, so a src/ change can sit past it.
+    const capped = Array.from({ length: 3000 }, (_, index) => ({
+      filename: `docs/page-${index}.md`,
+    }));
+    const decision = await decide("pull_request", capped);
+    expect(decision.run).toBe("true");
+    expect(decision.reason).toContain("3000");
+  });
+
+  it("still skips a large-but-under-cap irrelevant diff", async () => {
+    const under = Array.from({ length: 2999 }, (_, index) => ({
+      filename: `docs/page-${index}.md`,
+    }));
+    const decision = await decide("pull_request", under);
+    expect(decision.run).toBe("false");
   });
 });

--- a/tests/perf-budget-scope.test.ts
+++ b/tests/perf-budget-scope.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The daemon performance budget benchmarks a live daemon on a shared runner, so
+ * its p95 rows carry real variance. Backlog #452: on cmuxlayer#595 — a diff of
+ * one test file, no `src/` — it failed twice on two DIFFERENT metrics
+ * (`send_to_surface_warm` p95 99.72ms vs 89ms, then `send_to_agent_warm` p95
+ * 193.07ms vs 181.25ms) after passing on an earlier head of the same diff.
+ *
+ * This guards the scoping fix: strict where the diff could move a timing,
+ * warn-and-skip where it provably cannot.
+ */
+
+const workflow = readFileSync(
+  join(import.meta.dirname, "..", ".github", "workflows", "ci.yml"),
+  "utf8",
+);
+
+const perfBudgetJob = workflow.slice(
+  workflow.indexOf("  perf-budget:"),
+  workflow.indexOf("  test:"),
+);
+
+/**
+ * The prefix list is read out of the workflow rather than duplicated here, so
+ * editing the workflow's list re-points these cases instead of silently
+ * drifting from them.
+ */
+function performanceRelevantPrefixes(): string[] {
+  const block = perfBudgetJob.match(
+    /const PERF_RELEVANT = \[([\s\S]*?)\];/,
+  )?.[1];
+  if (!block) throw new Error("PERF_RELEVANT list not found in ci.yml");
+  return [...block.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+/** The workflow's own predicate, kept to one line so it cannot drift in spirit. */
+function wouldRunBudget(changedFiles: string[]): boolean {
+  const prefixes = performanceRelevantPrefixes();
+  return changedFiles.some((name) =>
+    prefixes.some((prefix) => name.startsWith(prefix)),
+  );
+}
+
+describe("perf-budget scoping (backlog #452)", () => {
+  it("gates the benchmark on the scope step rather than always running it", () => {
+    expect(perfBudgetJob).toContain("id: scope");
+    expect(perfBudgetJob).toMatch(
+      /- name: Run daemon performance budget\n\s+if: steps\.scope\.outputs\.run == 'true'/,
+    );
+  });
+
+  it("reports a skip instead of falling through to the comment step's ERROR", () => {
+    expect(perfBudgetJob).toMatch(
+      /- name: Report skipped performance budget\n\s+if: steps\.scope\.outputs\.run != 'true'/,
+    );
+    expect(perfBudgetJob).toContain("Daemon performance budget: SKIPPED");
+  });
+
+  it("never records green-main history from a skipped run", () => {
+    expect(perfBudgetJob).toMatch(
+      /- name: Save bounded green-main benchmark history\n\s+if: success\(\) && steps\.scope\.outputs\.run == 'true'/,
+    );
+  });
+
+  it("scopes with a step, not a workflow-level paths filter", () => {
+    // ci.yml carries seven jobs; `on.pull_request.paths` would gate all of them,
+    // because GitHub has no per-job paths filter.
+    const triggers = workflow.slice(0, workflow.indexOf("permissions:"));
+    expect(triggers).not.toMatch(/^\s+paths(-ignore)?:/m);
+  });
+
+  it("skips a diff that cannot move a daemon timing", () => {
+    // The literal cmuxlayer#595 file list that failed twice on jitter.
+    expect(wouldRunBudget(["tests/no-new-as-any.test.ts"])).toBe(false);
+    expect(wouldRunBudget(["README.md", "docs/design/foo.md"])).toBe(false);
+  });
+
+  it("stays strict on anything that can move a daemon timing", () => {
+    for (const changed of [
+      ["src/daemon.ts"],
+      ["src/server.ts", "tests/agent-engine.test.ts"],
+      ["benchmarks/daemon-baseline.json"],
+      ["scripts/bench-daemon.mjs"],
+      ["scripts/check-daemon-benchmark.mjs"],
+      ["package.json"],
+      ["bun.lock"],
+      [".github/workflows/ci.yml"],
+    ]) {
+      expect(
+        wouldRunBudget(changed),
+        `should run for ${changed.join(", ")}`,
+      ).toBe(true);
+    }
+  });
+
+  it("covers the baseline and harness, not just src/", () => {
+    // Skipping a baseline edit would let a budget change land unmeasured —
+    // the one regression this guard must not introduce.
+    const prefixes = performanceRelevantPrefixes();
+    expect(prefixes).toContain("src/");
+    expect(prefixes).toContain("benchmarks/");
+    expect(prefixes.some((prefix) => prefix.startsWith("scripts/"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Backlog **#452**. Size **XS** — one workflow job scoped, one test file, no production code.

The daemon performance budget benchmarks a **live daemon on a shared runner**, so its p95 rows carry real variance. Today it runs on every PR, including diffs that cannot possibly move a timing. A red row a diff cannot have caused costs a re-run and, worse, teaches people to skim past the check.

Now: **strict** when the diff touches anything that can move a timing, **warn-and-skip** otherwise.

## The evidence — cmuxlayer#595

#595 is a diff of exactly one test file: no `src/`, no daemon, no socket code. `perf-budget` failed on it **twice, on two different metrics**, having already passed on an earlier head of the same content:

| Head | Attempt | Result |
|---|---|---|
| `a8a31ea` | 1 | **pass** (7m21s) |
| `dcd04f1` | 1 | fail — `send_to_surface_warm` p95 **99.72 ms** vs 89 ms (+12%) |
| `dcd04f1` | 2 | fail — `send_to_agent_warm` p95 **193.07 ms** vs 181.25 ms (+6.5%) |
| `dcd04f1` | 3 | third re-run in flight |

Same tests-only diff, pass → fail → fail, a **different metric each failure**. That is runner variance, not a regression: no code path under measurement changed between those runs.

## Why a step and not `on.pull_request.paths`

`paths:` filters are **workflow-level**. `ci.yml` carries seven jobs — `docs-local-guard`, `perf-budget`, `test`, `launcher-parity`, `launchd-units`, `build-site`, `perf-baseline-refresh`. Filtering the file would silently gate *all* of them, so a docs PR would stop running `test`. GitHub has no per-job paths filter, so scoping a single job means deciding inside the job.

The decision uses `actions/github-script`, already pinned in this workflow at the same SHA — no new dependency, no third-party action added.

A test asserts this choice directly, so a future "simplification" to a paths filter goes red:

```
✓ scopes with a step, not a workflow-level paths filter
```

## Scope is deliberately wider than `src/`

```js
const PERF_RELEVANT = [
  'src/', 'benchmarks/', 'scripts/bench-daemon', 'scripts/check-daemon-benchmark',
  'package.json', 'bun.lock', 'package-lock.json', '.github/workflows/ci.yml',
];
```

The brief said `src/`. I widened it, and the reason is the one regression this guard must not introduce: **skipping a `benchmarks/daemon-baseline.json` edit would let a budget change land unmeasured**, which is strictly worse than the jitter being fixed. Dependency and harness changes can move real timings too. Erring toward running is the safe direction — a false run costs seven minutes, a false skip costs a silent regression.

Note this PR touches `.github/workflows/ci.yml`, which is on that list, so **`perf-budget` runs strictly on this PR**. The fix does not exempt itself.

## Two details that would otherwise bite

**Skips do not poison the green-main cache.** The history-save step now requires `steps.scope.outputs.run == 'true'` as well as push-to-main, and non-PR events always run — so `main` keeps a complete benchmark history.

**A skip reads as SKIPPED, not ERROR.** The existing comment step runs `if: always()` and falls back to *"The benchmark did not produce a report"* when `comment.md` is absent. A skipped run now writes that report itself, so the PR comment says:

```
## Daemon performance budget: SKIPPED

None of the N changed file(s) can affect daemon runtime, so the benchmark was not run.
```

It also emits a `core.warning` annotation — visible on the run, not silent.

## Verification

**RED first**, against `main`'s unscoped `ci.yml` — 6 of 7 assertions fail:

```
× gates the benchmark on the scope step rather than always running it
× reports a skip instead of falling through to the comment step's ERROR
× never records green-main history from a skipped run
✓ scopes with a step, not a workflow-level paths filter
× skips a diff that cannot move a daemon timing
× stays strict on anything that can move a daemon timing
× covers the baseline and harness, not just src/
  Tests  6 failed | 1 passed (7)
```

(The one that passes on both sides is the paths-filter guard — it asserts the *wrong* fix was not used, so it is correctly green before and after.)

**GREEN** with the fix: `Tests 7 passed (7)`.

**The embedded workflow JS is syntax-checked and dry-run**, since `tsc` cannot see inside YAML. Extracted and executed against synthetic file lists:

| Case | `run` | warned |
|---|---|---|
| tests-only PR | `false` | yes |
| docs-only PR | `false` | yes |
| `src/daemon.ts` PR | `true` | — |
| `benchmarks/daemon-baseline.json` PR | `true` | — |
| push to main | `true` | — |

**Suite:** `3766 passed | 1 skipped` (main's 3759 baseline + 7 new). `bun run typecheck` clean. Pre-push regression harness exit 0.

The test reads `PERF_RELEVANT` out of the workflow rather than duplicating it, so editing the list in `ci.yml` re-points the cases instead of letting them drift.

## Test plan

- [x] RED shown against main's `ci.yml` before GREEN
- [x] Embedded workflow JS syntax-checked (`node --check`) and behaviourally dry-run
- [x] Full suite green (3766 passed | 1 skipped)
- [x] `bun run typecheck` clean
- [x] Pre-push harness exit 0
- [x] Skip path cannot write green-main history
- [x] Skip path produces SKIPPED, not the comment step's ERROR fallback

## Bot policy

Read `cmuxlayer/AGENTS.md` — no bot clause, so the dispatch governs. Panel: **CodeRabbit only**. `@codex` excluded (forbidden until Mon 09-07 04:00, shared pool; it has also been answering "usage limits" on #595). Bugbot excluded — canon #9 tiers it to daemon/engine/transport diffs, and this is CI config plus a test.

Does **not** touch #595.

— cmuxlayerClaude-fabd94e2 (worker) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"cmuxlayerClaude-fabd94e2","role":"worker","harness":"claude-code","model":"claude-opus-5","model_source":"session-jsonl","session":"ccc8da16","ts":"2026-09-05T21:35:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only scoping for an existing benchmark job; behavior errs toward running when uncertain (cap, non-PR, relevant paths) so perf regressions are not silently skipped.
> 
> **Overview**
> **Scopes the `perf-budget` CI job** so the live daemon benchmark runs only when a PR could plausibly change timings, addressing flaky failures on docs/tests-only diffs (backlog #452).
> 
> A new **`Decide whether the benchmark must run`** step uses `github-script` to paginate changed files and match prefixes (`src/`, `benchmarks/`, harness scripts, lockfiles, `tsconfig`, and the workflow itself). It checks **both** `filename` and `previous_filename` on renames, **always runs** on non-`pull_request` events, and **runs when the file list hits the 3000-entry API cap** instead of skipping a hidden `src/` change. Irrelevant PRs get `core.warning`, `run=false`, and skip install/benchmark/cache-restore; a **`Report skipped performance budget`** step writes a **SKIPPED** `comment.md` so the PR comment is not the ERROR fallback. Green-main history save is gated on `run == 'true'`.
> 
> Adds **`tests/perf-budget-scope.test.ts`**, which parses the embedded YAML script from `ci.yml` and executes it with mocks so CI logic cannot drift from tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb18abdcbd1dc493f7ddf46a3631bf95fbb03cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope daemon perf-budget CI job to performance-relevant diffs
> - Adds a GitHub Script step in [.github/workflows/ci.yml](https://github.com/EtanHey/cmuxlayer/pull/596/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that inspects changed files and decides whether the daemon benchmark must run; relevant paths include daemon source, benchmark data/scripts, dependency manifests, TypeScript config, and the workflow itself
> - Gates Bun setup, dependency install, benchmark-history restore, and benchmark execution on that decision; skipped runs emit a SKIPPED performance-budget report with the decision reason
> - Detects renames via previous filename and forces execution when the changed-file count hits the 3000-entry API cap; non-pull-request events always run
> - Adds [tests/perf-budget-scope.test.ts](https://github.com/EtanHey/cmuxlayer/pull/596/files#diff-3a2c3b213ca2fb73462dba2a2bea98fbf423fa8896e239b9ba3c0bebb79b2b55) that loads the workflow, extracts the embedded scope script, and runs it against synthetic pull-request, rename, and large-diff inputs
> - Behavioral Change: green-main benchmark history is only saved when the benchmark actually executes; performance-evidence upload remains unconditional
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb18abd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->