### PR TITLE
fix(#611): make the send_to contract true, and stop the errors hiding the fix (S)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14524,7 +14524,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           })
           .optional()
           .describe(
-            'Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues ~/.cmux/agents/<agent_id>/report.md, returns it here, and verifies closure against it. Pass a distinct FILE path per child (never a directory) to place a report somewhere you already watch. If coordination_footer_delivered is false, relay contract_path, report_path and done_marker to the agent yourself.',
+            'Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues ~/.cmux/agents/<agent_id>/report.md, returns it here, and verifies closure against it. Pass a distinct FILE path per child (never a directory) to place a report somewhere you already watch. Check coordination_footer_delivered. For resume_agent_id calls, false means the pointer was deliberately not re-delivered: follow coordination_footer_note and relay only if the restored session lost its original context. For new spawns, if false and contract_path is present, folded pointer submission was queued or unverified, so YOU must relay contract_path, report_path, and done_marker. If false and contract_path is absent, inline mode is active or the contract file could not be written, so YOU must relay report_path and done_marker.',
           ),
         force_new: z
           .boolean()
@@ -18476,7 +18476,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
-          "Deprecated no-op retained for compatibility: send_to_agent uses send_to and always attempts immediate delivery. Input landing behind an active turn is reported as queued_behind_turn, not a nonterminal queued state.",
+          "Deprecated no-op. Safety gates still refuse text at a picker/menu or permission prompt; use mode=key to drive those deliberately.",
         ),
         allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",

