### PR TITLE
fix(spawn): validate Codex models against the account catalog, not --bundled (XS)

### DIFF
--- a/src/agent-engine.ts
+++ b/src/agent-engine.ts
@@ -659,19 +659,53 @@ async function validateCodexModel(
 ): Promise<void> {
   if (!model?.trim() || model.trim().toLowerCase() === "codex") return;
 
-  let result: { stdout: string; stderr?: string };
-  try {
-    result = await runner(["debug", "models", "--bundled"]);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  // AIDEV-NOTE: validate against the ACCOUNT catalog, not `--bundled`.
+  //
+  // `--bundled` is the list the installed codex binary shipped with. It is
+  // wrong in BOTH directions against a real account, verified 2026-09-10:
+  //   - it OMITS gpt-5.3-codex-spark, which the account lists with medium
+  //     supported. That rejection made 100% of Etan's Spark quota unreachable
+  //     while his general weekly sat at 3%.
+  //   - it INCLUDES gpt-5.4, gpt-5.4-mini, gpt-5.2 and
+  //     gpt-daybreak-red-latest, which the account does NOT list -- so those
+  //     passed validation here and would only fail later, at runtime.
+  //
+  // A bundled omission is not proof of unavailability. So the account catalog
+  // is authoritative, and bundled is a FALLBACK that may only warn: if the
+  // account list cannot be fetched (offline, auth), we must not invent a
+  // rejection from a list we already know disagrees with the account.
+  const readCatalog = async (
+    args: string[],
+  ): Promise<string[] | { error: string }> => {
+    try {
+      const result = await runner(args);
+      return parseCodexModelSlugs(result.stdout);
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  };
+
+  const account = await readCatalog(["debug", "models"]);
+  if (Array.isArray(account)) {
+    if (!account.includes(model.trim())) {
+      throw new Error(
+        `Unsupported Codex model "${model.trim()}". Codex models: ${account.join(", ")}. No agent was spawned.`,
+      );
+    }
+    return;
+  }
+
+  // Account catalog unavailable. Fall back to bundled, but only to catch an
+  // obvious typo -- never to reject a model the bundled list simply predates.
+  const bundled = await readCatalog(["debug", "models", "--bundled"]);
+  if (!Array.isArray(bundled)) {
     throw new Error(
-      `Unable to discover Codex models: ${message}. No agent was spawned.`,
+      `Unable to discover Codex models: ${account.error}. No agent was spawned.`,
     );
   }
-  const models = parseCodexModelSlugs(result.stdout);
-  if (!models.includes(model.trim())) {
-    throw new Error(
-      `Unsupported Codex model "${model.trim()}". Codex models: ${models.join(", ")}. No agent was spawned.`,
+  if (!bundled.includes(model.trim())) {
+    console.warn(
+      `[cmuxlayer] Codex account catalog unavailable (${account.error}); "${model.trim()}" is not in the BUNDLED list either. Proceeding anyway: a bundled omission is not proof the account lacks the model. Bundled: ${bundled.join(", ")}`,
     );
   }
 }

--- a/tests/spawn-agent-preflight.test.ts
+++ b/tests/spawn-agent-preflight.test.ts
@@ -99,7 +99,7 @@ describe("spawn_agent launcher preflight", () => {
     expect(mockClient.newSplit).not.toHaveBeenCalled();
   });
 
-  it("rejects an unknown Codex model from Codex's bundled model list before creating anything", async () => {
+  it("rejects an unknown Codex model from Codex's account model list before creating anything", async () => {
     const registryPath = join(TEST_DIR, "launchers.zsh");
     writeFileSync(
       registryPath,
@@ -130,5 +130,103 @@ describe("spawn_agent launcher preflight", () => {
       defaultEngine.dispose();
       vi.unstubAllEnvs();
     }
+  });
+
+  // AIDEV-NOTE: the catalog stubs below are ARGS-AWARE on purpose. The bug was
+  // which catalog we asked, so a stub that answers every call identically
+  // cannot tell `debug models` from `debug models --bundled` and proves nothing.
+  const catalogRunner =
+    (account: string[] | "throws", bundled: string[] | "throws") =>
+    async (args: string[]) => {
+      const list = args.includes("--bundled") ? bundled : account;
+      if (list === "throws") throw new Error("catalog unavailable (offline)");
+      return {
+        stdout: JSON.stringify({ models: list.map((slug) => ({ slug })) }),
+        stderr: "",
+      };
+    };
+
+  const spawnWith = async (
+    runner: (args: string[]) => Promise<{ stdout: string; stderr: string }>,
+    model: string,
+  ) => {
+    const registryPath = join(TEST_DIR, "launchers.zsh");
+    writeFileSync(
+      registryPath,
+      'repoGolem cmuxlayer "/home/test-user/Gits/cmuxlayer"\n',
+    );
+    vi.stubEnv("CMUXLAYER_LAUNCHER_REGISTRY_PATH", registryPath);
+    const engine = new AgentEngine(
+      stateMgr,
+      new AgentRegistry(stateMgr, async () => []),
+      mockClient,
+      { codexModelListRunner: runner },
+    );
+    try {
+      return await engine
+        .spawnAgent({ repo: "cmuxlayer", model, cli: "codex", prompt: "" })
+        .then(
+          () => ({ ok: true as const, error: null }),
+          (error: unknown) => ({
+            ok: false as const,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+    } finally {
+      engine.dispose();
+      vi.unstubAllEnvs();
+    }
+  };
+
+  it("accepts a model the ACCOUNT catalog lists even when the bundled list omits it", async () => {
+    // The live specimen: gpt-5.3-codex-spark is in `codex debug models` with
+    // medium supported, and absent from `--bundled`. Validating against
+    // bundled made 100% of Etan's Spark quota unreachable at 3% general.
+    const result = await spawnWith(
+      catalogRunner(
+        ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.3-codex-spark"],
+        ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.4"],
+      ),
+      "gpt-5.3-codex-spark",
+    );
+    expect(result.error ?? "").not.toMatch(/Unsupported Codex model/);
+  });
+
+  it("rejects a model only the bundled list carries when the account catalog lacks it", async () => {
+    // The other direction of the same defect: bundled green-lit models the
+    // account does not have, which would only fail later, at runtime.
+    const result = await spawnWith(
+      catalogRunner(["gpt-6-astra", "gpt-5.6-sol"], ["gpt-6-astra", "gpt-5.4"]),
+      "gpt-5.4",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Unsupported Codex model "gpt-5\.4".*No agent was spawned/s);
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
+  });
+
+  it("does not invent a rejection from the bundled list when the account catalog is unreachable", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await spawnWith(
+        catalogRunner("throws", ["gpt-6-astra", "gpt-5.6-sol"]),
+        "gpt-5.3-codex-spark",
+      );
+      expect(result.error ?? "").not.toMatch(/Unsupported Codex model/);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/bundled omission is not proof/),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("fails closed when neither catalog can be read", async () => {
+    const result = await spawnWith(
+      catalogRunner("throws", "throws"),
+      "gpt-5.3-codex-spark",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Unable to discover Codex models.*No agent was spawned/s);
+    expect(mockClient.newSplit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Validate Codex models against the account catalog, not `--bundled`

`size:XS`. Found by the lean Astra. **This is the fix that makes Etan's Spark quota reachable** — he is at 3% general weekly and 100% Spark, and `spawn_agent` was refusing the model that would use it.

### The defect

`validateCodexModel` (`src/agent-engine.ts`) ran `codex debug models --bundled` — the catalog the installed `codex` binary **shipped with**. Checked side by side against the account's refreshed catalog on 2026-09-10, it is wrong in **both** directions:

| model | `--bundled` (what we validated against) | account (what Etan can use) | old result |
|---|---|---|---|
| `gpt-5.3-codex-spark` | absent | **present**, `medium` supported | **wrongly rejected** |
| `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`, `gpt-daybreak-red-latest` | present | **absent** | **wrongly accepted** — fails later at runtime |

So it was not merely stale. It blocked quota the account has, and green-lit models the account does not.

### The fix

- **The account catalog (`codex debug models`) is authoritative.** A model it lists is accepted; one it does not is rejected, with the account list in the error.
- **`--bundled` is only a fallback**, used when the account list cannot be fetched (offline, auth). Even then **a bundled miss warns rather than rejects** — a bundled omission is not proof of unavailability, and we already know that list disagrees with the account.
- **If neither catalog can be read, spawn still fails closed**, exactly as before.

### Tests

Four cases in `tests/spawn-agent-preflight.test.ts`, using an **args-aware** catalog stub. That matters: the bug was *which* catalog we asked, so a stub answering every call identically — which is what the existing test used — cannot tell `debug models` from `debug models --bundled` and would pass either way.

**Calibrated against `origin/main`:** the three tests encoding the bug (both directions, plus the offline fallback) **fail there and pass here**. The fourth, fail-closed-when-neither-readable, passes on both — by design, it guards behaviour I kept.

**Still owed after merge:** this changes nothing on Etan's machine until it is released and installed — per #605, merged is not done.

— cmuxlayerClaude-70bfff64 (lead) · claude/claude-opus-5[1m]


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `validateCodexModel` to validate against account catalog instead of `--bundled` list
> Codex model preflight now treats the account catalog (fetched via `debug models`) as authoritative. A model present in the account catalog is accepted even if absent from the bundled list, and a model absent from a successfully fetched account catalog is rejected.
> - When the account catalog is unreachable, the bundled list is used only as a warning check — a model missing from it is no longer rejected.
> - If both catalog lookups fail, `validateCodexModel` still throws and no agent is spawned.
> - Adds tests in [spawn-agent-preflight.test.ts](https://github.com/EtanHey/cmuxlayer/pull/617/files#diff-ef66a6de8a1d795214f2cebf7573d64f3575b8b6b473d5c140b1791b603fc7ba) covering account-only acceptance, bundled-only rejection, unreachable-account fallback, and fail-closed behavior.
> - Behavioral Change: account-catalog fetch errors no longer block spawns based on the bundled list; a warning is emitted instead. Reviewers should check the catalog-reading helper in `src/agent-engine.ts` for correct error capture from `debug models` output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34a2439.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model validation now reflects the models available in your account catalog.
  - Account-only models can be used without being rejected as unsupported.
  - Models missing from the bundled catalog are no longer automatically blocked when the account catalog is unavailable; obvious typos may still trigger warnings.
  - Agent startup remains blocked when model catalog discovery fails completely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->