### PR TITLE
fix(health): stop the health blob crying wolf on every dispatch (S)

### DIFF
--- a/src/agent-health.ts
+++ b/src/agent-health.ts
@@ -65,7 +65,13 @@ export const DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY: Record<
   topology_three_or_more_columns: "blocking",
   orchestrator_not_leftmost: "blocking",
   worker_in_leftmost_column: "blocking",
-  non_claude_orchestrator: "blocking",
+  // AIDEV-NOTE (health-noise): NOT blocking. A non-Claude agent in an
+  // orchestrator role is the fleet's STANDARD topology -- every Astra seat
+  // (brainlayerCodex, golemsCodex, orchestratorCodex, voicelayerCodex) runs
+  // exactly this way. Marked blocking, it made deriveStatus() return
+  // "unhealthy" on EVERY send_to to any Astra, so the whole health blob cried
+  // wolf on every dispatch until nobody read any of it.
+  non_claude_orchestrator: "info",
   worker_spawned_orchestrator: "blocking",
   inbox_channel_dir_deleted: "blocking",
   monitor_collapsed: "blocking",
@@ -418,12 +424,32 @@ export function evaluateAgentHealth(
       "inbox_channel_dir_deleted",
       "agent inbox channel dir was deleted after creation; next inbox write will recreate it",
     );
-  } else if (input.monitor_alive === false) {
+  } else if (
+    input.monitor_alive === false &&
+    ((input.unread_count ?? 0) > 0 || (input.stale_count ?? 0) > 0)
+  ) {
+    // AIDEV-NOTE (health-noise): only when there is something UNREAD to miss.
+    //
+    // An agent-sourced heartbeat has exactly one writer -- the ACK path in
+    // inbox.ts, which runs when the agent handles a message. The engine-issued
+    // contract tells a worker to run a bare `tail -n0 -F inbox.jsonl`, and a
+    // bare tail cannot write a heartbeat. So a seat that follows the contract
+    // EXACTLY and has simply received no messages has no agent heartbeat by
+    // construction, and inboxMonitorState() reports "never-armed" forever.
+    // (The other writer is source "server_boot", which readLastAgentHeartbeat
+    // deliberately ignores.)
+    //
+    // Firing on that made a healthy idle seat indistinguishable from a dead
+    // monitor, on nearly every dispatch -- the published contract and the
+    // liveness check disagreeing, which is the same defect shape as #611.
+    //
+    // The signal worth keeping is the ACTIONABLE one: messages are waiting and
+    // nothing is reading them. That is what this now says.
     addIssue(
       issueCodes,
       issues,
       "inbox_monitor_not_alive",
-      "agent inbox monitor heartbeat is absent or stale",
+      `agent has ${(input.unread_count ?? 0) + (input.stale_count ?? 0)} unhandled inbox message(s) and no live monitor heartbeat; nothing is reading its inbox`,
     );
   }
 
@@ -499,13 +525,14 @@ export function evaluateAgentHealth(
     );
   }
   if (screenConfirmedState && screenConfirmedState !== agent.state) {
+    // Reconcile SILENTLY. The screen is authoritative and we are correcting the
+    // registry from it right here -- the caller's request succeeded and nothing
+    // is wrong with it. Emitting an issue for staleness we just self-healed put
+    // a permanent complaint on nearly every dispatch, and `reconciled_state`
+    // already tells any caller that cares. A self-healed disagreement is not a
+    // health problem; an UNhealable one would be, and that surfaces elsewhere
+    // (agent_shell_fallback, pane_pty_dead).
     reconciledState = screenConfirmedState;
-    addIssue(
-      issueCodes,
-      issues,
-      "registry_screen_disagreement",
-      `registry state is ${agent.state} while screen confirms ${screenConfirmedState}`,
-    );
   }
 
   if (
@@ -587,14 +614,6 @@ export function evaluateAgentHealth(
     }
   }
 
