### PR TITLE
chore: release v0.4.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.69",
+  "version": "0.4.70",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Automated version-bump PR for cmuxlayer v0.4.70. The release tag is created only after required checks pass and this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or behavioral changes in the PR diff.
> 
> **Overview**
> Automated release prep that bumps the published package version from **0.4.69** to **0.4.70** in `package.json`. No source, dependency, or script changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb41254b3258d2f196e087fbcc477d7ad1e3d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version to `0.4.70`
> Updates the version field in [package.json](https://github.com/EtanHey/cmuxlayer/pull/598/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `0.4.69` to `0.4.70` as part of the release process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccb4125.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped the package version to 0.4.70.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->