--- a/src/server.ts
+++ b/src/server.ts
@@ -723,6 +723,15 @@ const READY_PATTERN_CLIS: CliType[] = [
 const SEND_TO_WORKING_EXAMPLE =
   'Example: send_to({ mode: "agent", agent_id: "cmuxlayerCodex-1234", text: "hello" })';
 const SendToArgsSchema = z.object({
+  // AIDEV-NOTE (#611): `.default("agent")`, NOT `.optional()`. This field was
+  // declared optional while the runtime threw when it was omitted, so the
+  // published contract and the behaviour disagreed and a correct reading of the
+  // schema produced a failing call. Agents rediscovered that by trial and error
+  // and paid 2-3 turns each time -- one of them said out loud that "the
+  // coordination tool rejected its documented default mode". Either the schema
+  // tells the truth or it must not claim optionality: agent mode is what
+  // essentially every caller means, so it is now a real default that the
+  // runtime honours.
   mode: z
     .enum(["agent", "surface", "command", "key"], {
       errorMap: () => ({
@@ -731,7 +740,7 @@ const SendToArgsSchema = z.object({
           SEND_TO_WORKING_EXAMPLE,
       }),
     })
-    .optional(),
+    .default("agent"),
   target: z
     .union([z.string(), z.number().transform((value) => String(value))])
     .optional(),
@@ -11087,7 +11096,18 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     "read_screen",
     "Read a terminal screen and parsed harness status. Use raw=true for full text or parsed_only=true for monitoring.",
     {
-      surface: z.string().describe("Target surface ref"),
+      surface: z.string().optional().describe("Target surface ref"),
+      // AIDEV-NOTE (#611): `surface_id` is accepted because WE taught it. Our
+      // own spawn_agent output schema and every list_agents row EMIT
+      // `surface_id`, so the natural workflow -- list_agents, then read the
+      // surface it named -- hands that key straight back and got a validation
+      // error. The value was always right; only the name was, and the tool that
+      // taught the wrong name was ours. This is an alias for that reason, not
+      // for backwards compatibility.
+      surface_id: z
+        .string()
+        .optional()
+        .describe("Alias for `surface`, as emitted by list_agents/spawn_agent."),
       workspace: z.string().optional().describe("Target workspace ref"),
       lines: z
         .number()
@@ -11120,6 +11140,13 @@ export function createServer(opts?: CreateServerOptions): McpServer {
     ANNOTATIONS.readOnly,
     async (args) => {
       try {
+        // #611: accept either spelling, then use one resolved value below.
+        const surfaceRef = args.surface ?? args.surface_id;
+        if (!surfaceRef) {
+          throw new Error(
+            'read_screen requires a surface. Example: read_screen({ surface: "surface:122" }) -- the surface_id from list_agents is accepted too.',
+          );
+        }
         let codexAgentBeforeRead: AgentRecord | null = null;
         const hasCodexRolloutCandidate = stateMgr
           .listStates()
@@ -11134,7 +11161,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
             args.workspace,
           ).catch(() => null);
           codexAgentBeforeRead = resolveCodexAgentForSurface(
-            args.surface,
+            surfaceRef,
             topologyBeforeRead,
           );
         }
@@ -11145,7 +11172,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "remapped_from" | "remapped_to"
         > = {};
         const snapshotOpts = {
-          surface: args.surface,
+          surface: surfaceRef,
           workspace: args.workspace,
           lines: args.lines,
           scrollback: args.scrollback,
@@ -11154,12 +11181,12 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           ({ result, topology } = await readScreenSnapshot(snapshotOpts));
         } catch (readError) {
           const route = await resolveRawSurfaceMutationRoute(
-            args.surface,
+            surfaceRef,
             args.workspace,
             "read_screen",
           );
           if (
-            route.surface === args.surface &&
+            route.surface === surfaceRef &&
             (route.workspace ?? null) === (args.workspace ?? null)
           ) {
             throw readError;
@@ -11178,20 +11205,20 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           }
         }
         const requestedIsLive =
-          topology?.workspaceBySurface.has(args.surface) === true ||
-          topology?.surfaceIdByRef.has(args.surface) === true;
+          topology?.workspaceBySurface.has(surfaceRef) === true ||
+          topology?.surfaceIdByRef.has(surfaceRef) === true;
         if (
           topology?.complete === true &&
           !requestedIsLive &&
           !screenRemap.remapped_from
         ) {
           const route = await resolveRawSurfaceMutationRoute(
-            args.surface,
+            surfaceRef,
             args.workspace,
             "read_screen",
           );
           screenRemap = remapFields(route);
-          if (route.surface !== args.surface) {
+          if (route.surface !== surfaceRef) {
             const remapped = await readScreenSnapshot({
               ...snapshotOpts,
               surface: route.surface,
@@ -14497,7 +14524,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           })
           .optional()
           .describe(
-            'Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues `~/.cmux/agents/<agent_id>/report.md`, returns it in this receipt, persists it, and verifies closure against it. The engine also WRITES both strings to the spawn contract file (`contract_path`) and folds a pointer into the boot prompt; check `coordination_footer_delivered`. For resume_agent_id calls, false means the pointer was deliberately not re-delivered: follow coordination_footer_note and relay only if the restored session lost its original context. For new spawns, if false and contract_path is present, folded pointer submission was queued or unverified, so YOU must relay contract_path, report_path, and done_marker. If false and contract_path is absent, inline mode is active or the contract file could not be written, so YOU must relay report_path and done_marker, or a done worker renders closure:"artifact_missing". Pass this only to place the report somewhere you already watch (e.g. a collab dir).',
+            'Optional ABSOLUTE override for the engine-issued report path. Omit in almost all cases: the engine issues ~/.cmux/agents/<agent_id>/report.md, returns it here, and verifies closure against it. Pass a distinct FILE path per child (never a directory) to place a report somewhere you already watch. If coordination_footer_delivered is false, relay contract_path, report_path and done_marker to the agent yourself.',
           ),
         force_new: z
           .boolean()
@@ -17576,7 +17603,7 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           "Press enter after sending text",
         ),
         allow_busy: SendToArgsSchema.shape.allow_busy.describe(
-          "Deprecated no-op retained for compatibility: send_to always attempts immediate delivery. Input landing behind an active turn is reported as queued_behind_turn, not a nonterminal queued state. Picker/menu and permission-prompt safety gates still refuse text; use mode=key for deliberate menu driving.",
+          "Deprecated no-op. Safety gates still refuse text at a picker/menu or permission prompt; use mode=key to drive those deliberately.",
         ),
         allow_long_inline: SendToArgsSchema.shape.allow_long_inline.describe(
           "Bypass the inline length and multi-paragraph safety guards for a deliberate raw send. Large allowed sends keep the existing chunked delivery behavior.",
@@ -17586,11 +17613,15 @@ export function createServer(opts?: CreateServerOptions): McpServer {
       async (rawArgs) => {
         let failedReceiptPayload: Record<string, unknown> = {};
         try {
-          if (rawArgs.mode === undefined) {
-            throw new Error("mode required (agent|surface|command|key)");
-          }
+          // #611: an omitted mode is no longer an error -- the schema now
+          // defaults it to "agent". Only an explicitly invalid value fails, and
+          // that goes through the enum errorMap, which already carries a
+          // copy-pasteable example.
           if ("message" in rawArgs || "command" in rawArgs || "key" in rawArgs) {
-            throw new Error("send_to accepts one payload parameter: text");
+            throw new Error(
+              "send_to accepts one payload parameter: text. " +
+                SEND_TO_WORKING_EXAMPLE,
+            );
           }
           for (const field of ["surface", "target"] as const) {
             if (typeof rawArgs[field] === "number") {
@@ -17609,7 +17640,11 @@ export function createServer(opts?: CreateServerOptions): McpServer {
           const args = parsedArgs.data;
           const mode = args.mode;
           if (!mode) {
-            throw new Error("mode required (agent|surface|command|key)");
+            // Defensive only: the schema default makes this unreachable. If it
+            // ever fires, say what to do rather than what went wrong (#611).
+            throw new Error(
+              `mode required (agent|surface|command|key). ${SEND_TO_WORKING_EXAMPLE}`,
+            );
           }
           if (args.targeting && mode !== "agent") {
             throw new Error(

--- a/tests/enter-reliability.test.ts
+++ b/tests/enter-reliability.test.ts
@@ -1005,6 +1005,60 @@ describe("enter reliability", () => {
     await mcpClient.close();
   }, 10_000);
 
+  // AIDEV-NOTE (#611): the schema declared `mode` optional while the runtime
+  // threw when it was omitted, so a correct reading of the published contract
+  // produced a failing call. These go through a REAL MCP client because the
+  // defect was in the served contract, not in an internal helper.
+  it("delivers a send_to that omits mode, per the schema default", async () => {
+    vi.useRealTimers();
+    const client = new FakeClaudeSurfaceClient();
+    client.requiredReturns = 1;
+    client.completionMode = "idle";
+    server = createReliabilityServer(client, false);
+    registerAgent(server, { state: "idle" });
+    const mcpClient = new Client({ name: "mode-default-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      mcpClient.connect(clientTransport),
+    ]);
+    const result = await mcpClient.callTool({
+      name: "send_to",
+      arguments: { agent_id: "agent-1", text: "no mode supplied" },
+    });
+    const parsed = result.structuredContent as Record<string, unknown>;
+    expect(result.isError).not.toBe(true);
+    expect(JSON.stringify(parsed)).not.toContain("mode required");
+    expect(parsed.agent_id).toBe("agent-1");
+    await mcpClient.close();
+  }, 10_000);
+
+  it("publishes mode as defaulted, so the contract matches the runtime", async () => {
+    vi.useRealTimers();
+    const client = new FakeClaudeSurfaceClient();
+    server = createReliabilityServer(client, false);
+    const mcpClient = new Client({ name: "mode-contract-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      mcpClient.connect(clientTransport),
+    ]);
+    const { tools } = await mcpClient.listTools();
+    const sendTo = tools.find((tool) => tool.name === "send_to");
+    const schema = sendTo?.inputSchema as
+      | { properties?: Record<string, { default?: unknown }>; required?: string[] }
+      | undefined;
+    // Either the schema supplies the default the runtime honours, or it marks
+    // mode required. What it must never do again is claim plain optionality.
+    const modeProperty = schema?.properties?.mode;
+    const declaresDefault = modeProperty?.default === "agent";
+    const declaresRequired = schema?.required?.includes("mode") === true;
+    expect(declaresDefault || declaresRequired).toBe(true);
+    await mcpClient.close();
+  }, 10_000);
+
   it.each(["surface", "command", "key"] as const)(
     "keeps surface identity on a shaped %s-mode success",
     (mode) => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -538,7 +538,7 @@ describe("createServer", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("returns the exact missing-mode error and a working SDK invalid-mode example", async () => {
+  it("defaults an omitted mode and still gives an invalid mode a working example", async () => {
     const stateDir = processScopedTmpDir("cmuxlayer-send-to-schema-error");
     rmSync(stateDir, { recursive: true, force: true });
     const server = createServer({
@@ -566,12 +566,15 @@ describe("createServer", () => {
           text: "hello",
         },
       });
-      expect(missingMode.isError).toBe(true);
+      // #611: this arm used to assert the bare "mode required" refusal, which
+      // is precisely the bug -- the schema advertised mode as optional and the
+      // runtime rejected omitting it. Omission must now be accepted and take
+      // the documented default, so what is guarded here is inverted on purpose.
       const missingModeText = missingMode.content
         .filter((item) => item.type === "text")
         .map((item) => item.text)
         .join("\n");
-      expect(JSON.parse(missingModeText).error).toBe(
+      expect(missingModeText).not.toContain(
         "mode required (agent|surface|command|key)",
       );
 
@@ -876,8 +879,14 @@ describe("tool registration", () => {
 
   it("documents allow_busy as a deprecated no-op for immediate send delivery", () => {
     const source = readFileSync(join(import.meta.dirname, "..", "src", "server.ts"), "utf8");
-    expect(source.match(/Deprecated no-op retained for compatibility/g)).toHaveLength(2);
-    expect(source.match(/queued_behind_turn, not a nonterminal queued state/g)).toHaveLength(2);
+    // #611: this pinned 300+ chars of prose per site, twice. What it should
+    // guard is that allow_busy is still marked deprecated AND that the safety
+    // gates it does NOT bypass are stated -- not the exact wording, which is
+    // what made a description trim look like a behaviour regression.
+    expect(source.match(/Deprecated no-op\./g)).toHaveLength(2);
+    expect(
+      source.match(/Safety gates still refuse text at a picker\/menu/g),
+    ).toHaveLength(2);
   });
 
   it("warns when the active socket transport reports degraded health", async () => {

--- a/tests/thin-core-tools.test.ts
+++ b/tests/thin-core-tools.test.ts
@@ -338,12 +338,15 @@ describe("send_to consolidated modes", () => {
     );
   });
 
-  it("requires mode and accepts only text as the payload parameter", async () => {
+  it("defaults an omitted mode and accepts only text as the payload parameter", async () => {
     const server = createServer({ exec: makeExec(), controlHealthIntervalMs: 0 }) as any;
     const tool = server._registeredTools.send_to;
 
+    // #611: omitting mode is legal and takes the schema default. This test was
+    // named "requires mode" and asserted the refusal, which is exactly the
+    // contract lie the fix removes: the tool advertised mode as optional.
     const missing = await tool.handler({ target: "surface:1", text: "pwd" }, {});
-    expect(parseResult(missing).error).toBe(
+    expect(parseResult(missing).error).not.toBe(
       "mode required (agent|surface|command|key)",
     );
     for (const alias of ["message", "command", "key"] as const) {


### PR DESCRIPTION
## Make the `send_to` contract true

`size:S`. **Closes #611.**

Etan sent a screenshot of three consecutive `send_to` calls failing, with the agent's own line under them:

> *"The coordination tool rejected its documented default mode; I'll retry with an explicit mode."*

That sentence is the bug. **The schema declared `mode` `.optional()` (`server.ts:726`) while the runtime threw when it was omitted (`:17590`, `:17612`).** A correct reading of the published contract produced a failing call, so every agent rediscovered it by trial and error at 2–3 wasted turns each. It was never a regression — it was always wrong.

### What changed

**`mode` now has a real `.default("agent")` that the runtime honours.** Agent mode is what essentially every caller means. Verified off the wire against the built server: `mode default: "agent"`.

**The remaining guards carry the copy-pasteable example.** Previously a **bogus** mode got `Example: send_to({ mode: "agent", agent_id: "...", text: "hello" })` from the enum `errorMap`, and an **omitted** mode got a bare string. That is backwards — omission is the case agents actually hit. The constant already existed at `:723`; the throws just did not use it.

**`read_screen` accepts `surface_id` as an alias for `surface`** — because **our own output taught that name.** `spawn_agent`'s output schema (`:860`) and every `list_agents` row (`:4339`) **emit** `surface_id`, so the natural workflow (list agents, read the surface it named) hands the key straight back and got a validation error. The value was always right; only the name was, and the tool that taught the wrong name was ours. This is an alias for that reason — **not** backwards compatibility.

**No `message` alias.** `git log -S'message: z.string()' -- src/server.ts` returns nothing; that field never existed, so an alias would invent an API that was never real. The improved error names `text` instead.

### Description bloat

Etan raised this twice. Measured, rather than guessed — the whole tool surface, off the wire:

| | before | after |
|---|---|---|
| total | 31,674 B (~7,919 tok) | **30,993 B (~7,748 tok)** |
| `send_to` | 6,704 B | 6,552 B |
| `spawn_agent` | 10,942 B | 10,329 B |

**−2.2%. That is a start, not a win, and I am not dressing it up.** The measurement produced a more useful finding than the trim: **`spawn_agent` (~2,736 tok) is 63% BIGGER than `send_to` (~1,676), and the bulk is in PARAMETER descriptions, not the tool description.** Etan named `send_to` twice; the bigger cost is next door. That baseline is now recorded for the real lane.

Trimmed here: `allow_busy`, which spent **301 characters describing a deprecated no-op** (twice — the same prose was duplicated on `send_to_agent`), and `report_path`.

**The irony worth naming: the description is enormous and still failed to convey the one field a caller had to supply.** Length is not clarity; here it bought neither.

### Tests

New tests go through a **real MCP client**, because the defect was in the served contract rather than an internal helper.

**Calibrated against `origin/main`: both new tests FAIL there and pass here, while the 8 surrounding tests pass either way** — so the new arms are the only thing moving.

**Four existing tests encoded the old contract** and were updated, not deleted — including one literally named *"requires mode"*, which asserted the refusal that **was** the bug.

**One of them caught me over-trimming.** The coordination-footer test pinned that `report_path` documents every `coordination_footer_delivered: false` outcome. My first cut (1023 → 412 chars) dropped branches callers need. I restored the substance (**→ 838**) and left that guard's regex **untouched**. It did exactly its job, on me.

Full suite: **159 files, 3799 passed, 1 skipped.**

— cmuxlayerClaude-70bfff64 (lead) · claude/claude-opus-5[1m]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default parsing and validation for widely used coordination tools (`send_to`, `read_screen`); behavior is intentional but affects every agent caller omitting `mode` or passing `surface_id`.
> 
> **Overview**
> Fixes **#611** by aligning the MCP tool contract with runtime behavior so agents stop failing on “correct” calls.
> 
> **`send_to`:** `mode` is now **`.default("agent")`** instead of optional while the handler still required it. Omitted `mode` no longer throws before parse; invalid modes and wrong payload keys still error with the shared **`SEND_TO_WORKING_EXAMPLE`**. **`allow_busy`** descriptions on `send_to` / `send_to_agent` are shortened but still note picker/permission safety gates.
> 
> **`read_screen`:** Accepts **`surface_id`** as an alias for **`surface`** (matching `list_agents` / `spawn_agent` output), resolves one ref, and errors clearly if neither is provided.
> 
> **`spawn_agent`:** Trims **`report_path`** parameter docs without dropping coordination-footer guidance.
> 
> **Tests:** Real MCP client coverage for omitted-`mode` delivery and published schema default; prior tests that encoded the bogus “mode required” refusal are inverted or relaxed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa587728a227397f70206ae412ca94ff3daf951b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `send_to` mode to `agent` in `SendToArgsSchema` and accept `surface_id` in `read_screen`
> - Changes `SendToArgsSchema` to set `mode` default to `agent`, fixing a mismatch between the published contract and runtime behavior; omitted mode now reaches the agent path instead of being rejected.
> - Updates `read_screen` to accept `surface_id` (emitted by `list_agents` and `spawn_agent`) as an alias for `surface`, resolving both into one reference and erroring when neither is provided.
> - Adds a copy-pasteable `send_to` usage example to errors caused by legacy payload parameter names, and shortens `allow_busy` descriptions to mark the option as a deprecated no-op while noting picker/menu/permission safety gates remain active.
> - Updates tests across [enter-reliability.test.ts](https://github.com/EtanHey/cmuxlayer/pull/614/files#diff-5e89c52026fcdfee326f57b1efc91920f9bc47ec7a580591cebc889ffb9a21fb), [server.test.ts](https://github.com/EtanHey/cmuxlayer/pull/614/files#diff-28ef84c225a6c2db1bb2728a10b5af1c48addd809355d20fb44f93212c41f16d), and [thin-core-tools.test.ts](https://github.com/EtanHey/cmuxlayer/pull/614/files#diff-2cd190bfc0fe70c4ac7ec2d7102281e8a71ef4fce856c9adf0676ad8162b97e6) to verify omitted-mode acceptance and updated documentation concepts.
> - Behavioral Change: callers that previously received a missing-mode error for omitted `mode` now get agent-mode handling; `read_screen` callers must provide either `surface` or `surface_id` or receive an explicit target error.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aa58772. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->