### PR TITLE
fix(watch): bound silent child report waits

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -120,6 +120,7 @@ import {
 import type { CloseForensicsSweepResult } from "./close-forensics.js";
 import {
   armWatch as armDeclaredWatch,
+  isInterruptedEngineDeadlineClaim,
   readWatchRegistry,
   releaseWatchWaiter,
   removeWatches,
@@ -6693,6 +6694,10 @@ export class AgentEngine {
     await removeWatches(
       (watch) => {
         if (watch.notification_pending) {
+          retainedNeedsRecheck = true;
+          return false;
+        }
+        if (isInterruptedEngineDeadlineClaim(watch)) {
           retainedNeedsRecheck = true;
           return false;
         }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -553,6 +553,16 @@ export async function runDaemonFirstEntry(
     };
   }
 
+  if (env.CMUXLAYER_REPORT_WATCH_DEADLINE_MS !== undefined) {
+    // Like palette selection, this option belongs to the spawning MCP process;
+    // an already-running shared daemon cannot observe its environment.
+    return {
+      mode: "in-process",
+      server: await startInProcess({ env }),
+      fallbackWarnings: [],
+    };
+  }
+
   if (isEnabled(env.CMUXLAYER_FORCE_INPROCESS)) {
     return fallback(
       "CMUXLAYER_FORCE_INPROCESS=1; using heavy in-process runtime instead of daemon proxy",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -382,10 +382,7 @@ export async function startInProcessRuntime(
     { defaultWatchRegistryPath, httpNotifyWatch },
     { ensureNodeMaxOldSpaceEnv, installHeapGuard },
     { FleetSidebarPublisher },
-    {
-      makeSelfRegistrationSessionLookup,
-      makeSelfRegistrationSessionResolver,
-    },
+    { makeSelfRegistrationSessionLookup, makeSelfRegistrationSessionResolver },
   ] = await Promise.all([
     import("@modelcontextprotocol/sdk/server/stdio.js"),
     import("./stdio-lifecycle.js"),
@@ -404,6 +401,17 @@ export async function startInProcessRuntime(
   const client = await createCmuxClient();
   const runtimeEnv = opts.env ?? process.env;
   const explicitStateDir = runtimeEnv.CMUXLAYER_STATE_DIR?.trim();
+  const rawReportWatchDeadlineMs =
+    runtimeEnv.CMUXLAYER_REPORT_WATCH_DEADLINE_MS?.trim();
+  const reportWatchDeadlineMs = Number(rawReportWatchDeadlineMs);
+  if (
+    rawReportWatchDeadlineMs !== undefined &&
+    (!Number.isFinite(reportWatchDeadlineMs) || reportWatchDeadlineMs <= 0)
+  ) {
+    throw new Error(
+      "CMUXLAYER_REPORT_WATCH_DEADLINE_MS must be a finite positive number",
+    );
+  }
   const serverOpts: CreateServerOptions = {
     client,
     safetyCallerContextProvider: () => callerContextFromEnv(runtimeEnv),
@@ -418,6 +426,9 @@ export async function startInProcessRuntime(
     fleetSidebarPublisher: new FleetSidebarPublisher(),
     defaultPalette: opts.env?.CMUXLAYER_DEFAULT_PALETTE,
     ...(explicitStateDir ? { stateDir: explicitStateDir } : {}),
+    ...(rawReportWatchDeadlineMs !== undefined
+      ? { reportWatchDeadlineMs }
+      : {}),
     ...(opts.fallbackWarnings
       ? { controlHealthWarnings: opts.fallbackWarnings }
       : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -13902,7 +13902,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
           if (existing.deadline === Number.MAX_SAFE_INTEGER) {
             await updateWatchDeadline(existing.watch_id, reportWatchDeadline,
-              { registryPath: watchRegistryPath });
+              { registryPath: watchRegistryPath, now: opts?.watchRegistryNow });
           }
           return null;
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3834,6 +3834,8 @@ export interface CreateServerOptions {
   watchRegistryPath?: string;
   watchRegistryNow?: () => number;
   watchNotify?: WatchNotify;
+  /** Silence deadline for engine-owned child report watches. Defaults to one hour. */
+  reportWatchDeadlineMs?: number;
   /**
    * Enable close forensics: ingest cmux's OWN app-level `tab_close` events from
    * `~/.cmuxterm/events.jsonl` and attribute them each sweep. Omitted/false by
@@ -3880,6 +3882,7 @@ export type LifecycleAgentInputDeliverer = (args: {
 }) => Promise<PublicDeliveryReceipt & { bytes: number }>;
 
 export const DEFAULT_LIFECYCLE_START_TIMEOUT_MS = 60_000;
+export const DEFAULT_REPORT_WATCH_DEADLINE_MS = 60 * 60 * 1_000;
 
 /** Lifecycle initialization never settled inside its bound (#529). */
 export class LifecycleStartTimeoutError extends Error {
@@ -13904,7 +13907,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           target: reportPath,
           provenance: "engine",
           change: "content",
-          deadline: Number.MAX_SAFE_INTEGER,
+          deadline:
+            (opts?.watchRegistryNow?.() ?? Date.now()) +
+            (opts?.reportWatchDeadlineMs ??
+              DEFAULT_REPORT_WATCH_DEADLINE_MS),
         });
         return null;
       } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,6 +97,7 @@ import {
   removeWatches,
   reserveWatchReportPath,
   scopeWatchToSubject,
+  updateWatchDeadline,
   WatchArmError,
   type WatchNotify,
   type WatchSpec,
@@ -13863,6 +13864,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : null;
         const canonicalParent = canonicalAgentId(parentAgentId);
         const ownerCandidates = snapshotWatchOwnerCandidates();
+        const reportWatchDeadline = (opts?.watchRegistryNow?.() ?? Date.now()) +
+          (opts?.reportWatchDeadlineMs ?? DEFAULT_REPORT_WATCH_DEADLINE_MS);
         const existing = readWatchRegistry({
           registryPath: watchRegistryPath,
         }).watches.find(
@@ -13897,6 +13900,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               registryPath: watchRegistryPath,
             });
           }
+          if (existing.deadline === Number.MAX_SAFE_INTEGER) {
+            await updateWatchDeadline(existing.watch_id, reportWatchDeadline,
+              { registryPath: watchRegistryPath });
+          }
           return null;
         }
         await mkdir(dirname(reportPath), { recursive: true });
@@ -13907,10 +13914,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           target: reportPath,
           provenance: "engine",
           change: "content",
-          deadline:
-            (opts?.watchRegistryNow?.() ?? Date.now()) +
-            (opts?.reportWatchDeadlineMs ??
-              DEFAULT_REPORT_WATCH_DEADLINE_MS),
+          deadline: reportWatchDeadline,
         });
         return null;
       } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13864,7 +13864,8 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           : null;
         const canonicalParent = canonicalAgentId(parentAgentId);
         const ownerCandidates = snapshotWatchOwnerCandidates();
-        const reportWatchDeadline = (opts?.watchRegistryNow?.() ?? Date.now()) +
+        const reportWatchArmedAt = opts?.watchRegistryNow?.() ?? Date.now();
+        const reportWatchDeadline = reportWatchArmedAt +
           (opts?.reportWatchDeadlineMs ?? DEFAULT_REPORT_WATCH_DEADLINE_MS);
         const existing = readWatchRegistry({
           registryPath: watchRegistryPath,
@@ -13900,10 +13901,10 @@ export function createServer(opts?: CreateServerOptions): McpServer {
               registryPath: watchRegistryPath,
             });
           }
-          if (existing.deadline === Number.MAX_SAFE_INTEGER) {
-            await updateWatchDeadline(existing.watch_id, reportWatchDeadline,
-              { registryPath: watchRegistryPath, now: opts?.watchRegistryNow });
-          }
+          await updateWatchDeadline(existing.watch_id, reportWatchDeadline, {
+            registryPath: watchRegistryPath,
+            now: () => reportWatchArmedAt,
+          });
           return null;
         }
         await mkdir(dirname(reportPath), { recursive: true });

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -67,6 +67,7 @@ export interface WatchRecord extends WatchSpec {
   notification_attempts?: number;
   notification_next_attempt_at_ms?: number;
   notification_delivered_at_ms?: number;
+  deadline_notified_at_ms?: number;
   notification_exhausted_at_ms?: number;
   notification_exhausted_reason?: string;
   waiter_expires_at_ms?: number;
@@ -276,6 +277,8 @@ function hasValidNotificationMetadata(
       isFiniteNumber(value.notification_next_attempt_at_ms)) &&
     (value.notification_delivered_at_ms === undefined ||
       isFiniteNumber(value.notification_delivered_at_ms)) &&
+    (value.deadline_notified_at_ms === undefined ||
+      isFiniteNumber(value.deadline_notified_at_ms)) &&
     (value.notification_exhausted_at_ms === undefined ||
       isFiniteNumber(value.notification_exhausted_at_ms)) &&
     (value.notification_exhausted_reason === undefined ||
@@ -1105,23 +1108,30 @@ export async function sweepWatches(
         }, notification);
       }
 
-      if (observedAt >= record.deadline) {
+      if (
+        record.change !== "content" &&
+        observedAt >= record.deadline &&
+        record.deadline_notified_at_ms === undefined
+      ) {
         const notification = notificationFor(
           record,
           "deadline_elapsed",
           observedAt,
         );
         result.failed.push(record.watch_id);
-        return claimFailedNotification({
-          ...record,
-          ...heartbeat,
-          state: "failed" as const,
-          terminal_reason: "deadline_elapsed" as const,
-          terminal_at_ms: observedAt,
-          notification_pending: true,
-          notification_attempts: 0,
-          notification_next_attempt_at_ms: observedAt,
-        }, notification);
+        return claimFailedNotification(
+          {
+            ...record,
+            ...heartbeat,
+            state: "failed" as const,
+            terminal_reason: "deadline_elapsed" as const,
+            terminal_at_ms: observedAt,
+            notification_pending: true,
+            notification_attempts: 0,
+            notification_next_attempt_at_ms: observedAt,
+          },
+          notification,
+        );
       }
 
       const observedValue =
@@ -1160,6 +1170,34 @@ export async function sweepWatches(
           notification_attempts: 0,
           notification_next_attempt_at_ms: observedAt,
         };
+      }
+
+      if (
+        record.change === "content" &&
+        observedAt >= record.deadline &&
+        record.deadline_notified_at_ms === undefined
+      ) {
+        const notification = notificationFor(
+          record,
+          "deadline_elapsed",
+          observedAt,
+          observedValue,
+        );
+        result.failed.push(record.watch_id);
+        return claimFailedNotification(
+          {
+            ...record,
+            ...heartbeat,
+            state: "failed" as const,
+            terminal_reason: "deadline_elapsed" as const,
+            terminal_at_ms: observedAt,
+            observed_value: observedValue,
+            notification_pending: true,
+            notification_attempts: 0,
+            notification_next_attempt_at_ms: observedAt,
+          },
+          notification,
+        );
       }
 
       if (
@@ -1235,6 +1273,30 @@ export async function sweepWatches(
         ) {
           const attempts = record.notification_attempts ?? 1;
           if (delivered) {
+            if (
+              record.change === "content" &&
+              notification.reason === "deadline_elapsed" &&
+              typeof notification.observed_value === "string"
+            ) {
+              const {
+                terminal_reason: _terminalReason,
+                terminal_at_ms: _terminalAt,
+                notification_exhausted_at_ms: _exhaustedAt,
+                notification_exhausted_reason: _exhaustedReason,
+                ...persistent
+              } = record;
+              return {
+                ...persistent,
+                state: "armed" as const,
+                fingerprint: notification.observed_value,
+                observed_value: notification.observed_value,
+                deadline_notified_at_ms: observedAt,
+                notification_pending: false,
+                notification_attempts: attempts,
+                notification_next_attempt_at_ms: undefined,
+                notification_delivered_at_ms: observedAt,
+              };
+            }
             const {
               notification_exhausted_at_ms: _exhaustedAt,
               notification_exhausted_reason: _exhaustedReason,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -622,6 +622,22 @@ function storedContentDigest(
   return legacy?.[1] ?? fingerprint;
 }
 
+function rolledEngineContentDeadline(
+  record: WatchRecord,
+  reason: WatchNotificationReason,
+  observedAt: number,
+): Partial<WatchRecord> {
+  if (record.provenance !== "engine" || reason !== "target_changed") {
+    return {};
+  }
+  const intervalMs = Math.max(1, record.deadline - record.armed_at_ms);
+  return {
+    armed_at_ms: observedAt,
+    deadline: observedAt + intervalMs,
+    deadline_notified_at_ms: undefined,
+  };
+}
+
 function assertSpec(
   spec: WatchSpec,
   opts: WatchRegistryOptions,
@@ -1183,7 +1199,11 @@ export async function sweepWatches(
           observedAt,
           observedValue,
         );
-        result.failed.push(record.watch_id);
+        if (record.provenance === "engine") {
+          result.armed.push(record.watch_id);
+        } else {
+          result.failed.push(record.watch_id);
+        }
         return claimFailedNotification(
           {
             ...record,
@@ -1272,31 +1292,46 @@ export async function sweepWatches(
           claimedFailedWatchIds.has(record.watch_id)
         ) {
           const attempts = record.notification_attempts ?? 1;
+          if (
+            record.provenance === "engine" &&
+            record.change === "content" &&
+            notification.reason === "deadline_elapsed" &&
+            typeof notification.observed_value === "string"
+          ) {
+            const reason =
+              terminalFailureReason ??
+              (delivered ? null : "terminal_notice_fire_once");
+            if (reason) exhausted = { notification, attempts, reason };
+            const {
+              terminal_reason: _terminalReason,
+              terminal_at_ms: _terminalAt,
+              notification_exhausted_at_ms: _exhaustedAt,
+              notification_exhausted_reason: _exhaustedReason,
+              ...persistent
+            } = record;
+            return {
+              ...persistent,
+              ...rolledEngineContentDeadline(
+                record,
+                notification.reason,
+                observedAt,
+              ),
+              state: "armed" as const,
+              fingerprint: notification.observed_value,
+              observed_value: notification.observed_value,
+              deadline_notified_at_ms: observedAt,
+              notification_pending: false,
+              notification_attempts: attempts,
+              notification_next_attempt_at_ms: undefined,
+              ...(delivered
+                ? { notification_delivered_at_ms: observedAt }
+                : {
+                    notification_exhausted_at_ms: observedAt,
+                    notification_exhausted_reason: reason!,
+                  }),
+            };
+          }
           if (delivered) {
-            if (
-              record.change === "content" &&
-              notification.reason === "deadline_elapsed" &&
-              typeof notification.observed_value === "string"
-            ) {
-              const {
-                terminal_reason: _terminalReason,
-                terminal_at_ms: _terminalAt,
-                notification_exhausted_at_ms: _exhaustedAt,
-                notification_exhausted_reason: _exhaustedReason,
-                ...persistent
-              } = record;
-              return {
-                ...persistent,
-                state: "armed" as const,
-                fingerprint: notification.observed_value,
-                observed_value: notification.observed_value,
-                deadline_notified_at_ms: observedAt,
-                notification_pending: false,
-                notification_attempts: attempts,
-                notification_next_attempt_at_ms: undefined,
-                notification_delivered_at_ms: observedAt,
-              };
-            }
             const {
               notification_exhausted_at_ms: _exhaustedAt,
               notification_exhausted_reason: _exhaustedReason,
@@ -1341,6 +1376,11 @@ export async function sweepWatches(
             } = record;
             return {
               ...persistent,
+              ...rolledEngineContentDeadline(
+                record,
+                notification.reason,
+                observedAt,
+              ),
               state: "armed" as const,
               fingerprint: notification.observed_value,
               observed_value: notification.observed_value,
@@ -1371,6 +1411,11 @@ export async function sweepWatches(
             } = record;
             return {
               ...persistent,
+              ...rolledEngineContentDeadline(
+                record,
+                notification.reason,
+                observedAt,
+              ),
               state: "armed" as const,
               fingerprint: notification.observed_value,
               observed_value: notification.observed_value,
@@ -1404,6 +1449,11 @@ export async function sweepWatches(
             } = record;
             return {
               ...persistent,
+              ...rolledEngineContentDeadline(
+                record,
+                notification.reason,
+                observedAt,
+              ),
               state: "armed" as const,
               fingerprint: notification.observed_value,
               observed_value: notification.observed_value,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -917,6 +917,25 @@ export function removeWatches(
   });
 }
 
+export function updateWatchDeadline(
+  watchId: string,
+  deadline: number,
+  opts: WatchRegistryOptions = {},
+): Promise<boolean> {
+  const path = registryPathFor(opts);
+  return withWriteLock(path, () => {
+    const registry = readRegistryState(path);
+    let updated = false;
+    const rows = registry.rows.map((row) => {
+      if (!isWatchRecord(row) || row.watch_id !== watchId) return row;
+      updated = true;
+      return { ...row, deadline };
+    });
+    if (updated) writeRegistry(path, registry.version, rows);
+    return updated;
+  });
+}
+
 export function releaseWatchWaiter(
   watchId: string,
   opts: WatchRegistryOptions = {},
@@ -1327,7 +1346,8 @@ export async function sweepWatches(
                 ? { notification_delivered_at_ms: observedAt }
                 : {
                     notification_exhausted_at_ms: observedAt,
-                    notification_exhausted_reason: reason!,
+                    notification_exhausted_reason:
+                      reason ?? "terminal_notice_fire_once",
                   }),
             };
           }

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -924,12 +924,13 @@ export function updateWatchDeadline(
 ): Promise<boolean> {
   const path = registryPathFor(opts);
   return withWriteLock(path, () => {
+    const armedAt = nowMs(opts);
     const registry = readRegistryState(path);
     let updated = false;
     const rows = registry.rows.map((row) => {
       if (!isWatchRecord(row) || row.watch_id !== watchId) return row;
       updated = true;
-      return { ...row, deadline };
+      return { ...row, armed_at_ms: armedAt, deadline };
     });
     if (updated) writeRegistry(path, registry.version, rows);
     return updated;
@@ -1346,8 +1347,7 @@ export async function sweepWatches(
                 ? { notification_delivered_at_ms: observedAt }
                 : {
                     notification_exhausted_at_ms: observedAt,
-                    notification_exhausted_reason:
-                      reason ?? "terminal_notice_fire_once",
+                    notification_exhausted_reason: reason ?? "terminal_notice_fire_once",
                   }),
             };
           }

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -976,7 +976,12 @@ export function updateWatchDeadline(watchId: string, deadline: number,
     const rows = registry.rows.map((row) => {
       if (!isWatchRecord(row) || row.watch_id !== watchId) return row;
       updated = true;
-      return { ...row, armed_at_ms: armedAt, deadline };
+      return {
+        ...row,
+        armed_at_ms: armedAt,
+        deadline,
+        deadline_notified_at_ms: undefined,
+      };
     });
     if (updated) writeRegistry(path, registry.version, rows); return updated;
   });

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -917,11 +917,8 @@ export function removeWatches(
   });
 }
 
-export function updateWatchDeadline(
-  watchId: string,
-  deadline: number,
-  opts: WatchRegistryOptions = {},
-): Promise<boolean> {
+export function updateWatchDeadline(watchId: string, deadline: number,
+  opts: WatchRegistryOptions = {}): Promise<boolean> {
   const path = registryPathFor(opts);
   return withWriteLock(path, () => {
     const armedAt = nowMs(opts);
@@ -932,8 +929,7 @@ export function updateWatchDeadline(
       updated = true;
       return { ...row, armed_at_ms: armedAt, deadline };
     });
-    if (updated) writeRegistry(path, registry.version, rows);
-    return updated;
+    if (updated) writeRegistry(path, registry.version, rows); return updated;
   });
 }
 

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -622,6 +622,53 @@ function storedContentDigest(
   return legacy?.[1] ?? fingerprint;
 }
 
+export function isInterruptedEngineDeadlineClaim(
+  record: Pick<
+    WatchRecord,
+    | "provenance"
+    | "target_kind"
+    | "change"
+    | "state"
+    | "terminal_reason"
+    | "notification_pending"
+    | "deadline_notified_at_ms"
+    | "observed_value"
+  >,
+): record is typeof record & { observed_value: string } {
+  return (
+    record.provenance === "engine" &&
+    record.target_kind === "file" &&
+    record.change === "content" &&
+    record.state === "failed" &&
+    record.terminal_reason === "deadline_elapsed" &&
+    record.notification_pending === false &&
+    record.deadline_notified_at_ms === undefined &&
+    typeof record.observed_value === "string"
+  );
+}
+
+function recoverInterruptedEngineDeadlineClaim(
+  record: WatchRecord,
+  observedAt: number,
+): WatchRecord {
+  if (!isInterruptedEngineDeadlineClaim(record)) return record;
+  const {
+    terminal_reason: _terminalReason,
+    terminal_at_ms: terminalAt,
+    notification_exhausted_at_ms: _exhaustedAt,
+    notification_exhausted_reason: _exhaustedReason,
+    ...persistent
+  } = record;
+  return {
+    ...persistent,
+    state: "armed",
+    fingerprint: record.observed_value,
+    deadline_notified_at_ms: terminalAt ?? observedAt,
+    notification_pending: false,
+    notification_next_attempt_at_ms: undefined,
+  };
+}
+
 function rolledEngineContentDeadline(
   record: WatchRecord,
   reason: WatchNotificationReason,
@@ -633,7 +680,7 @@ function rolledEngineContentDeadline(
   const intervalMs = Math.max(1, record.deadline - record.armed_at_ms);
   return {
     armed_at_ms: observedAt,
-    deadline: observedAt + intervalMs,
+    deadline: Math.min(Number.MAX_SAFE_INTEGER, observedAt + intervalMs),
     deadline_notified_at_ms: undefined,
   };
 }
@@ -1097,7 +1144,7 @@ export async function sweepWatches(
     // skipcq: JS-R1005
     const watches = registry.rows.map((row) => {
       if (!isWatchRecord(row)) return row;
-      const record = row;
+      const record = recoverInterruptedEngineDeadlineClaim(row, observedAt);
       if (record.state === "firing" && record.terminal_reason) {
         const migrated: WatchRecord = {
           ...record,

--- a/src/watch-spec.ts
+++ b/src/watch-spec.ts
@@ -638,6 +638,55 @@ function rolledEngineContentDeadline(
   };
 }
 
+function settleEngineDeadlineNotification(
+  record: WatchRecord,
+  notification: WatchNotification,
+  delivered: boolean,
+  terminalFailureReason: string | null,
+  attempts: number,
+  observedAt: number,
+): { record: WatchRecord; exhausted: WatchNotificationExhausted | null } | null {
+  if (
+    record.provenance !== "engine" ||
+    record.change !== "content" ||
+    notification.reason !== "deadline_elapsed" ||
+    typeof notification.observed_value !== "string"
+  ) {
+    return null;
+  }
+  const reason =
+    terminalFailureReason ??
+    (delivered ? null : "terminal_notice_fire_once");
+  const {
+    terminal_reason: _terminalReason,
+    terminal_at_ms: _terminalAt,
+    notification_exhausted_at_ms: _exhaustedAt,
+    notification_exhausted_reason: _exhaustedReason,
+    ...persistent
+  } = record;
+  return {
+    record: {
+      ...persistent,
+      ...rolledEngineContentDeadline(record, notification.reason, observedAt),
+      state: "armed",
+      fingerprint: notification.observed_value,
+      observed_value: notification.observed_value,
+      deadline_notified_at_ms: observedAt,
+      notification_pending: false,
+      notification_attempts: attempts,
+      notification_next_attempt_at_ms: undefined,
+      ...(delivered
+        ? { notification_delivered_at_ms: observedAt }
+        : {
+            notification_exhausted_at_ms: observedAt,
+            notification_exhausted_reason:
+              reason ?? "terminal_notice_fire_once",
+          }),
+    },
+    exhausted: reason ? { notification, attempts, reason } : null,
+  };
+}
+
 function assertSpec(
   spec: WatchSpec,
   opts: WatchRegistryOptions,
@@ -1308,44 +1357,17 @@ export async function sweepWatches(
           claimedFailedWatchIds.has(record.watch_id)
         ) {
           const attempts = record.notification_attempts ?? 1;
-          if (
-            record.provenance === "engine" &&
-            record.change === "content" &&
-            notification.reason === "deadline_elapsed" &&
-            typeof notification.observed_value === "string"
-          ) {
-            const reason =
-              terminalFailureReason ??
-              (delivered ? null : "terminal_notice_fire_once");
-            if (reason) exhausted = { notification, attempts, reason };
-            const {
-              terminal_reason: _terminalReason,
-              terminal_at_ms: _terminalAt,
-              notification_exhausted_at_ms: _exhaustedAt,
-              notification_exhausted_reason: _exhaustedReason,
-              ...persistent
-            } = record;
-            return {
-              ...persistent,
-              ...rolledEngineContentDeadline(
-                record,
-                notification.reason,
-                observedAt,
-              ),
-              state: "armed" as const,
-              fingerprint: notification.observed_value,
-              observed_value: notification.observed_value,
-              deadline_notified_at_ms: observedAt,
-              notification_pending: false,
-              notification_attempts: attempts,
-              notification_next_attempt_at_ms: undefined,
-              ...(delivered
-                ? { notification_delivered_at_ms: observedAt }
-                : {
-                    notification_exhausted_at_ms: observedAt,
-                    notification_exhausted_reason: reason ?? "terminal_notice_fire_once",
-                  }),
-            };
+          const engineDeadline = settleEngineDeadlineNotification(
+            record,
+            notification,
+            delivered,
+            terminalFailureReason,
+            attempts,
+            observedAt,
+          );
+          if (engineDeadline) {
+            exhausted = engineDeadline.exhausted;
+            return engineDeadline.record;
           }
           if (delivered) {
             const {

--- a/tests/entry-watch-spec.test.ts
+++ b/tests/entry-watch-spec.test.ts
@@ -58,4 +58,22 @@ describe("in-process WatchSpec production wiring", () => {
       stateDir: "/tmp/cmuxlayer-prompt-freeze-probe-state",
     });
   });
+
+  it("passes a validated report-watch deadline override into createServer", async () => {
+    await startInProcessRuntime({
+      env: { CMUXLAYER_REPORT_WATCH_DEADLINE_MS: "250" },
+    });
+
+    expect(captured.options).toMatchObject({ reportWatchDeadlineMs: 250 });
+  });
+
+  it("rejects an invalid report-watch deadline override", async () => {
+    await expect(
+      startInProcessRuntime({
+        env: { CMUXLAYER_REPORT_WATCH_DEADLINE_MS: "0" },
+      }),
+    ).rejects.toThrow(
+      "CMUXLAYER_REPORT_WATCH_DEADLINE_MS must be a finite positive number",
+    );
+  });
 });

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -238,4 +238,18 @@ describe("daemon-first MCP entry", () => {
     });
     expect(logger.error).not.toHaveBeenCalled();
   });
+
+  it("keeps a report-watch deadline override isolated from a shared daemon", async () => {
+    const opts = createEntryOptions({
+      env: { CMUXLAYER_REPORT_WATCH_DEADLINE_MS: "250" },
+    });
+
+    const result = await runDaemonFirstEntry(opts);
+
+    expect(result.mode).toBe("in-process");
+    expect(opts.probeDaemon).not.toHaveBeenCalled();
+    expect(opts.spawnDaemon).not.toHaveBeenCalled();
+    expect(opts.runProxy).not.toHaveBeenCalled();
+    expect(opts.startInProcess).toHaveBeenCalledWith({ env: opts.env });
+  });
 });

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -339,7 +339,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     expect(detail.done_marker).toBe(parsed.done_marker);
   });
 
-  it("wakes the parent once per distinct report content", async () => {
+  it("warns once at the report deadline, then wakes once per distinct content after restart", async () => {
     await server.close();
     const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -383,6 +383,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         inboxBaseDir: inboxDir,
         watchRegistryPath,
         watchRegistryNow: () => watchNow,
+        reportWatchDeadlineMs: 60 * 60 * 1_000,
         watchNotify: unavailableExternalNotify,
       }),
     );
@@ -404,9 +405,26 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         target: child.report_path,
         provenance: "engine",
         change: "content",
+        deadline: 3_601_000,
         state: "armed",
       }),
     ]);
+
+    const beforeDeadline = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    watchNow = 3_601_000;
+    await engine.sweepWatchesBestEffort();
+    const deadlineCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      beforeDeadline,
+    );
+    expect(
+      deadlineCalls.filter(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) =>
+            arg.includes("[watch] deadline elapsed") &&
+            arg.includes(child.report_path),
+        ),
+      ),
+    ).toHaveLength(1);
 
     await server.close();
     server = createServer(
@@ -417,11 +435,24 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         inboxBaseDir: inboxDir,
         watchRegistryPath,
         watchRegistryNow: () => watchNow,
+        reportWatchDeadlineMs: 60 * 60 * 1_000,
         watchNotify: unavailableExternalNotify,
       }),
     );
     await server._registeredTools.list_agents.handler({}, {} as never);
     engine = server._registeredTools.interact._engine;
+    const beforeRestartSweep = (exec as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    watchNow += 1;
+    await engine.sweepWatchesBestEffort();
+    const restartCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      beforeRestartSweep,
+    );
+    expect(
+      restartCalls.some(([, args]: [string, string[]]) =>
+        args.some((arg) => arg.includes("[watch] deadline elapsed")),
+      ),
+    ).toBe(false);
     const before = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
     writeFileSync(
       child.report_path,

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -383,7 +383,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         inboxBaseDir: inboxDir,
         watchRegistryPath,
         watchRegistryNow: () => watchNow,
-        reportWatchDeadlineMs: 60 * 60 * 1_000,
+        reportWatchDeadlineMs: 2_000,
         watchNotify: unavailableExternalNotify,
       }),
     );
@@ -405,13 +405,13 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         target: child.report_path,
         provenance: "engine",
         change: "content",
-        deadline: 3_601_000,
+        deadline: 3_000,
         state: "armed",
       }),
     ]);
 
     const beforeDeadline = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
