### PR TITLE
feat: make successful delivery receipts lean

### DIFF
--- a/scripts/bench-daemon.mjs
+++ b/scripts/bench-daemon.mjs
@@ -886,7 +886,9 @@ function requireTerminalSubmission(receipt, label) {
     receipt.delivery_state !== "submitted" ||
     receipt.submit_verified !== true
   ) {
-    throw new Error(`${label} was not terminally submitted`);
+    throw new Error(
+      `${label} was not terminally submitted: ${compact(receipt)}`,
+    );
   }
   return receipt;
 }
@@ -1014,7 +1016,13 @@ async function measureSpawnLifecycleOnce(
     } = {},
   ) => {
     const startedAt = nowMs();
-    const receipt = toolData(await client.callTool("send_to", args), "send_to");
+    // Receipt diagnostics are benchmark instrumentation, not workload input.
+    // Keep canonical request bytes/hashes based on args while opting into the
+    // timing, terminal, and transport fields the benchmark validates below.
+    const receipt = toolData(
+      await client.callTool("send_to", { ...args, verbose: true }),
+      "send_to",
+    );
     if (requireSubmitted) {
       requireTerminalSubmission(receipt, `${args.mode} send`);
     }
@@ -1076,10 +1084,6 @@ async function measureSpawnLifecycleOnce(
     requireSubmitted: false,
     canonicalText: surfaceSampleSentinel("NNN"),
     validateReceipt: async (receipt) => {
-      requireTerminalSubmission(
-        receipt,
-        "sampled surface send initial receipt",
-      );
       try {
         const terminal = await requireSubmittedDelivery(
           client,
@@ -1351,7 +1355,13 @@ async function measureParallelStress(
     const receipts = await Promise.all(
       requests.map(async (requestArgs, index) =>
         toolData(
-          await clients[index].callTool(name, requestArgs, 30_000),
+          await clients[index].callTool(
+            name,
+            name === "send_to"
+              ? { ...requestArgs, verbose: true }
+              : requestArgs,
+            30_000,
+          ),
           name,
         ),
       ),

--- a/src/server.ts
+++ b/src/server.ts
@@ -725,6 +725,7 @@ const SendToArgsSchema = z.object({
   press_enter: z.boolean().optional().default(true),
   allow_busy: z.boolean().optional().default(false),
   allow_long_inline: z.boolean().optional().default(false),
+  verbose: z.boolean().optional().default(false).describe("Return the full legacy success receipt, including transport and timing diagnostics. Failures always keep full detail."),
   targeting: z
     .object({
       role: z.enum(["implementor", "reviewer", "gatherer"]).optional(),
@@ -1784,6 +1785,37 @@ function okFormatted(
   return {
     content: [{ type: "text", text: formattedText }],
     structuredContent: payload,
+  };
+}
+
+function shapeSuccessfulSendToResult(result: ToolReturn, args: Record<string, unknown>): ToolReturn {
+  const full = result.structuredContent;
+  if (
+    result.isError === true ||
+    !full ||
+    full.ok !== true ||
+    full.delivery_state !== "submitted" ||
+    full.submitted !== true
+  ) {
+    return result;
+  }
+
+  const surfaceMode = args.mode === "surface";
+  const identityKey = surfaceMode ? "surface" : "agent_id";
+  const identity = full[identityKey] ?? args[identityKey];
+  const text = typeof args.text === "string" ? sanitizeTerminalInput(args.text) : "";
+  const lean: Record<string, unknown> = {
+    ok: true,
+    ...(typeof identity === "string" ? { [identityKey]: identity } : {}),
+    delivery_state: "submitted",
+    submitted: true,
+    bytes: typeof full.bytes === "number" ? full.bytes : Buffer.byteLength(text, "utf8"),
+    ...(typeof full.delivery_id === "string" ? { delivery_id: full.delivery_id } : {}),
+  };
+  return {
+    ...result,
+    content: [{ type: "text", text: JSON.stringify(lean) }],
+    structuredContent: lean,
   };
 }
 
@@ -4946,6 +4978,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
   const attachTransportProvenance = (
     result: unknown,
     toolName: string,
+    verbose = false,
   ): unknown => {
     if (
       toolName !== "spawn_agent" &&
@@ -4962,6 +4995,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     const toolResult = result as ToolReturn;
     const structured = toolResult.structuredContent;
     if (!structured || typeof structured !== "object") return result;
+    const leanSuccessfulReceipt =
+      !verbose &&
+      toolResult.isError !== true &&
+      structured.ok === true &&
+      (toolName === "spawn_agent" ||
+        (toolName === "send_to" &&
+          structured.delivery_state === "submitted" &&
+          structured.submitted === true));
+    if (leanSuccessfulReceipt) return result;
     const provenance = transportProvenance();
     const existingWarnings = Array.isArray(structured.warnings)
       ? structured.warnings
@@ -5075,12 +5117,21 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     if (typeof handler === "function") {
       const trackedHandler = (...handlerArgs: unknown[]) =>
         runWithSurfaceTopologyCallScope(() =>
-          withTransportRetryTracking(async () =>
-            attachTransportProvenance(
-              await handler(...handlerArgs),
-              typeof toolName === "string" ? toolName : "",
-            ),
-          ),
+          withTransportRetryTracking(async () => {
+            const toolNameString =
+              typeof toolName === "string" ? toolName : "";
+            const rawArgs =
+              handlerArgs[0] && typeof handlerArgs[0] === "object"
+                ? (handlerArgs[0] as Record<string, unknown>)
+                : {};
+            const verbose = rawArgs.verbose === true;
+            const handled = (await handler(...handlerArgs)) as ToolReturn;
+            const shaped =
+              toolNameString === "send_to" && !verbose
+                ? shapeSuccessfulSendToResult(handled, rawArgs)
+                : handled;
+            return attachTransportProvenance(shaped, toolNameString, verbose);
+          }),
         );
       args[handlerIndex] = trackedHandler;
       if (typeof toolName === "string") {
@@ -14223,7 +14274,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 11. spawn_agent
     server.tool(
       "spawn_agent",
-      "Spawn a managed agent or terminal, or resume a captured agent on a fresh surface while preserving its ID. Placement is deterministic; boot prompts return evidence-backed receipts.",
+      "Spawn a managed agent or terminal, or resume a captured agent on a fresh surface while preserving its ID. Placement is deterministic; boot prompts return evidence-backed receipts. Successful receipts are lean by default; verbose=true restores full transport and diagnostic detail. Failures always keep full detail.",
       {
         version: z
           .literal(1)
@@ -17432,7 +17483,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode.",
+      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode. A verified successful submission returns at most six fields by default: ok, target identity, delivery_state, submitted, bytes, and delivery_id when available. Pass verbose=true for the full legacy receipt; non-success keeps full diagnostics automatically.",
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(

--- a/src/server.ts
+++ b/src/server.ts
@@ -17555,7 +17555,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode. A clean verified success returns six fields by default: ok, retry_count, target identity, delivery_state, submitted, and delivery_id. A degraded transport, queued-behind-turn landing, or deduplicated send adds its warning or status field. Pass verbose=true for the full legacy receipt; non-success keeps full diagnostics automatically.",
+      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode. A clean verified success returns up to six mode-specific core fields by default: text/command mode returns ok, retry_count, target identity, delivery_state, submitted, and delivery_id when available; key mode returns ok, retry_count, surface, key, submit_verified, and submit_verification_reason. A degraded transport, queued-behind-turn landing, or deduplicated send adds its warning or status field. Pass verbose=true for the full legacy receipt; non-success keeps full diagnostics automatically.",
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(

--- a/src/server.ts
+++ b/src/server.ts
@@ -428,6 +428,39 @@ type ToolReturn = {
   isError?: boolean;
 };
 
+const TRANSPORT_PROVENANCE_TOOLS = new Set([
+  "spawn_agent",
+  "send_to",
+  "close_surface",
+  "control_health",
+  "list_surfaces",
+  "read_screen",
+  "list_agents",
+]);
+
+function isLeanSuccessfulTransportReceipt(
+  toolResult: ToolReturn,
+  toolName: string,
+  verbose: boolean,
+): boolean {
+  const structured = toolResult.structuredContent;
+  if (
+    verbose ||
+    toolResult.isError === true ||
+    !structured ||
+    structured.ok !== true
+  ) {
+    return false;
+  }
+  if (toolName === "spawn_agent") return true;
+  if (toolName !== "send_to") return false;
+  const submittedReceipt =
+    structured.delivery_state === "submitted" && structured.submitted === true;
+  const verifiedKeyReceipt =
+    typeof structured.key === "string" && structured.submit_verified === true;
+  return submittedReceipt || verifiedKeyReceipt;
+}
+
 class SurfaceEnumerationError extends Error {
   constructor(message: string) {
     super(message);
@@ -5018,31 +5051,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     toolName: string,
     verbose = false,
   ): unknown => {
-    if (
-      toolName !== "spawn_agent" &&
-      toolName !== "send_to" &&
-      toolName !== "close_surface" &&
-      toolName !== "control_health" &&
-      toolName !== "list_surfaces" &&
-      toolName !== "read_screen" &&
-      toolName !== "list_agents"
-    ) {
+    if (!TRANSPORT_PROVENANCE_TOOLS.has(toolName)) {
       return result;
     }
     if (!result || typeof result !== "object") return result;
     const toolResult = result as ToolReturn;
     const structured = toolResult.structuredContent;
     if (!structured || typeof structured !== "object") return result;
-    const leanSuccessfulReceipt =
-      !verbose &&
-      toolResult.isError !== true &&
-      structured.ok === true &&
-      (toolName === "spawn_agent" ||
-        (toolName === "send_to" &&
-          ((structured.delivery_state === "submitted" &&
-            structured.submitted === true) ||
-            (typeof structured.key === "string" &&
-              structured.submit_verified === true))));
+    const leanSuccessfulReceipt = isLeanSuccessfulTransportReceipt(
+      toolResult,
+      toolName,
+      verbose,
+    );
     const provenance = transportProvenance();
     const existingWarnings = Array.isArray(structured.warnings)
       ? structured.warnings

--- a/src/server.ts
+++ b/src/server.ts
@@ -1788,29 +1788,59 @@ function okFormatted(
   };
 }
 
-function shapeSuccessfulSendToResult(result: ToolReturn, args: Record<string, unknown>): ToolReturn {
+/** Reduce verified send_to successes without discarding routing or safety state. */
+function shapeSuccessfulSendToResult(
+  result: ToolReturn,
+  args: Record<string, unknown>,
+): ToolReturn {
   const full = result.structuredContent;
+  const verifiedSubmit =
+    (full?.delivery_state === "submitted" && full.submitted === true) ||
+    (args.mode === "key" &&
+      full?.submit_attempted === true &&
+      full.submit_dispatched === true &&
+      full.submit_verified === true);
   if (
     result.isError === true ||
     !full ||
     full.ok !== true ||
-    full.delivery_state !== "submitted" ||
-    full.submitted !== true
+    !verifiedSubmit
   ) {
     return result;
   }
 
-  const surfaceMode = args.mode === "surface";
+  const surfaceMode = args.mode !== "agent";
   const identityKey = surfaceMode ? "surface" : "agent_id";
-  const identity = full[identityKey] ?? args[identityKey];
-  const text = typeof args.text === "string" ? sanitizeTerminalInput(args.text) : "";
+  const identity =
+    full[identityKey] ??
+    args[identityKey] ??
+    (surfaceMode ? args.target : undefined);
   const lean: Record<string, unknown> = {
     ok: true,
+    retry_count:
+      typeof full.retry_count === "number"
+        ? full.retry_count
+        : currentTransportRetryCount(),
     ...(typeof identity === "string" ? { [identityKey]: identity } : {}),
     delivery_state: "submitted",
     submitted: true,
-    bytes: typeof full.bytes === "number" ? full.bytes : Buffer.byteLength(text, "utf8"),
-    ...(typeof full.delivery_id === "string" ? { delivery_id: full.delivery_id } : {}),
+    ...(args.mode === "key"
+      ? {
+          submit_verified: full.submit_verified,
+          submit_verification_reason:
+            full.submit_verification_reason ?? null,
+        }
+      : {}),
+    ...(typeof full.delivery_id === "string"
+      ? { delivery_id: full.delivery_id }
+      : {}),
+    ...(full.queued_behind_turn === true ? { queued_behind_turn: true } : {}),
+    ...(typeof full.duplicate_of === "string"
+      ? { duplicate_of: full.duplicate_of }
+      : {}),
+    ...(Array.isArray(full.warnings) && full.warnings.length > 0
+      ? { warnings: full.warnings }
+      : {}),
   };
   return {
     ...result,
@@ -1818,6 +1848,8 @@ function shapeSuccessfulSendToResult(result: ToolReturn, args: Record<string, un
     structuredContent: lean,
   };
 }
+
+export const __leanReceiptTestHooks = { shapeSuccessfulSendToResult };
 
 function err(error: unknown, extra: Record<string, unknown> = {}): ToolReturn {
   const message = error instanceof Error ? error.message : String(error);
@@ -4975,6 +5007,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     getTransportHealth(client)?.mode === "socket"
       ? method
       : null;
+  /** Attach full transport diagnostics, or warnings alone on lean successes. */
   const attachTransportProvenance = (
     result: unknown,
     toolName: string,
@@ -5003,7 +5036,6 @@ export function createServer(opts?: CreateServerOptions): McpServer {
         (toolName === "send_to" &&
           structured.delivery_state === "submitted" &&
           structured.submitted === true));
-    if (leanSuccessfulReceipt) return result;
     const provenance = transportProvenance();
     const existingWarnings = Array.isArray(structured.warnings)
       ? structured.warnings
@@ -5012,6 +5044,19 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       ? provenance.warnings
       : [];
     const warnings = [...new Set([...existingWarnings, ...provenanceWarnings])];
+    if (leanSuccessfulReceipt) {
+      if (warnings.length === 0) return result;
+      const nextStructured = { ...structured, warnings };
+      return {
+        ...toolResult,
+        content: toolResult.content.map((entry) =>
+          entry.type === "text"
+            ? { ...entry, text: JSON.stringify(nextStructured) }
+            : entry,
+        ),
+        structuredContent: nextStructured,
+      };
+    }
     const nextStructured = {
       ...structured,
       ...provenance,
@@ -17483,7 +17528,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     // 17. send_to
     server.tool(
       "send_to",
-      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode. A verified successful submission returns at most six fields by default: ok, target identity, delivery_state, submitted, bytes, and delivery_id when available. Pass verbose=true for the full legacy receipt; non-success keeps full diagnostics automatically.",
+      "Send text or a key through the shared delivery engine. Targets may be one agent, structured agent targeting, or a raw surface in surface/command/key mode. A clean verified success returns six fields by default: ok, retry_count, target identity, delivery_state, submitted, and delivery_id. A degraded transport, queued-behind-turn landing, or deduplicated send adds its warning or status field. Pass verbose=true for the full legacy receipt; non-success keeps full diagnostics automatically.",
       {
         ...SendToArgsSchema.shape,
         text: SendToArgsSchema.shape.text.describe(
@@ -18395,6 +18440,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               agent_id: agentId,
               target: undefined,
               targeting: undefined,
+              verbose: true,
             },
             {},
           );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1815,22 +1815,27 @@ function shapeSuccessfulSendToResult(
     full[identityKey] ??
     args[identityKey] ??
     (surfaceMode ? args.target : undefined);
-  const lean: Record<string, unknown> = {
+  const receiptFloor = {
     ok: true,
     retry_count:
       typeof full.retry_count === "number"
         ? full.retry_count
         : currentTransportRetryCount(),
     ...(typeof identity === "string" ? { [identityKey]: identity } : {}),
-    delivery_state: "submitted",
-    submitted: true,
+  };
+  const lean: Record<string, unknown> = {
+    ...receiptFloor,
     ...(args.mode === "key"
       ? {
+          key: full.key ?? args.text,
           submit_verified: full.submit_verified,
           submit_verification_reason:
             full.submit_verification_reason ?? null,
         }
-      : {}),
+      : {
+          delivery_state: "submitted",
+          submitted: true,
+        }),
     ...(typeof full.delivery_id === "string"
       ? { delivery_id: full.delivery_id }
       : {}),
@@ -5034,8 +5039,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       structured.ok === true &&
       (toolName === "spawn_agent" ||
         (toolName === "send_to" &&
-          structured.delivery_state === "submitted" &&
-          structured.submitted === true));
+          ((structured.delivery_state === "submitted" &&
+            structured.submitted === true) ||
+            (typeof structured.key === "string" &&
+              structured.submit_verified === true))));
     const provenance = transportProvenance();
     const existingWarnings = Array.isArray(structured.warnings)
       ? structured.warnings

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -105,17 +105,26 @@ function leanWorktree(value: unknown): JsonObject | undefined {
   );
 }
 
+/** Retain actionable spawn identity and evidence while omitting routine detail. */
 export function shapeSpawnResponse(
   full: JsonObject,
   verbose = false,
 ): JsonObject {
   if (verbose) return full;
 
-  const lean: JsonObject = {};
+  const hasBootPromptReceipt = record(full.boot_prompt_receipt) !== null;
+  const lean: JsonObject = Object.fromEntries(
+    ESSENTIAL_FIELDS.filter(
+      (field) =>
+        full[field] !== undefined &&
+        !(
+          field.startsWith("boot_prompt_") &&
+          full[field] === null &&
+          !(field === "boot_prompt_submit_verified" && hasBootPromptReceipt)
+        ),
+    ).map((field) => [field, full[field]]),
+  );
   if (full.ok !== undefined) lean.ok = full.ok;
-  for (const field of ESSENTIAL_FIELDS) {
-    if (full[field] !== undefined && !(field.startsWith("boot_prompt_") && full[field] === null)) lean[field] = full[field];
-  }
 
   const worktree = leanWorktree(full.worktree);
   if (worktree) lean.worktree = worktree;

--- a/src/spawn-response.ts
+++ b/src/spawn-response.ts
@@ -114,7 +114,7 @@ export function shapeSpawnResponse(
   const lean: JsonObject = {};
   if (full.ok !== undefined) lean.ok = full.ok;
   for (const field of ESSENTIAL_FIELDS) {
-    if (full[field] !== undefined) lean[field] = full[field];
+    if (full[field] !== undefined && !(field.startsWith("boot_prompt_") && full[field] === null)) lean[field] = full[field];
   }
 
   const worktree = leanWorktree(full.worktree);

--- a/tests/delivery-truth-t2.test.ts
+++ b/tests/delivery-truth-t2.test.ts
@@ -180,7 +180,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true, verbose: true },
       {} as any,
     );
 
@@ -526,7 +526,7 @@ describe("T2 delivery truth — composer draft safety (#442)", () => {
     mockExec.mockClear();
 
     const result = await (server as any)._registeredTools["send_to"].handler(
-      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true },
+      { mode: "agent", agent_id: agentId, text: "fleet message", press_enter: true, verbose: true },
       {} as any,
     );
 

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -553,7 +553,7 @@ function createReliabilityServer(client: FakeClaudeSurfaceClient) {
   const sendTo = (server as any)._registeredTools.send_to;
   const sendToHandler = sendTo.handler.bind(sendTo);
   sendTo.handler = (args: Record<string, unknown>, context: unknown) =>
-    sendToHandler({ mode: "agent", ...args }, context);
+    sendToHandler({ mode: "agent", verbose: true, ...args }, context);
   // These tests exercise registry routing and submit verification, not the
   // periodic reconciliation loop. Stop its wall-clock sweep so it cannot race
   // the five-second submit deadline or add unrelated work under parallel load.
@@ -906,6 +906,7 @@ describe("enter reliability", () => {
       surface: client.surface,
       text: "surface receipt parity",
       press_enter: false,
+      verbose: true,
     });
     const contentReceipt = JSON.parse(result.content[0].text);
 
@@ -930,6 +931,7 @@ describe("enter reliability", () => {
       agent_id: "agent-1",
       text: "lean successful receipt",
       press_enter: true,
+      verbose: false,
     });
     const parsed = parseResult(result);
 
@@ -939,7 +941,18 @@ describe("enter reliability", () => {
     expect(parsed).not.toHaveProperty("timings_ms");
     expect(parsed).not.toHaveProperty("transport");
     expect(parsed).not.toHaveProperty("WARNING");
-    expect(parsed).not.toHaveProperty("boot_prompt_receipt");
+    expect(result.content[0]!.text).toBe(JSON.stringify(parsed));
+
+    const verboseResult = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "verbose successful receipt",
+      press_enter: true,
+      verbose: true,
+    });
+    const verboseParsed = parseResult(verboseResult);
+
+    expect(verboseResult.isError).not.toBe(true);
+    expect(verboseParsed).toMatchObject({ delivery_state: "submitted", submitted: true, rpc_methods: expect.any(Array), timings_ms: expect.any(Object), transport: expect.any(String), socket_path: null });
   });
 
   it("resolves agent-mode composer-only delivery as terminal typed on the same ID", async () => {
@@ -1073,6 +1086,7 @@ describe("enter reliability", () => {
         ...target,
         text: "timed send",
         press_enter: true,
+        verbose: true,
       });
       const parsed = parseResult(result);
 

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -919,6 +919,29 @@ describe("enter reliability", () => {
     expect(contentReceipt).toEqual(result.structuredContent);
   });
 
+  it("keeps a successful send_to receipt lean unless verbose is requested", async () => {
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client);
+    registerAgent(server, { state: "idle" });
+
+    const result = await callTool(server, "send_to", {
+      agent_id: "agent-1",
+      text: "lean successful receipt",
+      press_enter: true,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).not.toBe(true);
+    expect(Object.keys(parsed).length).toBeLessThanOrEqual(6);
+    expect(parsed).not.toHaveProperty("rpc_methods");
+    expect(parsed).not.toHaveProperty("timings_ms");
+    expect(parsed).not.toHaveProperty("transport");
+    expect(parsed).not.toHaveProperty("WARNING");
+    expect(parsed).not.toHaveProperty("boot_prompt_receipt");
+  });
+
   it("resolves agent-mode composer-only delivery as terminal typed on the same ID", async () => {
     const client = new FakeClaudeSurfaceClient();
     client.stableSurfaceIdentity = "11111111-1111-4111-8111-111111111111";

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer, __submitEvidenceTestHooks } from "../src/server.js";
+import {
+  createServer,
+  __leanReceiptTestHooks,
+  __submitEvidenceTestHooks,
+} from "../src/server.js";
 import type { AgentRecord } from "../src/agent-types.js";
 
 const TEST_DIR = join(tmpdir(), "cmux-enter-reliability-test");
@@ -138,6 +144,15 @@ class FakeClaudeSurfaceClient {
   private returnCount = 0;
   private queuedCodexReadsRemaining = 0;
   private mode: "idle" | "working" = "idle";
+  transportHealth: {
+    mode: "socket";
+    degraded: boolean;
+    current_socket_path: string;
+  } | null = null;
+
+  getTransportHealth() {
+    return this.transportHealth;
+  }
 
   async listWorkspaces() {
     return {
@@ -542,7 +557,10 @@ class FakeUnavailableVerificationScreenClient extends FakeClaudeSurfaceClient {
   }
 }
 
-function createReliabilityServer(client: FakeClaudeSurfaceClient) {
+function createReliabilityServer(
+  client: FakeClaudeSurfaceClient,
+  legacyVerboseDefault = true,
+) {
   const server = createServer({
     client: client as any,
     stateDir: TEST_DIR,
@@ -550,10 +568,25 @@ function createReliabilityServer(client: FakeClaudeSurfaceClient) {
     surfaceObserverOwnerIdProvider: () => TEST_OBSERVER_OWNER,
     surfaceObserverEpochProvider: () => `${TEST_OBSERVER_OWNER}@test`,
   });
-  const sendTo = (server as any)._registeredTools.send_to;
-  const sendToHandler = sendTo.handler.bind(sendTo);
-  sendTo.handler = (args: Record<string, unknown>, context: unknown) =>
-    sendToHandler({ mode: "agent", verbose: true, ...args }, context);
+  if (legacyVerboseDefault) {
+    const sendTo = (
+      server as unknown as {
+        _registeredTools: Record<
+          string,
+          {
+            handler: (
+              args: Record<string, unknown>,
+              context: unknown,
+            ) => unknown;
+          }
+        >;
+      }
+    )._registeredTools.send_to;
+    if (!sendTo) throw new Error("send_to test handler is not registered");
+    const sendToHandler = sendTo.handler.bind(sendTo);
+    sendTo.handler = (args: Record<string, unknown>, context: unknown) =>
+      sendToHandler({ mode: "agent", verbose: true, ...args }, context);
+  }
   // These tests exercise registry routing and submit verification, not the
   // periodic reconciliation loop. Stop its wall-clock sweep so it cannot race
   // the five-second submit deadline or add unrelated work under parallel load.
@@ -921,23 +954,100 @@ describe("enter reliability", () => {
   });
 
   it("keeps a successful send_to receipt lean unless verbose is requested", async () => {
+    vi.useRealTimers();
     const client = new FakeClaudeSurfaceClient();
-    client.requiredReturns = 1; client.completionMode = "idle";
-    server = createReliabilityServer(client);
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    client.transportHealth = {
+      mode: "socket",
+      degraded: false,
+      current_socket_path: "/tmp/cmuxlayer-test.sock",
+    };
+    server = createReliabilityServer(client, false);
     registerAgent(server, { state: "idle" });
-    const send = (text: string, verbose: boolean) => callTool(server, "send_to", { agent_id: "agent-1", text, press_enter: true, verbose });
-    const result = await send("lean successful receipt", false);
-    const parsed = parseResult(result);
+    const mcpClient = new Client({
+      name: "lean-receipt-test",
+      version: "0.1.0",
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      mcpClient.connect(clientTransport),
+    ]);
+    await mcpClient.listTools();
+    const result = await mcpClient.callTool({
+      name: "send_to",
+      arguments: {
+        mode: "agent",
+        agent_id: "agent-1",
+        text: "lean successful receipt",
+        press_enter: true,
+      },
+    });
+    const parsed = result.structuredContent as Record<string, unknown>;
     expect(result.isError).not.toBe(true);
-    expect(Object.keys(parsed).length).toBeLessThanOrEqual(6);
+    expect(parsed).toEqual({
+      ok: true,
+      retry_count: 0,
+      agent_id: "agent-1",
+      delivery_state: "submitted",
+      submitted: true,
+      delivery_id: expect.any(String),
+    });
+    expect(Buffer.byteLength(JSON.stringify(parsed))).toBe(147);
     for (const field of ["rpc_methods", "timings_ms", "transport", "WARNING"])
       expect(parsed).not.toHaveProperty(field);
-    expect(result.content[0]!.text).toBe(JSON.stringify(parsed));
-    const verboseResult = await send("verbose successful receipt", true);
-    const verboseParsed = parseResult(verboseResult);
-    expect(verboseResult.isError).not.toBe(true);
-    expect(verboseParsed).toMatchObject({ delivery_state: "submitted", submitted: true, rpc_methods: expect.any(Array), timings_ms: expect.any(Object), transport: expect.any(String), socket_path: null });
-  });
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify(parsed) },
+    ]);
+
+    await mcpClient.close();
+  }, 10_000);
+
+  it.each(["surface", "command", "key"] as const)(
+    "keeps surface identity on a shaped %s-mode success",
+    (mode) => {
+      const full =
+        mode === "key"
+          ? {
+              ok: true,
+              retry_count: 0,
+              surface: "surface:agent",
+              submit_attempted: true,
+              submit_dispatched: true,
+              submit_verified: true,
+            }
+          : {
+              ok: true,
+              retry_count: 0,
+              surface: "surface:agent",
+              delivery_state: "submitted",
+              submitted: true,
+              delivery_id: "delivery:test",
+            };
+      const result = __leanReceiptTestHooks.shapeSuccessfulSendToResult(
+        {
+          content: [{ type: "text", text: JSON.stringify(full) }],
+          structuredContent: full,
+        },
+        { mode, surface: "surface:agent", text: "probe" },
+      );
+
+      expect(result.structuredContent).toMatchObject({
+        surface: "surface:agent",
+        delivery_state: "submitted",
+        submitted: true,
+        ...(mode === "key"
+          ? {
+              submit_verified: true,
+              submit_verification_reason: null,
+            }
+          : {}),
+      });
+      expect(result.structuredContent).not.toHaveProperty("agent_id");
+    },
+  );
 
   it("resolves agent-mode composer-only delivery as terminal typed on the same ID", async () => {
     const client = new FakeClaudeSurfaceClient();

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1034,17 +1034,24 @@ describe("enter reliability", () => {
         { mode, surface: "surface:agent", text: "probe" },
       );
 
-      expect(result.structuredContent).toMatchObject({
-        surface: "surface:agent",
-        delivery_state: "submitted",
-        submitted: true,
-        ...(mode === "key"
+      expect(result.structuredContent).toMatchObject(
+        mode === "key"
           ? {
+              surface: "surface:agent",
+              key: "probe",
               submit_verified: true,
               submit_verification_reason: null,
             }
-          : {}),
-      });
+          : {
+              surface: "surface:agent",
+              delivery_state: "submitted",
+              submitted: true,
+            },
+      );
+      if (mode === "key") {
+        expect(result.structuredContent).not.toHaveProperty("delivery_state");
+        expect(result.structuredContent).not.toHaveProperty("submitted");
+      }
       expect(result.structuredContent).not.toHaveProperty("agent_id");
     },
   );

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -922,35 +922,19 @@ describe("enter reliability", () => {
 
   it("keeps a successful send_to receipt lean unless verbose is requested", async () => {
     const client = new FakeClaudeSurfaceClient();
-    client.requiredReturns = 1;
-    client.completionMode = "idle";
+    client.requiredReturns = 1; client.completionMode = "idle";
     server = createReliabilityServer(client);
     registerAgent(server, { state: "idle" });
-
-    const result = await callTool(server, "send_to", {
-      agent_id: "agent-1",
-      text: "lean successful receipt",
-      press_enter: true,
-      verbose: false,
-    });
+    const send = (text: string, verbose: boolean) => callTool(server, "send_to", { agent_id: "agent-1", text, press_enter: true, verbose });
+    const result = await send("lean successful receipt", false);
     const parsed = parseResult(result);
-
     expect(result.isError).not.toBe(true);
     expect(Object.keys(parsed).length).toBeLessThanOrEqual(6);
-    expect(parsed).not.toHaveProperty("rpc_methods");
-    expect(parsed).not.toHaveProperty("timings_ms");
-    expect(parsed).not.toHaveProperty("transport");
-    expect(parsed).not.toHaveProperty("WARNING");
+    for (const field of ["rpc_methods", "timings_ms", "transport", "WARNING"])
+      expect(parsed).not.toHaveProperty(field);
     expect(result.content[0]!.text).toBe(JSON.stringify(parsed));
-
-    const verboseResult = await callTool(server, "send_to", {
-      agent_id: "agent-1",
-      text: "verbose successful receipt",
-      press_enter: true,
-      verbose: true,
-    });
+    const verboseResult = await send("verbose successful receipt", true);
     const verboseParsed = parseResult(verboseResult);
-
     expect(verboseResult.isError).not.toBe(true);
     expect(verboseParsed).toMatchObject({ delivery_state: "submitted", submitted: true, rpc_methods: expect.any(Array), timings_ms: expect.any(Object), transport: expect.any(String), socket_path: null });
   });

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -39,6 +39,7 @@ async function callTool(
 ) {
   const tool = server._registeredTools[name];
   if (!tool) throw new Error(`Tool not found: ${name}`);
+  if (name === "send_to") args = { verbose: true, ...args };
   return tool.handler(args, {} as any);
 }
 

--- a/tests/f1-live-state-truth.test.ts
+++ b/tests/f1-live-state-truth.test.ts
@@ -32,7 +32,7 @@ function parseResult(result: any): any {
   return result.structuredContent ?? JSON.parse(result.content[0].text);
 }
 
-async function callTool(
+function callTool(
   server: any,
   name: string,
   args: Record<string, unknown>,

--- a/tests/perf-budget.test.ts
+++ b/tests/perf-budget.test.ts
@@ -1045,7 +1045,10 @@ describe("daemon performance budget", () => {
     expect(source).toMatch(
       /await Promise\.all\([\s\S]*?validateReceipt\?\.[\s\S]*?\);\n {4}const elapsedMs = nowMs\(\) - startedAt;/,
     );
-    expect(source).toContain('"sampled surface send initial receipt"');
+    expect(source).not.toContain('"sampled surface send initial receipt"');
+    expect(source).toContain(
+      "const terminal = await requireSubmittedDelivery(\n          client,\n          receipt,\n          \"sampled surface send\"",
+    );
     expect(source).toContain(
       'requireTerminalSubmission(receipt, "parallel send initial receipt")',
     );

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -10985,7 +10985,7 @@ codex>
     ).agent_id;
 
     const result = await sendTo.handler(
-      { agent_id: agentId, text: "hello", press_enter: true, verbose: true },
+      { agent_id: agentId, text: "hello", press_enter: true },
       {} as any,
     );
     const parsed = parseToolResult(result);
@@ -10993,6 +10993,7 @@ codex>
     expect(parsed.terminal).toBe(true);
     expect(parsed.delivery_state).toBe("submitted");
     expect(parsed.submit_verified).toBe(true);
+    expect(parsed.rpc_methods).toEqual(expect.any(Array));
   });
 
   it("send_to_agent leaves an idle agent idle when submitted delivery fails", async () => {
@@ -11195,6 +11196,7 @@ codex>
         agent_id: agentId,
         text: "interject while working",
         press_enter: true,
+        verbose: false,
       },
       {} as any,
     );
@@ -11209,9 +11211,6 @@ codex>
     expect(parsed.ok).toBe(true);
     expect(parsed.agent_id).toBe(agentId);
     expect(parsed.queued_behind_turn).toBe(true);
-    expect(parsed.transport).toBe("cli");
-    expect(parsed.socket_path).toBeNull();
-    expect(parsed.socket_path_state).toBe("unavailable");
     expect(parsed.warnings).toContain("cli_fallback_active");
     expect(deliveredText).toBe("interject while working");
     expect(sendCalls[0]?.[1]).toEqual(

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -363,7 +363,7 @@ function createTrackedServer(
   if (sendToTool?.handler) {
     const sendToHandler = sendToTool.handler.bind(sendToTool);
     sendToTool.handler = (args: Record<string, unknown>, toolContext: unknown) =>
-      sendToHandler({ mode: "agent", ...args }, toolContext);
+      sendToHandler({ mode: "agent", verbose: true, ...args }, toolContext);
   }
   if (defaultCallerContext) {
     const registeredTools = (server as any)._registeredTools as Record<
@@ -1061,6 +1061,7 @@ describe("lean spawn tool responses", () => {
       cli: "claude",
       role: "reviewer",
       force_new: true,
+      verbose: true,
     });
 
     const result = await runWithCallerContext(
@@ -10984,7 +10985,7 @@ codex>
     ).agent_id;
 
     const result = await sendTo.handler(
-      { agent_id: agentId, text: "hello", press_enter: true },
+      { agent_id: agentId, text: "hello", press_enter: true, verbose: true },
       {} as any,
     );
     const parsed = parseToolResult(result);

--- a/tests/spawn-response.test.ts
+++ b/tests/spawn-response.test.ts
@@ -152,6 +152,28 @@ describe("spawn response shaping", () => {
     expect(shaped.readiness_cleared).toEqual(["wenfnng"]);
   });
 
+  it("distinguishes no boot prompt from an attempted but unverified prompt", () => {
+    const noPrompt = shapeSpawnResponse({
+      ...base,
+      boot_prompt_receipt: null,
+      boot_prompt_submit_verified: null,
+    });
+    const attempted = shapeSpawnResponse({
+      ...base,
+      boot_prompt_receipt: { submit_verified: null },
+      boot_prompt_submit_verified: null,
+    });
+
+    expect(noPrompt.boot_prompt_delivered).toBe(false);
+    expect(noPrompt).not.toHaveProperty("boot_prompt_receipt");
+    expect(noPrompt).not.toHaveProperty("boot_prompt_submit_verified");
+    expect(attempted).toMatchObject({
+      boot_prompt_delivered: false,
+      boot_prompt_receipt: { submit_verified: null },
+      boot_prompt_submit_verified: null,
+    });
+  });
+
   it("uses the same lean payload for text and structured content", () => {
     const result = buildSpawnToolReturn({ ...base, retry_count: 0 });
 

--- a/tests/spawn-response.test.ts
+++ b/tests/spawn-response.test.ts
@@ -13,7 +13,6 @@ const base = {
   role: "worker",
   cwd: "/tmp/cmuxlayer",
   boot_prompt_delivered: false,
-  boot_prompt_submit_verified: null,
 };
 
 describe("spawn response shaping", () => {

--- a/tests/t2b-silent-failures.test.ts
+++ b/tests/t2b-silent-failures.test.ts
@@ -342,8 +342,11 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
 
     const data = payload(result);
     expect(result.isError).toBeUndefined();
+    expect(data.key).toBe("return");
     expect(data.submit_verified).toBe(true);
     expect(data.submit_verification_reason).toBeNull();
+    expect(data).not.toHaveProperty("delivery_state");
+    expect(data).not.toHaveProperty("submitted");
   });
 
   it("does not verify Return when the composer was already empty", async () => {
@@ -381,8 +384,11 @@ describe("#484 — send_to(mode:key) must not report success for an unattempted 
 
     const data = payload(result);
     expect(result.isError).toBeUndefined();
+    expect(data.key).toBe("return");
     expect(data.submit_verified).toBe(true);
     expect(data.submit_verification_reason).toBeNull();
+    expect(data).not.toHaveProperty("delivery_state");
+    expect(data).not.toHaveProperty("submitted");
   });
 
   it("does not infer key failure from a composer that remains populated", async () => {


### PR DESCRIPTION
## Summary
- A clean verified `send_to` success returns up to six mode-specific core fields; text/command and key modes keep their distinct evidence, while degradation, queued-behind-turn, and dedup each add their status field.
- `verbose:true` restores legacy diagnostics; failures remain full, and lean spawn keeps boot-prompt tri-state evidence.
## Evidence
- RED `ebe004c`: default success had 24 fields and violated the lean contract.
- Blocker regression now exercises a verified default send through a real MCP client/output schema.
- Served fixtures: reviewer verbose receipt 1,143 bytes; current MCP agent lean receipt 147 UTF-8 bytes.
- Focused blocker set: 450/450; full gate: 159/159 files, 3,788 passed, one skip, exit 0.
— cmuxlayerCodex-d557d689 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-d557d689","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a07acc","ts":"2026-09-07T08:59:09Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking contract change for callers that read transport, timing, or RPC fields from successful `send_to`/`spawn_agent` receipts without passing `verbose: true`.
> 
> **Overview**
> Verified **`send_to`** successes now return a **small default receipt** (identity, retry count, submission/key evidence, plus optional `delivery_id`, `queued_behind_turn`, dedup, and warnings). **`verbose: true`** brings back the full legacy payload with transport and timing fields; **errors and unverified outcomes stay fully detailed**.
> 
> The MCP tool wrapper applies **`shapeSuccessfulSendToResult`** and tightens **`attachTransportProvenance`** so routine transport metadata is not merged onto lean successes (warnings still attach). **`send_to_agent`** internally always uses **`verbose: true`**. Tool descriptions document the new default.
> 
> **`shapeSpawnResponse`** drops null boot-prompt fields when no prompt was attempted, but keeps evidence when a boot prompt was tried without verification.
> 
> Benchmarks and tests opt into **`verbose`** where they still assert timings/transport; sampled surface sends no longer require terminal fields on the first receipt before **`wait_for`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ec2320552b33877793dec4128bca82ee60f46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make successful `send_to` and `spawn_agent` delivery receipts lean by default
> - Adds optional `verbose` flag (default `false`) to `SendToArgsSchema`; when `false`, verified successful `send_to` results return a reduced receipt with routing identity, retry count, delivery/key-verification evidence, and selected metadata. Failures and unverified results keep full receipts.
> - Introduces `isLeanSuccessfulTransportReceipt` and `shapeSuccessfulSendToResult` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/600/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595); `attachTransportProvenance` now skips routine provenance fields for qualifying lean successes while retaining warnings.
> - Updates `shapeSpawnResponse` in [spawn-response.ts](https://github.com/EtanHey/cmuxlayer/pull/600/files#diff-8e32bbd194555438af0bcd530b415445a30a3fa1c3eb8ef3a2a05d9204d01445) to omit null boot-prompt fields when no prompt receipt exists, but retains evidence when a prompt was attempted without verification.
> - Updates benchmark and test helpers to explicitly request `verbose` mode where full receipts are still asserted; the `send_to_agent` compatibility adapter always uses `verbose`.
> - Behavioral Change: existing callers that rely on transport, timing, RPC-method, or socket-path fields in successful `send_to`/`spawn_agent` receipts will no longer see them unless they pass `verbose: true`. Verify out-of-tree consumers of `shapeSuccessfulSendToResult` and `attachTransportProvenance` in [server.ts](https://github.com/EtanHey/cmuxlayer/pull/600/files#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595) handle the reduced receipt shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13ec232.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spawn-related tools and `send_to` now return concise success receipts by default.
  - Added `verbose: true` to restore detailed receipt information, including transport details and diagnostics.
  - Updated tool descriptions to explain default and verbose response formats.
  - Spawn responses omit unavailable boot-prompt status fields while preserving relevant verification details.

- **Bug Fixes**
  - Improved consistency and clarity of successful message-delivery responses.
  - Retained diagnostic details for failed or unverified deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->