-  if (agent.cli !== "claude" && role === "orchestrator") {
-    addIssue(
-      issueCodes,
-      issues,
-      "non_claude_orchestrator",
-      "non-Claude agent was assigned orchestrator topology role; use worker unless this is the single explicit left-side coordinator",
-    );
-  }
   if (
     agent.cli === "claude" &&
     role === "orchestrator" &&
@@ -610,6 +629,25 @@ export function evaluateAgentHealth(
 
   const topology = input.topology;
   const topologyRole = inferTopologyRole(agent, input) ?? role;
+
+  // Only fires when the seat is GENUINELY mis-placed. A non-Claude orchestrator
+  // in the leftmost column IS the explicit left-side coordinator the old
+  // message told you to be -- so the old check was advice to do the thing it
+  // was already doing, emitted as BLOCKING, on every dispatch to every Astra.
+  if (
+    agent.cli !== "claude" &&
+    role === "orchestrator" &&
+    topology &&
+    topology.column !== null &&
+    topology.column > 0
+  ) {
+    addIssue(
+      issueCodes,
+      issues,
+      "non_claude_orchestrator",
+      `non-Claude agent holds an orchestrator role in column ${topology.column}; the left-side coordinator is column 0, so use role=worker here`,
+    );
+  }
   if (topology && topology.column_count !== null) {
     if (topology.column_count >= 3) {
       addIssue(

--- a/tests/agent-engine.test.ts
+++ b/tests/agent-engine.test.ts
@@ -3249,7 +3249,7 @@ describe("AgentEngine", () => {
         expect(mockClient.clearStatus).not.toHaveBeenCalled();
         expect(mockClient.setStatus).toHaveBeenCalledWith(
           "worker-archived-before-status",
-          "brainlayer | role=worker | state=done | health=unhealthy(inbox_monitor_not_alive:info,closure_without_artifact:blocking) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
+          "brainlayer | role=worker | state=done | health=unhealthy(closure_without_artifact:blocking) | blocked=- | last_prompt=Fix search gap F | worktree=- | branch=- | report=n/a | pr=n/a",
           expect.objectContaining({
             surface: "surface:archived-before-status",
           }),

--- a/tests/agent-health.test.ts
+++ b/tests/agent-health.test.ts
@@ -102,13 +102,15 @@ describe("agent lifecycle health", () => {
       "auto_discovered_agent",
       "missing_cli_session_id",
       "non_resumable",
-      "inbox_monitor_not_alive",
+      // health-noise: inbox_monitor_not_alive is gone from this list on
+      // purpose. This agent has an EMPTY inbox, and the shipped contract's
+      // bare `tail` cannot write a heartbeat, so its absence was never
+      // evidence of anything.
     ]);
     expect(health.issue_severities).toMatchObject({
       auto_discovered_agent: "info",
       missing_cli_session_id: "info",
       non_resumable: "info",
-      inbox_monitor_not_alive: "info",
     });
   });
 
@@ -139,9 +141,9 @@ describe("agent lifecycle health", () => {
       },
     );
 
-    expect(withinGrace.issue_severities?.inbox_monitor_not_alive).toBe("info");
+    expect(withinGrace.issue_codes).not.toContain("inbox_monitor_not_alive");
     expect(withinGrace.status).toBe("healthy");
-    expect(pastGrace.issue_severities?.inbox_monitor_not_alive).toBe("info");
+    expect(pastGrace.issue_codes).not.toContain("inbox_monitor_not_alive");
     expect(pastGrace.status).toBe("healthy");
     expect(pastGrace.reconciled_state).toBeUndefined();
   });
@@ -185,7 +187,7 @@ describe("agent lifecycle health", () => {
     );
 
     expect(health.status).toBe("healthy");
-    expect(health.issue_severities?.inbox_monitor_not_alive).toBe("info");
+    expect(health.issue_codes).not.toContain("inbox_monitor_not_alive");
   });
 
   it("distinguishes a deleted inbox channel dir from a never-armed monitor", () => {
@@ -193,8 +195,13 @@ describe("agent lifecycle health", () => {
       monitor_alive: false,
       inbox_channel_dir_deleted: true,
     });
+    // health-noise: the distinction this guards is still exercised, but with
+    // UNREAD work present. An absent heartbeat on an EMPTY inbox is now silent,
+    // because the shipped contract (a bare `tail`) cannot write a heartbeat, so
+    // that state said nothing about liveness. Unread + no heartbeat still does.
     const neverArmed = evaluateAgentHealth(makeRecord(), {
       monitor_alive: false,
+      unread_count: 2,
     });
 
     expect(deleted.issue_codes).toContain("inbox_channel_dir_deleted");
@@ -238,18 +245,33 @@ describe("agent lifecycle health", () => {
     expect(health.issue_severities?.ambiguous_repo_cwd_label).toBe("info");
   });
 
-  it("marks non-Claude orchestrators as role health failures", () => {
-    const health = evaluateAgentHealth(
+  it("accepts a non-Claude orchestrator in column 0 and flags only a mis-placed one", () => {
+    // health-noise: a Codex orchestrator in the leftmost column is the fleet's
+    // STANDARD Astra topology. Flagging it -- as BLOCKING -- made every send_to
+    // to every Astra report "unhealthy", which is how a health blob stops being
+    // read. It is only worth saying when the seat is genuinely mis-placed.
+    const coordinator = evaluateAgentHealth(
       makeRecord({
         cli: "codex",
         role: "orchestrator",
         surface_provenance: "cmuxlayer_spawn",
       }),
-      { monitor_alive: true },
+      { monitor_alive: true, topology: { column: 0, column_count: 2 } },
     );
+    expect(coordinator.issue_codes).not.toContain("non_claude_orchestrator");
+    expect(coordinator.status).not.toBe("unhealthy");
 
-    expect(health.status).toBe("unhealthy");
-    expect(health.issue_codes).toContain("non_claude_orchestrator");
+    const misplaced = evaluateAgentHealth(
+      makeRecord({
+        cli: "codex",
+        role: "orchestrator",
+        surface_provenance: "cmuxlayer_spawn",
+      }),
+      { monitor_alive: true, topology: { column: 1, column_count: 2 } },
+    );
+    expect(misplaced.issue_codes).toContain("non_claude_orchestrator");
+    // Still not blocking: it is advice about placement, and it blocks nothing.
+    expect(misplaced.issue_severities?.non_claude_orchestrator).toBe("info");
   });
 
   it("#378 health: flags a Claude orchestrator spawned by a worker", () => {
@@ -289,10 +311,13 @@ describe("agent lifecycle health", () => {
       },
     );
 
+    // health-noise: the reconciliation is the whole point and it still happens.
+    // What is gone is the COMPLAINT about staleness we just self-healed in the
+    // same object -- emitting that put a permanent issue on nearly every
+    // dispatch. `reconciled_state` remains the caller-visible truth.
     expect(health.status).toBe("healthy");
     expect(health.reconciled_state).toBe("working");
-    expect(health.issue_codes).toContain("registry_screen_disagreement");
-    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
+    expect(health.issue_codes).not.toContain("registry_screen_disagreement");
   });
 
   it("blocks a live-spinner pane after repeated recent broken-pipe writes", () => {
@@ -309,9 +334,7 @@ describe("agent lifecycle health", () => {
     expect(health.status).toBe("unhealthy");
     expect(health.issue_codes).toContain("pane_pty_dead");
     expect(health.issue_severities?.pane_pty_dead).toBe("blocking");
-    expect(health.issue_severities?.registry_screen_disagreement).toBe(
-      "degraded",
-    );
+    expect(health.reconciled_state).toBeDefined();
   });
 
   it("does not flag one transient broken-pipe write", () => {
@@ -326,7 +349,7 @@ describe("agent lifecycle health", () => {
     });
 
     expect(health.issue_codes).not.toContain("pane_pty_dead");
-    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
+    expect(health.reconciled_state).toBe("working");
     expect(health.status).toBe("healthy");
   });
 
@@ -357,11 +380,9 @@ describe("agent lifecycle health", () => {
       },
     );
 
-    expect(health.status).toBe("degraded");
-    expect(health.issue_codes).toContain("registry_screen_disagreement");
-    expect(health.issue_severities?.registry_screen_disagreement).toBe(
-      "degraded",
-    );
+    expect(health.status).toBe("healthy");
+    expect(health.issue_codes).not.toContain("registry_screen_disagreement");
+    expect(health.reconciled_state).toBeDefined();
   });
 
   it("reconciles a ready registry agent whose pane fell back to a bare shell as errored", () => {
@@ -386,8 +407,7 @@ describe("agent lifecycle health", () => {
     });
 
     expect(health.reconciled_state).toBe("ready");
-    expect(health.issue_codes).toContain("registry_screen_disagreement");
-    expect(health.issue_severities?.registry_screen_disagreement).toBe("info");
+    expect(health.issue_codes).not.toContain("registry_screen_disagreement");
     expect(health.status).toBe("healthy");
   });
 
@@ -424,8 +444,9 @@ describe("agent lifecycle health", () => {
     });
 
     expect(health.status).toBe("healthy");
-    expect(health.issue_codes).toContain("inbox_monitor_not_alive");
-    expect(health.issue_severities?.inbox_monitor_not_alive).toBe("info");
+    // health-noise: silent now -- a bare `tail` (what the contract instructs)
+    // cannot write a heartbeat, so its absence on an empty inbox said nothing.
+    expect(health.issue_codes).not.toContain("inbox_monitor_not_alive");
     expect(health.issue_codes).not.toContain("agent_wedged");
   });
 

--- a/tests/live-agent-harness-replay.test.ts
+++ b/tests/live-agent-harness-replay.test.ts
@@ -550,8 +550,13 @@ describe("MCP-shaped no-live harness replay", () => {
       { monitor_alive: true, screen_status: "done" },
     );
 
+    // health-noise: the guard that matters is the first line -- the replay
+    // CLASSIFIER must not own a registry/screen disagreement. That still holds.
+    // agent-health no longer emits a code for it at all: it reconciles from the
+    // screen silently, and reconciled_state is where the information lives now.
     expect(classifierResult.failures).toEqual([]);
-    expect(health.issue_codes).toContain("registry_screen_disagreement");
+    expect(health.issue_codes).not.toContain("registry_screen_disagreement");
+    expect(health.reconciled_state).toBe("done");
   });
 });
 

--- a/tests/server-agent-tools.test.ts
+++ b/tests/server-agent-tools.test.ts
@@ -7851,7 +7851,8 @@ describe("agent lifecycle tool handlers", () => {
     );
 
     expect(live.state).toMatchObject({ value: "ready", source: "screen" });
-    expect(live.health.issue_codes).toContain("registry_screen_disagreement");
+    // health-noise: reconciled silently now; reconciled_state is the signal.
+    expect(live.health.reconciled_state).toBeDefined();
   });
 
   it("inbox_check preserves harness API errors through the general health evaluator", async () => {
@@ -9751,10 +9752,9 @@ describe("agent lifecycle tool handlers", () => {
       },
       health: {
         status: "healthy",
-        issue_codes: expect.arrayContaining(["registry_screen_disagreement"]),
-        issue_severities: {
-          registry_screen_disagreement: "info",
-        },
+        issue_codes: expect.any(Array),
+        // health-noise: no severity to pin -- the disagreement is reconciled
+        // silently now. reconciled_state below is what this test cares about.
         reconciled_state: "working",
       },
     });
@@ -9907,7 +9907,7 @@ describe("agent lifecycle tool handlers", () => {
 
     expect(parsed.health).toMatchObject({
       reconciled_state: "working",
-      issue_codes: expect.arrayContaining(["registry_screen_disagreement"]),
+      issue_codes: expect.any(Array),
     });
     expect(routeClient.client.readScreen).toHaveBeenCalledWith(
       "surface:new",
@@ -10064,7 +10064,6 @@ describe("agent lifecycle tool handlers", () => {
       issue_codes: expect.arrayContaining([
         "missing_cli_session_id",
         "non_resumable",
-        "inbox_monitor_not_alive",
       ]),
     });
   });
@@ -10915,8 +10914,7 @@ codex>
           "auto_discovered_agent",
           "missing_cli_session_id",
           "non_resumable",
-          "inbox_monitor_not_alive",
-        ]),
+          ]),
         issues: expect.any(Array),
       },
     });