-    watchNow = 3_601_000;
+    watchNow = 3_000;
     await engine.sweepWatchesBestEffort();
     const deadlineCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
       beforeDeadline,
@@ -435,7 +435,7 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         inboxBaseDir: inboxDir,
         watchRegistryPath,
         watchRegistryNow: () => watchNow,
-        reportWatchDeadlineMs: 60 * 60 * 1_000,
+        reportWatchDeadlineMs: 2_000,
         watchNotify: unavailableExternalNotify,
       }),
     );
@@ -1747,10 +1747,10 @@ describe("P11 spawn_agent issues the coordination contract", () => {
     const wakeCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(before);
     expect(
       wakeCalls.some(([, args]: [string, string[]]) =>
-        args.includes("surface:new") &&
-        args.some(
-          (arg) => arg.includes("[report]") && arg.includes(reportPath),
-        ),
+          args.includes("surface:new") &&
+          args.some(
+            (arg) => arg.includes("[report]") && arg.includes(reportPath),
+          ),
       ),
     ).toBe(true);
     expect(

--- a/tests/p11-spawn-contract.test.ts
+++ b/tests/p11-spawn-contract.test.ts
@@ -20,6 +20,8 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { spawn as nodeSpawn } from "node:child_process";
+import { once } from "node:events";
 import {
   createServer,
   createServerContext,
@@ -513,6 +515,140 @@ describe("P11 spawn_agent issues the coordination contract", () => {
         notification_pending: false,
       }),
     ]);
+  });
+
+  it("recovers a report watch after a process crash before deadline settlement", async () => {
+    await server.close();
+    const parentUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childUuid = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const baseExec = makeExec(
+      "Claude Code\nWhat can I help you with?\n❯ ",
+      "parent-pane",
+      undefined,
+      [
+        {
+          id: childUuid,
+          ref: "surface:child",
+          title: "child-pane",
+          text: "Claude Code\nWhat can I help you with?\n❯ ",
+        },
+      ],
+      parentUuid,
+    );
+    exec = vi.fn().mockImplementation((cmd, args: string[]) => {
+      if (args.includes("new-split")) {
+        return {
+          stdout: JSON.stringify({
+            workspace: "workspace:1",
+            surface: "surface:child",
+            surface_id: childUuid,
+            pane: "pane:1",
+            title: "",
+            type: "terminal",
+          }),
+          stderr: "",
+        };
+      }
+      return baseExec(cmd, args);
+    });
+    let watchNow = 1_000;
+    const serverOptions = withTestSurfaceObserver({
+      exec,
+      stateDir: STATE_DIR,
+      disableSpawnPreflight: true,
+      inboxBaseDir: inboxDir,
+      watchRegistryPath,
+      watchRegistryNow: () => watchNow,
+      reportWatchDeadlineMs: 2_000,
+    });
+    server = createServer(serverOptions);
+    const engine = server._registeredTools.interact._engine;
+    const parent = parentRecord(parentUuid);
+    engine.stateMgr.writeState(parent);
+    engine.getRegistry().set(parent.agent_id, parent);
+    const child = await spawn({ parent_agent_id: parent.agent_id });
+    await server.close();
+
+    const moduleUrl = new URL("../src/watch-spec.ts", import.meta.url).href;
+    const crashScript = `
+      const { sweepWatches } = await import(process.env.TEST_WATCH_MODULE_URL);
+      await sweepWatches({
+        registryPath: process.env.TEST_WATCH_REGISTRY_PATH,
+        now: () => 3000,
+        notify: () => new Promise(() => {
+          process.send?.({ phase: "pre-settlement" });
+        }),
+      });
+    `;
+    const crashingSweep = nodeSpawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", crashScript],
+      {
+        env: {
+          ...process.env,
+          TEST_WATCH_MODULE_URL: moduleUrl,
+          TEST_WATCH_REGISTRY_PATH: watchRegistryPath,
+        },
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+      },
+    );
+    let crashStderr = "";
+    crashingSweep.stderr?.on("data", (chunk) => {
+      crashStderr += String(chunk);
+    });
+    try {
+      const [message] = await once(crashingSweep, "message");
+      expect(message).toEqual({ phase: "pre-settlement" });
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches[0],
+      ).toMatchObject({
+        state: "failed",
+        terminal_reason: "deadline_elapsed",
+        notification_pending: false,
+      });
+      crashingSweep.kill("SIGKILL");
+      const [, signal] = (await once(crashingSweep, "exit")) as [
+        number | null,
+        NodeJS.Signals | null,
+      ];
+      expect(signal, crashStderr).toBe("SIGKILL");
+    } finally {
+      if (crashingSweep.exitCode === null && crashingSweep.signalCode === null) {
+        crashingSweep.kill("SIGKILL");
+      }
+    }
+
+    watchNow = 3_001;
+    server = createServer(serverOptions);
+    await server._registeredTools.list_agents.handler({}, {} as never);
+    const restartedEngine = server._registeredTools.interact._engine;
+    await restartedEngine.sweepWatchesBestEffort();
+    expect(
+      readWatchRegistry({ registryPath: watchRegistryPath }).watches,
+    ).toEqual([
+      expect.objectContaining({
+        watch_id: expect.any(String),
+        state: "armed",
+        deadline_notified_at_ms: 3_000,
+        notification_pending: false,
+      }),
+    ]);
+
+    const beforeReport = (exec as ReturnType<typeof vi.fn>).mock.calls.length;
+    writeFileSync(child.report_path, "late report after crash\n", "utf8");
+    watchNow = 3_002;
+    await restartedEngine.sweepWatchesBestEffort();
+    const reportCalls = (exec as ReturnType<typeof vi.fn>).mock.calls.slice(
+      beforeReport,
+    );
+    expect(
+      reportCalls.some(([, args]: [string, string[]]) =>
+        args.some(
+          (arg) =>
+            arg.includes("[report]") && arg.includes(child.report_path),
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("drops a child-scoped report watch when close_surface closes the agent", async () => {

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2619,14 +2619,14 @@ describe("agent lifecycle tool handlers", () => {
       ),
     ).toMatchObject({ state: "armed", deadline_notified_at_ms: 3_000 });
     watchNow = 10_000;
-    const spawn = (server as any)._registeredTools["spawn_agent"];
+    const spawn = registeredTestTool(server, "spawn_agent");
 
     try {
       const result = await spawn.handler(
         { resume_agent_id: agentId, report_path: customReportPath },
-        {} as any,
+        {},
       );
-      const parsed = parseToolResult(result) as Record<string, any>;
+      const parsed = parseToolResult(result);
       expect(parsed.ok, JSON.stringify(parsed)).toBe(true);
       expect(parsed.resumed).toBe(true);
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -54,7 +54,6 @@ import { MODEL_OVERRIDE_ENV } from "../src/model-policy.js";
 import {
   armWatch,
   readWatchRegistry,
-  removeWatches,
   sweepWatches,
 } from "../src/watch-spec.js";
 import { recordCliFallback } from "../src/transport-retry-context.js";
@@ -2116,14 +2115,6 @@ function parseToolResult(result: TestToolResult): Record<string, unknown> {
   );
 }
 
-function requireTestValue<T>(
-  value: T | null | undefined,
-  message: string,
-): T {
-  if (value === null || value === undefined) throw new Error(message);
-  return value;
-}
-
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((settle) => {
@@ -2544,7 +2535,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(spawn.inputSchema.shape.resume_agent_id).toBeDefined();
   });
 
-  it("P11b/#462: resume adopts legacy and re-arms a notified watch", async () => {
+  it("P11b/#462: resume re-arms an already-notified report watch", async () => {
     // Before this, resume returned no contract at all: no report_path, no
     // done_marker, no contract file. The crash-recovery case this repo exists
     // for was the one case where a lead could not even see where its worker
@@ -2559,6 +2550,7 @@ describe("agent lifecycle tool handlers", () => {
       "custom",
       "resume-report.md",
     );
+    let watchNow = 1_000;
     const stateMgr = new StateManager(TEST_DIR);
     stateMgr.writeState(
       makeServerAgentRecord({
@@ -2598,13 +2590,10 @@ describe("agent lifecycle tool handlers", () => {
       sessionIdentityResolver: () => null,
       inboxBaseDir: resumeInboxDir,
       watchRegistryPath,
+      watchRegistryNow: () => watchNow,
       reportWatchDeadlineMs: 2_000,
     });
-    const lifecycleContext = requireTestValue(
-      serverContexts.at(-1),
-      "missing lifecycle test context",
-    );
-    await lifecycleContext.lifecycleStartPromise;
+    await serverContexts.at(-1)?.lifecycleStartPromise;
     // Arm after startup pruning so this assertion isolates resume's dedupe
     // boundary rather than the separate terminal-child startup policy.
     const oldWatch = await armWatch(
@@ -2612,21 +2601,24 @@ describe("agent lifecycle tool handlers", () => {
         owner: parentSeat,
         subject_agent_id: agentId,
         target: expected.report_path,
+        provenance: "engine",
         change: "content",
-        deadline: Number.MAX_SAFE_INTEGER,
+        deadline: 3_000,
       },
-      { registryPath: watchRegistryPath },
+      { registryPath: watchRegistryPath, now: () => watchNow },
     );
-    appendFileSync(expected.report_path, "first revision\n", "utf8");
+    watchNow = 3_000;
     await sweepWatches({
       registryPath: watchRegistryPath,
-      notify: async () => true,
+      now: () => watchNow,
+      notify: () => Promise.resolve(true),
     });
     expect(
       readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
         (watch) => watch.watch_id === oldWatch.watch_id,
-      )?.state,
-    ).toBe("armed");
+      ),
+    ).toMatchObject({ state: "armed", deadline_notified_at_ms: 3_000 });
+    watchNow = 10_000;
     const spawn = (server as any)._registeredTools["spawn_agent"];
 
     try {
@@ -2657,7 +2649,7 @@ describe("agent lifecycle tool handlers", () => {
       );
 
       // Persisted, so the closure consumer reads what resume issued.
-      const detail = lifecycleContext.stateMgr.readState(agentId);
+      const detail = stateMgr.readState(agentId);
       expect(detail?.report_path).toBe(expected.report_path);
       expect(detail?.done_marker).toBe(expected.done_marker);
       const reportWatches = readWatchRegistry({
@@ -2670,79 +2662,10 @@ describe("agent lifecycle tool handlers", () => {
         subject_agent_id: agentId,
         change: "content",
         state: "armed",
+        armed_at_ms: 10_000,
+        deadline: 12_000,
       });
-      const reportWatch = requireTestValue(
-        reportWatches[0],
-        "missing adopted legacy report watch",
-      );
-      expect(reportWatch.deadline - reportWatch.armed_at_ms).toBe(2_000);
-
-      await removeWatches(
-        (watch) => watch.watch_id === oldWatch.watch_id,
-        { registryPath: watchRegistryPath },
-      );
-      const notifiedWatch = await armWatch(
-        {
-          owner: parentSeat,
-          subject_agent_id: agentId,
-          target: expected.report_path,
-          provenance: "engine",
-          change: "content",
-          deadline: 14_000,
-        },
-        { registryPath: watchRegistryPath, now: () => 12_000 },
-      );
-      await sweepWatches({
-        registryPath: watchRegistryPath,
-        now: () => 14_000,
-        notify: () => Promise.resolve(true),
-      });
-      expect(
-        readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
-          (watch) => watch.watch_id === notifiedWatch.watch_id,
-        ),
-      ).toMatchObject({ deadline_notified_at_ms: 14_000 });
-
-      const lifecycleEngine = requireTestValue(
-        lifecycleContext.lifecycleSweepEngine,
-        "missing lifecycle test engine",
-      );
-      const engineStateMgr = lifecycleEngine.stateMgr;
-      const resumedRecord = requireTestValue(
-        engineStateMgr.readState(agentId),
-        "missing resumed agent state",
-      );
-      const terminalRecord = {
-        ...resumedRecord,
-        state: "done" as const,
-      };
-      engineStateMgr.writeState(terminalRecord);
-      const lifecycleRegistry = requireTestValue(
-        lifecycleContext.lifecycleRegistry,
-        "missing lifecycle test registry",
-      );
-      lifecycleRegistry.set(agentId, terminalRecord);
-      const resumedAgain = parseToolResult(
-        await spawn.handler(
-          { resume_agent_id: agentId, report_path: customReportPath },
-          {} as never,
-        ),
-      ) as Record<string, unknown>;
-      expect(resumedAgain.ok, JSON.stringify(resumedAgain)).toBe(true);
-      const resumedWatch =
-        readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
-          (watch) => watch.watch_id === notifiedWatch.watch_id,
-        );
-      expect(resumedWatch).toMatchObject({
-        state: "armed",
-      });
-      const adoptedWatch = requireTestValue(
-        resumedWatch,
-        "missing resumed report watch",
-      );
-      expect(adoptedWatch.deadline_notified_at_ms).toBeUndefined();
-      expect(adoptedWatch.deadline - adoptedWatch.armed_at_ms).toBe(2_000);
-      expect(adoptedWatch.armed_at_ms).toBeGreaterThan(14_000);
+      expect(reportWatches[0]?.deadline_notified_at_ms).toBeUndefined();
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -54,6 +54,7 @@ import { MODEL_OVERRIDE_ENV } from "../src/model-policy.js";
 import {
   armWatch,
   readWatchRegistry,
+  removeWatches,
   sweepWatches,
 } from "../src/watch-spec.js";
 import { recordCliFallback } from "../src/transport-retry-context.js";
@@ -2535,7 +2536,7 @@ describe("agent lifecycle tool handlers", () => {
     expect(spawn.inputSchema.shape.resume_agent_id).toBeDefined();
   });
 
-  it("P11b/#462: resume refreshes a custom contract and adopts its legacy watch", async () => {
+  it("P11b/#462: resume adopts legacy and re-arms a notified watch", async () => {
     // Before this, resume returned no contract at all: no report_path, no
     // done_marker, no contract file. The crash-recovery case this repo exists
     // for was the one case where a lead could not even see where its worker
@@ -2589,8 +2590,10 @@ describe("agent lifecycle tool handlers", () => {
       sessionIdentityResolver: () => null,
       inboxBaseDir: resumeInboxDir,
       watchRegistryPath,
+      reportWatchDeadlineMs: 2_000,
     });
-    await serverContexts.at(-1)?.lifecycleStartPromise;
+    const lifecycleContext = serverContexts.at(-1)!;
+    await lifecycleContext.lifecycleStartPromise;
     // Arm after startup pruning so this assertion isolates resume's dedupe
     // boundary rather than the separate terminal-child startup policy.
     const oldWatch = await armWatch(
@@ -2643,12 +2646,9 @@ describe("agent lifecycle tool handlers", () => {
       );
 
       // Persisted, so the closure consumer reads what resume issued.
-      const stateTool = (server as any)._registeredTools["get_agent_state"];
-      const detail = parseToolResult(
-        await stateTool.handler({ agent_id: agentId }, {} as any),
-      ) as Record<string, unknown>;
-      expect(detail.report_path).toBe(expected.report_path);
-      expect(detail.done_marker).toBe(expected.done_marker);
+      const detail = lifecycleContext.stateMgr.readState(agentId);
+      expect(detail?.report_path).toBe(expected.report_path);
+      expect(detail?.done_marker).toBe(expected.done_marker);
       const reportWatches = readWatchRegistry({
         registryPath: watchRegistryPath,
       }).watches.filter((watch) => watch.target === expected.report_path);
@@ -2660,6 +2660,59 @@ describe("agent lifecycle tool handlers", () => {
         change: "content",
         state: "armed",
       });
+      expect(reportWatches[0]!.deadline - reportWatches[0]!.armed_at_ms)
+        .toBe(2_000);
+
+      await removeWatches(
+        (watch) => watch.watch_id === oldWatch.watch_id,
+        { registryPath: watchRegistryPath },
+      );
+      const notifiedWatch = await armWatch(
+        {
+          owner: parentSeat,
+          subject_agent_id: agentId,
+          target: expected.report_path,
+          provenance: "engine",
+          change: "content",
+          deadline: 14_000,
+        },
+        { registryPath: watchRegistryPath, now: () => 12_000 },
+      );
+      await sweepWatches({
+        registryPath: watchRegistryPath,
+        now: () => 14_000,
+        notify: async () => true,
+      });
+      expect(
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
+          (watch) => watch.watch_id === notifiedWatch.watch_id,
+        ),
+      ).toMatchObject({ deadline_notified_at_ms: 14_000 });
+
+      const engineStateMgr = lifecycleContext.lifecycleSweepEngine!.stateMgr;
+      const terminalRecord = {
+        ...engineStateMgr.readState(agentId)!,
+        state: "done" as const,
+      };
+      engineStateMgr.writeState(terminalRecord);
+      lifecycleContext.lifecycleRegistry!.set(agentId, terminalRecord);
+      const resumedAgain = parseToolResult(
+        await spawn.handler(
+          { resume_agent_id: agentId, report_path: customReportPath },
+          {} as never,
+        ),
+      ) as Record<string, unknown>;
+      expect(resumedAgain.ok, JSON.stringify(resumedAgain)).toBe(true);
+      const resumedWatch =
+        readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(
+          (watch) => watch.watch_id === notifiedWatch.watch_id,
+        );
+      expect(resumedWatch).toMatchObject({
+        state: "armed",
+      });
+      expect(resumedWatch?.deadline_notified_at_ms).toBeUndefined();
+      expect(resumedWatch!.deadline - resumedWatch!.armed_at_ms).toBe(2_000);
+      expect(resumedWatch!.armed_at_ms).toBeGreaterThan(14_000);
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useHarnessHome } from "./helpers/harness-home.js";
 import {
-  appendFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2592,7 +2592,8 @@ describe("agent lifecycle tool handlers", () => {
       watchRegistryPath,
       reportWatchDeadlineMs: 2_000,
     });
-    const lifecycleContext = serverContexts.at(-1)!;
+    const lifecycleContext = serverContexts.at(-1);
+    if (!lifecycleContext) throw new Error("missing lifecycle test context");
     await lifecycleContext.lifecycleStartPromise;
     // Arm after startup pruning so this assertion isolates resume's dedupe
     // boundary rather than the separate terminal-child startup policy.
@@ -2660,8 +2661,9 @@ describe("agent lifecycle tool handlers", () => {
         change: "content",
         state: "armed",
       });
-      expect(reportWatches[0]!.deadline - reportWatches[0]!.armed_at_ms)
-        .toBe(2_000);
+      const reportWatch = reportWatches[0];
+      if (!reportWatch) throw new Error("missing adopted legacy report watch");
+      expect(reportWatch.deadline - reportWatch.armed_at_ms).toBe(2_000);
 
       await removeWatches(
         (watch) => watch.watch_id === oldWatch.watch_id,
@@ -2689,13 +2691,19 @@ describe("agent lifecycle tool handlers", () => {
         ),
       ).toMatchObject({ deadline_notified_at_ms: 14_000 });
 
-      const engineStateMgr = lifecycleContext.lifecycleSweepEngine!.stateMgr;
+      const lifecycleEngine = lifecycleContext.lifecycleSweepEngine;
+      if (!lifecycleEngine) throw new Error("missing lifecycle test engine");
+      const engineStateMgr = lifecycleEngine.stateMgr;
+      const resumedRecord = engineStateMgr.readState(agentId);
+      if (!resumedRecord) throw new Error("missing resumed agent state");
       const terminalRecord = {
-        ...engineStateMgr.readState(agentId)!,
+        ...resumedRecord,
         state: "done" as const,
       };
       engineStateMgr.writeState(terminalRecord);
-      lifecycleContext.lifecycleRegistry!.set(agentId, terminalRecord);
+      const lifecycleRegistry = lifecycleContext.lifecycleRegistry;
+      if (!lifecycleRegistry) throw new Error("missing lifecycle test registry");
+      lifecycleRegistry.set(agentId, terminalRecord);
       const resumedAgain = parseToolResult(
         await spawn.handler(
           { resume_agent_id: agentId, report_path: customReportPath },
@@ -2710,9 +2718,10 @@ describe("agent lifecycle tool handlers", () => {
       expect(resumedWatch).toMatchObject({
         state: "armed",
       });
-      expect(resumedWatch?.deadline_notified_at_ms).toBeUndefined();
-      expect(resumedWatch!.deadline - resumedWatch!.armed_at_ms).toBe(2_000);
-      expect(resumedWatch!.armed_at_ms).toBeGreaterThan(14_000);
+      if (!resumedWatch) throw new Error("missing resumed report watch");
+      expect(resumedWatch.deadline_notified_at_ms).toBeUndefined();
+      expect(resumedWatch.deadline - resumedWatch.armed_at_ms).toBe(2_000);
+      expect(resumedWatch.armed_at_ms).toBeGreaterThan(14_000);
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2116,6 +2116,14 @@ function parseToolResult(result: TestToolResult): Record<string, unknown> {
   );
 }
 
+function requireTestValue<T>(
+  value: T | null | undefined,
+  message: string,
+): T {
+  if (value === null || value === undefined) throw new Error(message);
+  return value;
+}
+
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((settle) => {
@@ -2592,8 +2600,10 @@ describe("agent lifecycle tool handlers", () => {
       watchRegistryPath,
       reportWatchDeadlineMs: 2_000,
     });
-    const lifecycleContext = serverContexts.at(-1);
-    if (!lifecycleContext) throw new Error("missing lifecycle test context");
+    const lifecycleContext = requireTestValue(
+      serverContexts.at(-1),
+      "missing lifecycle test context",
+    );
     await lifecycleContext.lifecycleStartPromise;
     // Arm after startup pruning so this assertion isolates resume's dedupe
     // boundary rather than the separate terminal-child startup policy.
@@ -2661,8 +2671,10 @@ describe("agent lifecycle tool handlers", () => {
         change: "content",
         state: "armed",
       });
-      const reportWatch = reportWatches[0];
-      if (!reportWatch) throw new Error("missing adopted legacy report watch");
+      const reportWatch = requireTestValue(
+        reportWatches[0],
+        "missing adopted legacy report watch",
+      );
       expect(reportWatch.deadline - reportWatch.armed_at_ms).toBe(2_000);
 
       await removeWatches(
@@ -2691,18 +2703,24 @@ describe("agent lifecycle tool handlers", () => {
         ),
       ).toMatchObject({ deadline_notified_at_ms: 14_000 });
 
-      const lifecycleEngine = lifecycleContext.lifecycleSweepEngine;
-      if (!lifecycleEngine) throw new Error("missing lifecycle test engine");
+      const lifecycleEngine = requireTestValue(
+        lifecycleContext.lifecycleSweepEngine,
+        "missing lifecycle test engine",
+      );
       const engineStateMgr = lifecycleEngine.stateMgr;
-      const resumedRecord = engineStateMgr.readState(agentId);
-      if (!resumedRecord) throw new Error("missing resumed agent state");
+      const resumedRecord = requireTestValue(
+        engineStateMgr.readState(agentId),
+        "missing resumed agent state",
+      );
       const terminalRecord = {
         ...resumedRecord,
         state: "done" as const,
       };
       engineStateMgr.writeState(terminalRecord);
-      const lifecycleRegistry = lifecycleContext.lifecycleRegistry;
-      if (!lifecycleRegistry) throw new Error("missing lifecycle test registry");
+      const lifecycleRegistry = requireTestValue(
+        lifecycleContext.lifecycleRegistry,
+        "missing lifecycle test registry",
+      );
       lifecycleRegistry.set(agentId, terminalRecord);
       const resumedAgain = parseToolResult(
         await spawn.handler(
@@ -2718,10 +2736,13 @@ describe("agent lifecycle tool handlers", () => {
       expect(resumedWatch).toMatchObject({
         state: "armed",
       });
-      if (!resumedWatch) throw new Error("missing resumed report watch");
-      expect(resumedWatch.deadline_notified_at_ms).toBeUndefined();
-      expect(resumedWatch.deadline - resumedWatch.armed_at_ms).toBe(2_000);
-      expect(resumedWatch.armed_at_ms).toBeGreaterThan(14_000);
+      const adoptedWatch = requireTestValue(
+        resumedWatch,
+        "missing resumed report watch",
+      );
+      expect(adoptedWatch.deadline_notified_at_ms).toBeUndefined();
+      expect(adoptedWatch.deadline - adoptedWatch.armed_at_ms).toBe(2_000);
+      expect(adoptedWatch.armed_at_ms).toBeGreaterThan(14_000);
     } finally {
       rmSync(resumeInboxDir, { recursive: true, force: true });
     }

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -2683,7 +2683,7 @@ describe("agent lifecycle tool handlers", () => {
       await sweepWatches({
         registryPath: watchRegistryPath,
         now: () => 14_000,
-        notify: async () => true,
+        notify: () => Promise.resolve(true),
       });
       expect(
         readWatchRegistry({ registryPath: watchRegistryPath }).watches.find(

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -1106,6 +1106,36 @@ describe("WatchSpec arm contract", () => {
     );
   });
 
+  it("never rolls an engine report deadline beyond MAX_SAFE_INTEGER", async () => {
+    const target = join(TEST_DIR, "legacy-infinite-report.md");
+    writeFileSync(target, "before\n", "utf8");
+    await armWatch(
+      {
+        owner: "lead-a",
+        provenance: "engine",
+        target,
+        change: "content",
+        deadline: Number.MAX_SAFE_INTEGER,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    writeFileSync(target, "after\n", "utf8");
+
+    await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify: vi.fn().mockResolvedValue(true),
+    });
+
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      state: "armed",
+      armed_at_ms: 2_000,
+      deadline: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
   it("persists and delivers deadline_elapsed through the retryable transition", async () => {
     const target = join(TEST_DIR, "deadline.md");
     writeFileSync(target, "", "utf8");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -986,6 +986,113 @@ describe("WatchSpec arm contract", () => {
     });
   });
 
+  it("keeps an engine report watch alive when its deadline notice is undelivered", async () => {
+    const target = join(TEST_DIR, "undelivered-report.md");
+    writeFileSync(target, "", "utf8");
+    const notify = vi.fn().mockResolvedValue(false);
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        provenance: "engine",
+        target,
+        change: "content",
+        deadline: 2_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    const deadline = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+    expect(deadline).toMatchObject({ armed: [armed.watch_id], failed: [] });
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({
+      state: "armed",
+      deadline_notified_at_ms: 2_000,
+      notification_exhausted_reason: "terminal_notice_fire_once",
+    });
+
+    writeFileSync(target, "late report\n", "utf8");
+    const revision = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_001,
+      notify,
+    });
+    expect(revision.fired).toEqual([armed.watch_id]);
+  });
+
+  it("keeps public content-watch deadline failure terminal", async () => {
+    const target = join(TEST_DIR, "public-content.md");
+    writeFileSync(target, "", "utf8");
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        provenance: "public",
+        target,
+        change: "content",
+        deadline: 2_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    const result = await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify: vi.fn().mockResolvedValue(true),
+    });
+    expect(result.failed).toEqual([armed.watch_id]);
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({ state: "failed", terminal_reason: "deadline_elapsed" });
+  });
+
+  it("rolls an engine report deadline forward after content activity", async () => {
+    const target = join(TEST_DIR, "active-report.md");
+    writeFileSync(target, "", "utf8");
+    const notify = vi.fn().mockResolvedValue(true);
+    const armed = await armWatch(
+      {
+        owner: "lead-a",
+        provenance: "engine",
+        target,
+        change: "content",
+        deadline: 2_000,
+      },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+    writeFileSync(target, "activity\n", "utf8");
+
+    await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 1_900,
+      notify,
+    });
+    expect(
+      readWatchRegistry({ registryPath: registryPath() }).watches[0],
+    ).toMatchObject({ state: "armed", armed_at_ms: 1_900, deadline: 2_900 });
+
+    await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_000,
+      notify,
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+    await sweepWatches({
+      registryPath: registryPath(),
+      now: () => 2_900,
+      notify,
+    });
+    expect(notify).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        watch_id: armed.watch_id,
+        reason: "deadline_elapsed",
+      }),
+    );
+  });
+
   it("persists and delivers deadline_elapsed through the retryable transition", async () => {
     const target = join(TEST_DIR, "deadline.md");
     writeFileSync(target, "", "utf8");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -44,13 +44,11 @@ describe("WatchSpec arm contract", () => {
       { owner: "lead-a", target, change: "content", deadline: 9_000 },
       { registryPath: registryPath(), now: () => 1_000 },
     );
-
     expect(await updateWatchDeadline(armed.watch_id, 3_000,
-      { registryPath: registryPath() })).toBe(true);
+      { registryPath: registryPath(), now: () => 1_500 })).toBe(true);
     expect(readWatchRegistry({ registryPath: registryPath() }).watches[0])
-      .toMatchObject({ watch_id: armed.watch_id, deadline: 3_000 });
+      .toMatchObject({ watch_id: armed.watch_id, armed_at_ms: 1_500, deadline: 3_000 });
   });
-
   it("notifies the transport only when the declared watch opts in", async () => {
     const silentTarget = join(TEST_DIR, "silent.md");
     const notifyingTarget = join(TEST_DIR, "notifying.md");

--- a/tests/watch-spec.test.ts
+++ b/tests/watch-spec.test.ts
@@ -21,6 +21,7 @@ import {
   releaseWatchReportPathReservation,
   removeWatches,
   sweepWatches,
+  updateWatchDeadline,
 } from "../src/watch-spec.js";
 
 const TEST_DIR = join(tmpdir(), "cmuxlayer-watch-spec-test");
@@ -34,6 +35,20 @@ describe("WatchSpec arm contract", () => {
 
   afterEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("updates a legacy watch deadline atomically", async () => {
+    const target = join(TEST_DIR, "legacy-deadline.md");
+    writeFileSync(target, "", "utf8");
+    const armed = await armWatch(
+      { owner: "lead-a", target, change: "content", deadline: 9_000 },
+      { registryPath: registryPath(), now: () => 1_000 },
+    );
+
+    expect(await updateWatchDeadline(armed.watch_id, 3_000,
+      { registryPath: registryPath() })).toBe(true);
+    expect(readWatchRegistry({ registryPath: registryPath() }).watches[0])
+      .toMatchObject({ watch_id: armed.watch_id, deadline: 3_000 });
   });
 
   it("notifies the transport only when the declared watch opts in", async () => {


### PR DESCRIPTION
## Summary
- Bound engine child-report silence to one hour by default for newly armed or adopted rows; env/option overrides roll on activity.
- Preserve watches after undelivered alerts, isolate public `wait_for`, re-arm on resume, and recover pre-settlement process crashes.
- Upgrade limit: durable pre-upgrade `MAX_SAFE_INTEGER` rows keep their deadline until the child is next spawned or resumed; boot migration is deferred to #607.
Size: L because the lead ruled the crash-boundary fix and its real-process regression belong with the deadline lifecycle, bringing the hand-written diff to 671 lines.
RED: the process-crash gate failed on frozen `6b8cfe3` (restart pruned the only watch); original MAX_SAFE and resumed-after-alert controls also failed on their pre-fix heads.
GREEN: crash gate + MAX_SAFE cap pass; 471 focused tests and typecheck pass; pre-push full suite 159 files / 3,797 passed / 1 skipped at c4b1194; import-only head 257e8a2 passes its 353-test file and typecheck; exact-head GitHub test passed in 4m11s and DeepSource JavaScript/Shell passed.
Perf: repeated local RED under acknowledged contention; no benchmark edits; exact-head remote `perf-budget` passed in 7m21s.
Live: reviewer proved compiled/installed live-daemon paths and the migrated/revised 1.5s control; full spawn→wake remains unrun.
— cmuxlayerCodex-61d79d57 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"cmuxlayerCodex-61d79d57","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a07ae7","ts":"2026-09-07T10:44:00Z"} -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `watch` pruning to retain engine-owned deadline-claim content watches
> The watch-pruning path in [agent-engine.ts](https://github.com/EtanHey/cmuxlayer/pull/602/files#diff-cf76c46fe081eb26c409fa0c7a5374598a7f5e77f0401a12388773a7a6abdae5) was silently removing engine-owned content watches whose deadline fired before the deadline notification was durably settled. It now imports the interrupted engine-deadline predicate and keeps such watches scheduled for another check rather than dropping them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 257e8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistent watch state, spawn/resume report-watch adoption, and notification semantics on a coordination-critical path; mistakes could miss parent wakes or duplicate deadline alerts.
> 
> **Overview**
> **Engine-owned child report watches** no longer use an effectively infinite deadline. They default to a **one-hour silence window** (`DEFAULT_REPORT_WATCH_DEADLINE_MS`), overridable via `CMUXLAYER_REPORT_WATCH_DEADLINE_MS` (validated at startup and forced **in-process** so a shared daemon cannot ignore the spawning MCP’s env).
> 
> The watch registry gains **`deadline_notified_at_ms`** and new sweep/settlement paths so **engine `content` watches** fire a **single** `deadline_elapsed` notice, then **stay armed** for later report activity instead of failing terminally (public content watches still fail on deadline). Report activity **rolls** the deadline forward by the original interval; resume/spawn **refreshes** deadlines on existing rows via `updateWatchDeadline`.
> 
> **Crash recovery**: interrupted pre-settlement deadline claims are **re-armed on sweep** (`recoverInterruptedEngineDeadlineClaim`) and **not pruned** in the agent engine (`isInterruptedEngineDeadlineClaim`), so a restart does not drop a watch that died mid-notification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257e8a20323542ed09c0192b87c054b42c206c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable report-watch deadlines through the `CMUXLAYER_REPORT_WATCH_DEADLINE_MS` environment variable.
  * Report watches now use a one-hour default deadline when no custom value is provided.
  * Engine-managed watches re-arm after deadline notifications and continue monitoring new activity.
  * Active engine-managed watches extend their deadline when new content arrives.
  * Public content watches end when their deadline expires.
  * Deadline notifications are issued once per watch and recover correctly after restarts.

* **Bug Fixes**
  * Invalid deadline values are rejected with a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->