### PR TITLE
docs(release): a release is not done at the tag (XS)

### DIFF
--- a/docs/releases-and-brew.md
+++ b/docs/releases-and-brew.md
@@ -255,6 +255,30 @@ Manual equivalent, if you prefer:
 The formula also carries a `head` block, so `--HEAD` installs always track
 `main` with **no** sha/tag bump — that is the on-the-go dogfood path.
 
+### A release is not done at the tag
+
+**Tag pushed ≠ tap published ≠ installed ≠ served.** Steps 1–3 above produce a tag; they produce
+nothing anyone can run. A release is done only when all four of these are true, checked in order:
+
+1. **Tag pushed** — `git ls-remote --tags origin vX.Y.Z` returns the tag.
+2. **Tap published** — `brew info cmuxlayer` reports `stable: X.Y.Z`. Until the formula points at the
+   new tag, `brew upgrade cmuxlayer` is a **no-op** and every Mac stays on the old build.
+3. **Installed on every Mac** — `brew list --versions cmuxlayer` is X.Y.Z, and the running daemon's
+   path is `Cellar/cmuxlayer/X.Y.Z/libexec/dist/daemon.js`. The daemon replaces itself on upgrade;
+   confirm the path rather than assuming it.
+4. **Served** — the installed binary actually serves the change. Drive
+   `/opt/homebrew/opt/cmuxlayer/bin/cmuxlayer` as a real MCP client (`initialize` + `tools/list`) and
+   confirm `serverInfo.version` is X.Y.Z and the behaviour you shipped is present in what it serves.
+   Per-seat MCP servers are separate processes from the daemon, so a seat keeps serving the OLD build
+   until it is reconnected: `/mcp reconnect cmuxlayer` on **every Claude seat**, verified on screen —
+   the send receipt says only that text was typed.
+
+**Why this block exists.** v0.4.71 was tagged and its release PR merged on 2026-09-07 while the tap was
+never bumped. `brew info` still resolved `stable: 0.4.70`, so the release was not installable by anyone
+and #600's merge SHA was served by nothing, with zero reconnect receipts — while the lane read as done
+because the tag existed. The procedure above was already correct; it was stopped at step 3.
+
+
 ## Pre-deploy hygiene: archive the outbox before shipping outbox-semantics changes
 
 Any release that could change how `outbox-drainer.ts` derives dedup ids or


### PR DESCRIPTION
## A release is not done at the tag

`size:XS`, docs only — one block added to `docs/releases-and-brew.md`.

**What happened.** v0.4.71 was tagged and its release PR (#604) merged today, but the Homebrew tap was never bumped. `brew info cmuxlayer` still resolved `stable: 0.4.70`, so **the release was not installable by anyone and `brew upgrade` was a no-op** — leaving #600's merge SHA (`2332faa`) served by nothing on either Mac, with zero `/mcp reconnect` receipts, while the lane read as done because a tag existed.

**The procedure was already correct.** Steps 4–7 in this same document already covered computing the sha256, bumping the formula, syncing the tap clone, and running `release-verify.sh` on each Mac. Nothing was missing from the steps. It was stopped at step 3, and nothing in the document said that stopping there was not a release.

So this adds the **definition of done** rather than another step: tag pushed → tap published → installed on every Mac → **served** by the installed binary, each with the check that proves it. Plus the part that is easy to miss even after upgrading: per-seat MCP servers are separate processes from the daemon, so a seat keeps serving the old build until `/mcp reconnect` — and that must be verified on screen, because the send receipt reports only that text was typed.

Now closed out for real: tap #55 merged, M4 on 0.4.71 with daemon pid 5743 from `Cellar/0.4.71`, and the installed binary verified serving `serverInfo 0.4.71` plus the new six-field `send_to` description. The M1 remains outstanding.

— cmuxlayerClaude-70bfff64 (lead) · claude/claude-opus-5[1m]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to release runbook; no code, build, or install behavior changes.
> 
> **Overview**
> Adds a **definition of done** to `docs/releases-and-brew.md` right after the manual release steps, clarifying that pushing a tag (steps 1–3) does not ship anything runnable.
> 
> The new block states a release is complete only when four checks pass in order: **tag pushed**, **Homebrew tap published** (`brew info` stable version), **installed on every Mac** (keg version + daemon `Cellar` path), and **served** (MCP `serverInfo.version` and shipped behaviour, plus `/mcp reconnect cmuxlayer` on every seat because MCP children can keep old code after upgrade).
> 
> It documents the v0.4.71 incident (tag merged without tap bump) as motivation — the existing procedure was fine but stopping at step 3 was mistaken for “released.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c3344e23e4a74630f4d72179254d6d6483ba88e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document release completion states and verification checks in release guide
> Adds a release-completion section to [releases-and-brew.md](https://github.com/EtanHey/cmuxlayer/pull/605/files#diff-d9f5d9acbab288ab1ba5fdac4d6d43a968642f0fbfb11341968c6903d4da84f6) that separates tag creation, tap publication, local installation, and serving into distinct release states. Documents concrete checks for the Git tag, Homebrew stable version, installed Cellar daemon path, and MCP server version. Notes that each Claude seat must reconnect because per-seat MCP processes can keep serving a previous build, and records the v0.4.71 failure where the tap was not bumped.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6c3344e. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>docs/releases-and-brew.md — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 272](https://github.com/EtanHey/cmuxlayer/blob/6c3344e23e4a74630f4d72179254d6d6483ba88e/docs/releases-and-brew.md#L272): The statement that every per-seat MCP process keeps serving the old build until `/mcp reconnect` is no longer true for normal brew-installed proxies. `CmuxLayerProxy.start()` starts a version-bump watcher, and an eligible stale brew child drains then `execve`s the installed entrypoint while preserving its handshake (`src/proxy.ts` lines 407-415 and 1307-1403). Thus a seat can move to the new build automatically; requiring a manual reconnect on every seat makes this release procedure and its definition of done inaccurate. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->