--- a/tests/sidebar-sync.test.ts
+++ b/tests/sidebar-sync.test.ts
@@ -3582,7 +3582,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.notify).not.toHaveBeenCalled();
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       agentId,
-      expect.stringContaining("health=healthy(inbox_monitor_not_alive:info)"),
+      expect.stringContaining("health=healthy"),
       expect.any(Object),
     );
   });
@@ -3627,7 +3627,7 @@ describe("Sidebar Sync", () => {
     expect(mockClient.notify).not.toHaveBeenCalled();
     expect(mockClient.setStatus).toHaveBeenCalledWith(
       agentId,
-      expect.stringContaining("health=healthy(inbox_monitor_not_alive:info)"),
+      expect.stringContaining("health=healthy"),
       expect.any(Object),
     );
   });


### PR DESCRIPTION
## Stop the health blob crying wolf on every dispatch

`size:S`. Etan, seeing a raw `send_to` response: **"hows cmuxlayer still this shitty?"**

Three defects, all noise on **every single dispatch**. Before and after, from the real `evaluateAgentHealth` on an Astra-shaped record:

```
BEFORE  status: "unhealthy"
        issue_codes: [inbox_monitor_not_alive, registry_screen_disagreement, non_claude_orchestrator]
        issue_severities: { non_claude_orchestrator: "blocking", ... }

AFTER   status: "healthy"
        issue_codes: []
        reconciled_state: "working"      <- the reconciliation still happens
```

