### PR TITLE
fix(contract): hand the seat a PID for its inbox tail, not a pattern (skill-creator-led)

### DIFF
--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -195,6 +195,8 @@ export function coordinationContractPath(
 /** Mailbox half of the contract, as the boot prompt used to carry it inline. */
 export interface MailboxContractFields {
   monitor_command: string;
+  /** Where the seat records the detached tail's pid, so teardown needs no pattern. */
+  tail_pid_path: string;
   cursor_update_command: string;
   cursor_update_env: string;
 }
@@ -235,10 +237,28 @@ export function renderBootContractFile(input: BootContractFileInput): string {
     // supposed to model against. Those callers are the F5 follow-up (#461).
     // The canonical command stays a verbatim substring of the line below, so a
     // consumer matching on it still matches.
+    // AIDEV-NOTE (D232 / 2026-09-05 mass-kill): this block used to stop at the
+    // backgrounded tail and say nothing about stopping it. A seat with a detached
+    // job and no teardown improvises one, and what it improvised was
+    // `pkill -f 'inbox.jsonl' -P 1` -- BSD getopt stops at the first non-option
+    // operand, so `-P` and `1` folded INTO the pattern and SIGTERM went to every
+    // process whose argv held a `1`: 20 launchd jobs and every
+    // `--model claude-opus-5[1m]` Claude seat. The contract now hands over a PID.
+    // Keeping the pidfile write on the SAME line as the tail keeps
+    // `monitor_command` a verbatim substring, so consumers matching on it (receipts,
+    // nudges, tool descriptions) still match -- the F5 constraint above still holds.
     "Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a",
-    "self-deadlock (ledger #24). Detach it, then return:",
+    "self-deadlock (ledger #24). Detach it, record its pid, then return:",
     "",
-    `    ${input.mailbox.monitor_command} &`,
+    `    ${input.mailbox.monitor_command} & echo $! > ${input.mailbox.tail_pid_path}`,
+    "",
+    "To stop it, kill that PID -- never a pattern:",
+    "",
+    `    kill "$(cat ${input.mailbox.tail_pid_path})"`,
+    "",
+    "Do NOT reach for a pattern-matching killer here. Trailing flags fold into the",
+    "pattern under BSD getopt, which is how one such command SIGTERM'd 20 launchd",
+    "jobs and every Claude seat on this machine on 2026-09-05.",
     "",
     `After each handled message run: ${input.mailbox.cursor_update_env}=<handled-message-id> ${input.mailbox.cursor_update_command}`,
     "",

--- a/src/coordination-paths.ts
+++ b/src/coordination-paths.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { agentDir, type InboxOpts } from "./inbox.js";
+import { shellQuote } from "./shell-safe.js";
 
 // AIDEV-NOTE (P11 / U10): engine-issued coordination paths. Before this, the
 // DONE signal's producer (the worker, told a path in the lead's prose brief)
@@ -215,6 +216,9 @@ export interface BootContractFileInput {
  * bounded by a keystroke threshold.
  */
 export function renderBootContractFile(input: BootContractFileInput): string {
+  // Agent dirs are user-configurable (CMUXLAYER_INBOX_BASE_DIR), so the path can
+  // carry spaces. Both generated commands are pasted into a shell verbatim.
+  const pidFile = shellQuote(input.mailbox.tail_pid_path);
   const lines = [
     `# cmuxlayer contract for ${input.agentId}`,
     "",
@@ -250,11 +254,13 @@ export function renderBootContractFile(input: BootContractFileInput): string {
     "Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a",
     "self-deadlock (ledger #24). Detach it, record its pid, then return:",
     "",
-    `    ${input.mailbox.monitor_command} & echo $! > ${input.mailbox.tail_pid_path}`,
+    `    ${input.mailbox.monitor_command} & echo $! > ${pidFile}`,
     "",
     "To stop it, kill that PID -- never a pattern:",
     "",
-    `    kill "$(cat ${input.mailbox.tail_pid_path})"`,
+    // `rm -f` on success: a pidfile outliving its tail is a stale PID, and PIDs
+    // are reused -- a second teardown would then SIGTERM whatever inherited it.
+    `    kill "$(cat ${pidFile})" && rm -f ${pidFile}`,
     "",
     "Do NOT reach for a pattern-matching killer here. Trailing flags fold into the",
     "pattern under BSD getopt, which is how one such command SIGTERM'd 20 launchd",

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -135,6 +135,16 @@ export function heartbeatPath(agentId: string, opts?: InboxOpts): string {
   return join(agentDir(agentId, opts), "monitor.heartbeat");
 }
 
+/**
+ * Where the agent records the pid of its detached inbox tail. The boot contract hands
+ * this path over so a seat stopping its own tail addresses a PID, never a PATTERN:
+ * `pkill -f 'inbox.jsonl' -P 1` folds the trailing flags into the pattern under BSD
+ * getopt and SIGTERMs every process with a `1` in its argv (2026-09-05 incident).
+ */
+export function inboxTailPidPath(agentId: string, opts?: InboxOpts): string {
+  return join(agentDir(agentId, opts), "inbox-tail.pid");
+}
+
 function channelMarkerDir(opts?: InboxOpts): string {
   return join(baseDirOf(opts), ".channel-dirs");
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,6 +186,7 @@ import {
   ensureInboxFile,
   formatInboxPing,
   inboxCursorPath,
+  inboxTailPidPath,
   inboxMonitorState,
   inboxPath,
   monitorAlive,
@@ -4414,6 +4415,9 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           agentId,
           mailbox: {
             monitor_command: monitorBoot.monitor_command,
+            // Contract-file only, deliberately NOT on the monitor_boot receipt: the
+            // pidfile is the seat's own teardown handle, not engine-observed state.
+            tail_pid_path: inboxTailPidPath(agentId, inboxOpts),
             cursor_update_command: monitorBoot.cursor_update_command,
             cursor_update_env: monitorBoot.cursor_update_env,
           },

--- a/tests/inbox-tail-teardown.test.ts
+++ b/tests/inbox-tail-teardown.test.ts
@@ -13,18 +13,20 @@
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import { renderBootContractFile } from "../src/coordination-paths.js";
+import { shellQuote } from "../src/shell-safe.js";
 
 const AGENT_ID = "cmuxlayerClaude-w27bfake";
 const BASE_DIR = "/tmp/cmux-w27b-fixture";
 const INBOX = join(BASE_DIR, AGENT_ID, "inbox.jsonl");
 const PID_FILE = join(BASE_DIR, AGENT_ID, "inbox-tail.pid");
 
-function render(): string {
+function render(baseDir: string = BASE_DIR): string {
+  const inbox = join(baseDir, AGENT_ID, "inbox.jsonl");
   return renderBootContractFile({
     agentId: AGENT_ID,
     mailbox: {
-      monitor_command: `tail -n0 -F ${INBOX}`,
-      tail_pid_path: PID_FILE,
+      monitor_command: `tail -n0 -F ${inbox}`,
+      tail_pid_path: join(baseDir, AGENT_ID, "inbox-tail.pid"),
       cursor_update_command: `cmuxlayer inbox-cursor '${AGENT_ID}'`,
       cursor_update_env: "CMUX_INBOX_MSG_ID",
     },
@@ -45,12 +47,25 @@ describe("boot contract mailbox teardown", () => {
   it("records the tail's pid so the seat never has to find it", () => {
     const block = mailboxBlock(render());
     expect(block).toContain(`tail -n0 -F ${INBOX} &`);
-    expect(block).toContain(`echo $! > ${PID_FILE}`);
+    expect(block).toContain(`echo $! > ${shellQuote(PID_FILE)}`);
   });
 
   it("gives the exact stop command, addressed by pid", () => {
     const block = mailboxBlock(render());
-    expect(block).toContain(`kill "$(cat ${PID_FILE})"`);
+    expect(block).toContain(
+      `kill "$(cat ${shellQuote(PID_FILE)})" && rm -f ${shellQuote(PID_FILE)}`,
+    );
+  });
+
+  it("survives an agent dir with spaces in it", () => {
+    // CMUXLAYER_INBOX_BASE_DIR is user-configurable, so the path can carry
+    // spaces; unquoted, the redirect would write to the wrong file and the
+    // teardown would `cat` a path that does not exist.
+    const spaced = "/tmp/cmux w27b fixture";
+    const pid = join(spaced, AGENT_ID, "inbox-tail.pid");
+    const block = mailboxBlock(render(spaced));
+    expect(block).toContain(`echo $! > '${pid}'`);
+    expect(block).toContain(`kill "$(cat '${pid}')" && rm -f '${pid}'`);
   });
 
   it("never hands the seat a pattern-matching killer", () => {

--- a/tests/inbox-tail-teardown.test.ts
+++ b/tests/inbox-tail-teardown.test.ts
@@ -1,0 +1,66 @@
+/**
+ * W27b / D232 — the spawn contract must hand over a PID, never a pattern.
+ *
+ * Every issued contract orders `tail -n0 -F <inbox> &` and stops there. With no
+ * teardown line, a seat improvises one. On 2026-09-05 a brainlayer seat improvised
+ * `pkill -f 'inbox.jsonl' -P 1`; BSD getopt stops at the first non-option operand, so
+ * `-P` and `1` folded INTO the pattern and SIGTERM went to every process whose argv
+ * held a `1` — 20 launchd jobs and every `--model claude-opus-5[1m]` Claude seat.
+ * See docs.local/incidents/2026-09-05-mass-claude-kill.md.
+ *
+ * The contract is the upstream fix: it must give the exact stop command.
+ */
+import { describe, it, expect } from "vitest";
+import { join } from "node:path";
+import { renderBootContractFile } from "../src/coordination-paths.js";
+
+const AGENT_ID = "cmuxlayerClaude-w27bfake";
+const BASE_DIR = "/tmp/cmux-w27b-fixture";
+const INBOX = join(BASE_DIR, AGENT_ID, "inbox.jsonl");
+const PID_FILE = join(BASE_DIR, AGENT_ID, "inbox-tail.pid");
+
+function render(): string {
+  return renderBootContractFile({
+    agentId: AGENT_ID,
+    mailbox: {
+      monitor_command: `tail -n0 -F ${INBOX}`,
+      tail_pid_path: PID_FILE,
+      cursor_update_command: `cmuxlayer inbox-cursor '${AGENT_ID}'`,
+      cursor_update_env: "CMUX_INBOX_MSG_ID",
+    },
+    coordination: null,
+  });
+}
+
+/** The "## Mailbox" section, up to the next `## ` heading or end of file. */
+function mailboxBlock(contract: string): string {
+  const start = contract.indexOf("## Mailbox");
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = contract.slice(start + "## Mailbox".length);
+  const next = rest.indexOf("\n## ");
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe("boot contract mailbox teardown", () => {
+  it("records the tail's pid so the seat never has to find it", () => {
+    const block = mailboxBlock(render());
+    expect(block).toContain(`tail -n0 -F ${INBOX} &`);
+    expect(block).toContain(`echo $! > ${PID_FILE}`);
+  });
+
+  it("gives the exact stop command, addressed by pid", () => {
+    const block = mailboxBlock(render());
+    expect(block).toContain(`kill "$(cat ${PID_FILE})"`);
+  });
+
+  it("never hands the seat a pattern-matching killer", () => {
+    const contract = render();
+    expect(contract).not.toMatch(/\bpkill\b/);
+    expect(contract).not.toMatch(/\bkillall\b/);
+  });
+
+  it("names the folding footgun so an improvised pkill is not a blank slate", () => {
+    const block = mailboxBlock(render());
+    expect(block.toLowerCase()).toContain("pattern");
+  });
+});


### PR DESCRIPTION
## Why (D232)

Every issued contract orders the seat to detach a tail on its inbox and never says how to stop it. `src/coordination-paths.ts` rendered exactly this and stopped:

```
Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a
self-deadlock (ledger #24). Detach it, then return:

    tail -n0 -F <inbox> &
```

A seat holding a detached job it was never told how to stop improvises a teardown. On **2026-09-05 at 18:29:48.108Z** a brainlayer seat improvised:

```
pkill -f 'inbox.jsonl' -P 1 2>/dev/null; kill 40955 2>/dev/null && echo …
```

BSD getopt stops at the first non-option operand, so `inbox.jsonl`, `-P` and `1` were all consumed as patterns and joined into one alternation — the command was equivalent to `pkill -f 'inbox.jsonl|-P|1'`, i.e. SIGTERM to every process whose full argv contains the character `1`. It killed 20 launchd jobs (Google Drive, 1Password, WhatsApp, the TTS synthesizers, tailnet-dashboards) and every Claude seat whose argv held a `1` — which every `--model claude-opus-5[1m]` seat does. Verified read-only at the time: `pgrep -f 'inbox.jsonl' -P 1` and `pgrep -f 'inbox.jsonl|-P|1'` returned identical 92-pid sets; `pgrep -f -P 1 'inbox.jsonl'` returns 1.

Incident write-up: `docs.local/incidents/2026-09-05-mass-claude-kill.md` (fleet orchestrator repo).
Brief: `docs.local/weave/2026-09-04/brief-W27b-cmux-inbox-tail-teardown.md`.

**This is live, not historical.** Counted this turn: **2,038** files under `~/.cmux/agents/*/contract.md`, **2,038** ordering a detached tail, **0** carrying any teardown line.

## Which fix, and the evidence for it

The brief offered (a) record the pid and give the exact teardown, or (b) drop the detached tail entirely if `send_to` already delivers. **I took (a).** Evidence against (b):

- `recommendedCodexWatch()` exists precisely because Codex/Cursor harnesses have **no native Monitor and no async wake-up**; its own doc comment says the durable queue is the inbox file and the load-bearing requirement is a poll cadence over it.
- The same `mailboxBootContract` / `renderBootContractFile` producer serves **every** harness — `tests/harness-session.test.ts:655` shows a `cmuxlayerCodex-*` seat receiving it — and the renderer has no harness discriminator. Adding one to justify dropping the tail is a runtime change well past this lane's size.

So the tail still carries traffic for harnesses `send_to`'s nudge path cannot wake, and removing it from the shared renderer would silently degrade those seats. (a) is correct and is the smaller change.

## What changed

`src/coordination-paths.ts` — the Mailbox block now emits the pidfile write, the exact stop command, and a named warning:

```
Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a
self-deadlock (ledger #24). Detach it, record its pid, then return:

    tail -n0 -F <inbox> & echo $! > '<agent-dir>/inbox-tail.pid'

To stop it, kill that PID -- never a pattern:

    kill "$(cat '<agent-dir>/inbox-tail.pid')" && rm -f '<agent-dir>/inbox-tail.pid'

Do NOT reach for a pattern-matching killer here. Trailing flags fold into the
pattern under BSD getopt, which is how one such command SIGTERM'd 20 launchd
jobs and every Claude seat on this machine on 2026-09-05.
```

The pidfile write stays on the **same line** as the tail, so `monitor_command` remains a verbatim substring and the receipt / nudge / tool-description consumers that match on it still match — the F5 constraint in the existing AIDEV-NOTE is preserved.

`src/inbox.ts` — `inboxTailPidPath()`, joining the existing agent-dir path helpers.

`src/server.ts` — threads the path into the contract-file input only. **Deliberately not added to the `monitor_boot` receipt**: the pidfile is the seat's own teardown handle, not engine-observed state, and keeping it off the receipt leaves the wire shape (and `tests/spawn-monitor-boot.test.ts`) untouched.

## Stated limitation

Only the **pointer/file** contract carries the teardown, which is the default (`bootContractMode()` returns `"pointer"` unless `CMUXLAYER_BOOT_CONTRACT=inline`). The inline variant is left alone on purpose: the existing AIDEV-NOTE records that the inline mailbox contract is already ~479 chars against a 500-char chunk threshold, so adding four lines there would move every spawn onto the chunked-paste path. Inline-mode seats still get no teardown line.

## Tests

`tests/inbox-tail-teardown.test.ts` — 4 cases: the pidfile write, the exact `kill "$(cat …)"` line, no `pkill`/`killall` anywhere in a rendered contract, and that the block names the footgun.

- **RED on `main`:** 3 failed | 1 passed. (The "no pattern-matching killer" case passes on main by absence — it is a ratchet, not a repair.)
- **GREEN on this branch:** 4 passed.
- **Full suite:** `npm test` → **159 files passed, 3783 passed | 1 skipped**. `npx tsc --noEmit` clean.
- On an earlier run one infra-level `Error: [vitest-worker]: Timeout calling "onTaskUpdate"` appeared in the summary — a worker RPC timeout, not a test failure; every file and test passed. It did not recur on the final run. Reporting it rather than hiding it.

## Review round 1 (Macroscope — both findings accepted, both real)

1. **Unquoted pidfile path.** Agent dirs are user-configurable via `CMUXLAYER_INBOX_BASE_DIR`, so the path can carry spaces; unquoted, the redirect wrote to the wrong file and the teardown could not `cat` it back. Both generated commands now go through `shellQuote()`, applied in the renderer where the shell command is built, so `tail_pid_path` stays a plain path like the other contract fields. New test case covers a base dir with spaces.
2. **Stale pidfile after teardown.** PIDs are reused, so a leftover pidfile meant a second teardown could SIGTERM whatever inherited the number — the exact failure this PR exists to prevent. Teardown is now `kill "$(cat <pidfile>)" && rm -f <pidfile>`; the file is cleared only when the kill succeeded.

Cross-checked both generated lines against the downstream guard in `EtanHey/golems#27` — neither is blocked by it.

## Live proof (not inferred)

A real contract rendered through `writeBootContractFile()` on this branch:

```
# cmuxlayer contract for golemsClaude-32ba5875

Engine-issued at spawn. Do not re-derive these strings; use them verbatim.

## Mailbox

Run this in the BACKGROUND -- it blocks, and holding a turn open on it is a
self-deadlock (ledger #24). Detach it, record its pid, then return:

    tail -n0 -F <home>/.cmux/agents/golemsClaude-32ba5875/inbox.jsonl & echo $! > '<home>/.cmux/agents/golemsClaude-32ba5875/inbox-tail.pid'

To stop it, kill that PID -- never a pattern:

    kill "$(cat '<home>/.cmux/agents/golemsClaude-32ba5875/inbox-tail.pid')" && rm -f '<home>/.cmux/agents/golemsClaude-32ba5875/inbox-tail.pid'

Do NOT reach for a pattern-matching killer here. Trailing flags fold into the
pattern under BSD getopt, which is how one such command SIGTERM'd 20 launchd
jobs and every Claude seat on this machine on 2026-09-05.

After each handled message run: CMUX_INBOX_MSG_ID=<handled-message-id> cmuxlayer inbox-cursor 'golemsClaude-32ba5875'
```

## Downstream

`EtanHey/golems#27` adds the git-guardian rule that blocks the malformed command itself. This PR is the upstream half: it stops seats from needing to invent one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract prose and spawn file content only; no auth or dispatch logic changes. Inline-mode spawns still lack teardown until a separate budget change.
> 
> **Overview**
> **Fixes seats improvising dangerous `pkill` teardown** after the boot contract told them to background `tail -n0 -F` on the inbox but never said how to stop it (2026-09-05 mass-kill incident).
> 
> The **file-backed boot contract** (`contract.md`) now tells the seat to record the detached tail’s PID on the same line as the monitor command (`echo $! > …/inbox-tail.pid`), stop it with `kill "$(cat …)" && rm -f …`, and explicitly warns against pattern-based killers. Paths are **`shellQuote`d** so configurable agent dirs with spaces still work.
> 
> Adds **`inboxTailPidPath()`** and a required **`tail_pid_path`** on `MailboxContractFields`; spawn wiring in **`server.ts`** passes that path only into the written contract file—not the **`monitor_boot` receipt**—so `monitor_command` stays a verbatim substring for existing matchers. **Inline** boot contract mode is unchanged (budget).
> 
> New Vitest coverage in **`inbox-tail-teardown.test.ts`** locks PID write, exact stop line, quoting with spaces, no `pkill`/`killall`, and the pattern warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b13768b0a2afb8b13b2e4f6e801f9f2975b853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass inbox tail PID path to boot contract renderer and kill by PID instead of pattern
> - Adds `inboxTailPidPath` in [inbox.ts](https://github.com/EtanHey/cmuxlayer/pull/597/files#diff-e7d7b98b0b1751422d7830f19a6c0a9f7d885ccd9ea6d9468baf89c8b6b1869d) to derive a deterministic `inbox-tail.pid` path inside the agent directory.
> - `createServer` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/597/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) supplies this path as `tail_pid_path` in the boot contract payload; the field is limited to the contract file and not added to the monitor boot receipt.
> - `renderBootContractFile` in [coordination-paths.ts](https://github.com/EtanHey/cmuxlayer/pull/597/files#diff-e9755eeba4a0e2b38c0755d707183f4db575afa048b0020a2c7bf74fd4e5e8b4) renders a monitor launch that records `$!` into the PID file, a stop command that kills the quoted PID and removes the file, and explicitly prohibits pattern-based termination (`pkill`/`killall`).
> - Tests in [inbox-tail-teardown.test.ts](https://github.com/EtanHey/cmuxlayer/pull/597/files#diff-a8c099794f2bbaac0f950322cca576ef501f80ff7aafffab03d4a195e32548d5) verify PID recording, quoted kill/removal, path-with-spaces quoting, and absence of pattern-based commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8b1376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated process identifier for detached inbox monitoring.
  - Boot instructions now record the monitor’s process ID and provide a direct command to stop that specific process.
  - Added guidance against broad pattern-based termination commands, reducing the risk of stopping unrelated processes.

- **Tests**
  - Added coverage to verify process tracking, targeted shutdown instructions, and safety guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
