### PR TITLE
chore: release v0.4.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmuxlayer",
-  "version": "0.4.71",
+  "version": "0.4.72",
   "description": "Terminal multiplexer MCP server for AI agent workspace orchestration",
   "type": "module",
   "main": "./dist/lib.js",


### PR DESCRIPTION
Automated version-bump PR for cmuxlayer v0.4.72. The release tag is created only after required checks pass and this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or behavioral code changes in this PR.
> 
> **Overview**
> Automated **release prep** PR that bumps the published package version from **0.4.71** to **0.4.72** in `package.json`. No application, API, or dependency changes are included in this diff—the tag and release flow run after merge and checks pass, per the existing release process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a820890c4b1d8a256399a4f519cf2f521b4f85cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump package version to 0.4.72 in `package.json`
> Updates the package version field from 0.4.71 to 0.4.72 in [package.json](https://github.com/EtanHey/cmuxlayer/pull/609/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a820890.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->