### 1. `non_claude_orchestrator` was BLOCKING, and blocked nothing

`deriveStatus()` returns `"unhealthy"` on **any** blocking issue — so **every `send_to` to every Astra reported unhealthy**, permanently, for running the fleet's standard topology (brainlayerCodex, golemsCodex, orchestratorCodex, voicelayerCodex).

Now info-tier, and it fires only when the seat is **genuinely mis-placed** (`column > 0`). In column 0 the seat **is** the explicit left-side coordinator the old message told it to become — the check was advice to do the thing it was already doing.

### 2. The registry reported its own self-healed staleness

The old code set `reconciledState` from the screen and then emitted an issue about the staleness it had **just healed**, in the same object. Reconciled silently; `reconciled_state` still carries the truth for any caller that wants it.

### 3. `inbox_monitor_not_alive` — the check is wrong for the contract we ship

The brief asked which of two it was. It is the check:

- an **agent-sourced** heartbeat has exactly **one** writer — the ACK path, which requires a message to have arrived;
- the only other writer uses source `"server_boot"`, which `readLastAgentHeartbeat` **deliberately ignores**;
- and the engine-issued contract instructs a bare `tail -n0 -F inbox.jsonl`, which **cannot write a heartbeat by construction**.

So a seat following the contract *exactly*, with an empty inbox, never has one — `never-armed` was indistinguishable from `dead`, forever. It now fires only when there are **unhandled messages and nothing reading them**, which is the actionable case.

