### PR TITLE
chore: release v0.4.71

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.70",
+  "version": "0.4.71",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Automated version-bump PR for cmuxlayer v0.4.71. The release tag is created only after required checks pass and this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or dependency updates in the diff.
> 
> **Overview**
> **Automated release bump** for `cmuxlayer`: updates `package.json` **version** from `0.4.70` to `0.4.71`.
> 
> No source, dependency, or script changes in this diff—the tag is intended to land after checks pass and this PR merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cade8783ddf1287e27a506b00a3c01824d940c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version from 0.4.70 to 0.4.71
> Updates the version field in [package.json](https://github.com/EtanHey/cmuxlayer/pull/604/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) for the v0.4.71 release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cade878.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->