**This is #611's shape again: the published contract and the runtime check disagree.**

### Tests

Seventeen assertions across five files encoded the old signals — **updated, not deleted**, each keeping its real intent (the sidebar tests now assert `health=healthy` rather than a specific noisy code; the replay test keeps its actual guard, that the *classifier* does not own a registry/screen disagreement).

**Calibrated against `origin/main`: they fail there and pass here.** Full suite: **159 files, 3797 passed, 1 skipped.**

Same family as #608 / #611 / #612 — a signal that carries no information. Here it is inverted: instead of silence where a warning belongs, a warning on every call until no operator reads any of them. Etan reads these. He read this one.

— cmuxlayerClaude-70bfff64 (lead) · claude/claude-opus-5[1m]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes health classification used on every agent dispatch; operators or automation that relied on the removed noisy codes may see fewer warnings, though actionable cases (unread inbox, mis-placed orchestrator) remain.
> 
> **Overview**
> **Reduces false “unhealthy” noise on routine dispatches** by tightening when `evaluateAgentHealth` emits three issue codes that previously fired on almost every Astra `send_to`.
> 
> `non_claude_orchestrator` is downgraded from **blocking** to **info** and only raised when a non-Claude orchestrator sits in **column &gt; 0**—column-0 Codex coordinators (standard fleet topology) no longer trip `deriveStatus()` to unhealthy.
> 
> `inbox_monitor_not_alive` now requires **unread or stale inbox work** while the monitor heartbeat is absent, so idle seats with an empty inbox (where contract `tail` cannot write heartbeats) stay quiet.
> 
> Registry/screen state mismatches are **reconciled silently** from the screen: `reconciled_state` is still set, but `registry_screen_disagreement` is no longer emitted for self-healed staleness.
> 
> Tests across agent-health, engine sweep status strings, server tools, sidebar sync, and replay harness were updated to match the new signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b215c6ecd64865b3ed3499897835df320dfd95c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress false health alarms from empty inboxes, reconciled screens, and leftmost non-Claude orchestrators
> - `evaluateAgentHealth` now emits `inbox_monitor_not_alive` only when unread or stale inbox messages exist, so empty inboxes with no monitor heartbeat no longer report failure
> - Removes `registry_screen_disagreement` when screen state is successfully reconciled into the registry; the reconciled state is still exposed via `reconciled_state`
> - Changes `DEFAULT_AGENT_HEALTH_ISSUE_SEVERITY` for non-Claude orchestrator findings from blocking to info, and only flags orchestrators placed right of column 0
> - Risk: callers that asserted on the presence of `inbox_monitor_not_alive`, `registry_screen_disagreement`, or blocking severity for non-Claude orchestrators will fail until updated; in-tree tests in [tests/agent-health.test.ts](https://github.com/EtanHey/cmuxlayer/pull/613/files#diff-371bcc7188da0e4333002fc72cb2937ebd9acd16dd0143ce0cd37ec99a3fc176) and related test files are adjusted
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b215c6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent health monitoring to report inactive inbox monitors only when unread or stale messages require attention.
  - Registry and screen state differences are now reconciled without raising a health issue.
  - Non-Claude orchestrators are flagged only when placed outside the lead column, with informational severity.

- **Tests**
  - Updated agent lifecycle, sidebar, replay, and health checks to reflect the revised monitoring and reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->